### PR TITLE
[Issue #1] Schema types and go.mod initialization

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,6 @@
+// Package markedup provides a markdown-as-knowledge-graph toolkit.
+//
+// It treats markdown files with structured YAML frontmatter as nodes in a
+// knowledge graph, enabling relationship traversal, temporal confidence
+// decay, and multi-signal search scoring — all without a vector database.
+package markedup

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/KHAEntertainment/markedup
+
+go 1.22.0
+
+require (
+	github.com/stretchr/testify v1.9.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/schema/types.go
+++ b/schema/types.go
@@ -1,0 +1,64 @@
+// Package schema defines the core types for the markedup knowledge graph.
+//
+// All structs use kebab-case YAML tags to match the frontmatter format used
+// in Obsidian-compatible markdown files.
+package schema
+
+// GraphFrontmatter represents the structured YAML frontmatter of a knowledge
+// graph page. It captures identity, classification, relationships, temporal
+// metadata, and provenance for a single node in the graph.
+type GraphFrontmatter struct {
+	ID                string         `yaml:"id"`
+	Title             string         `yaml:"title"`
+	EntityType        string         `yaml:"entity-type"`
+	Confidence        float64        `yaml:"confidence"`
+	Tags              []string       `yaml:"tags"`
+	Entities          []Entity       `yaml:"entities"`
+	Relationships     []Relationship `yaml:"relationships"`
+	Temporal          TemporalInfo   `yaml:"temporal"`
+	Provenance        Provenance     `yaml:"provenance"`
+	SemanticHints     []string       `yaml:"semantic-hints"`
+	PossibleQuestions []string       `yaml:"possible-questions"`
+}
+
+// Entity represents a named entity referenced within a page. Aliases allow
+// fuzzy matching when the same concept appears under different names.
+type Entity struct {
+	Name    string   `yaml:"name"`
+	Aliases []string `yaml:"aliases"`
+	Role    string   `yaml:"role"`
+}
+
+// Relationship represents a directed edge from the containing page to a
+// target page. Strength is a float64 in the range [0.0, 1.0].
+type Relationship struct {
+	Target   string  `yaml:"target"`
+	Type     string  `yaml:"type"`
+	Strength float64 `yaml:"strength"`
+}
+
+// TemporalInfo captures time-based metadata for confidence decay calculations.
+// Date fields use string representation (e.g. "2024-01-15") to avoid timezone
+// ambiguity. DecayRate controls how quickly confidence degrades over time.
+type TemporalInfo struct {
+	ValidFrom    string  `yaml:"valid-from"`
+	ValidUntil   string  `yaml:"valid-until"`
+	LastVerified string  `yaml:"last-verified"`
+	DecayRate    float64 `yaml:"decay-rate"`
+}
+
+// Provenance tracks where the information in a page originated and who
+// created it.
+type Provenance struct {
+	Sources   []string `yaml:"sources"`
+	CreatedBy string   `yaml:"created-by"`
+}
+
+// Page holds a parsed markdown file: its structured frontmatter, the raw
+// markdown body, and the filesystem path it was loaded from. Page is a
+// runtime container and is not itself serialized to YAML.
+type Page struct {
+	Frontmatter GraphFrontmatter
+	Body        string
+	SourcePath  string
+}

--- a/schema/types_test.go
+++ b/schema/types_test.go
@@ -1,0 +1,356 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// yamlRoundTrip marshals v to YAML and unmarshals back into a new T.
+// This is the fundamental operation under test: marshal→unmarshal should
+// produce a struct equal to the input (modulo nil→empty-slice coercion
+// by yaml.v3).
+func yamlRoundTrip[T any](t *testing.T, v T) T {
+	t.Helper()
+	data, err := yaml.Marshal(v)
+	require.NoError(t, err, "marshal should not fail")
+
+	var got T
+	err = yaml.Unmarshal(data, &got)
+	require.NoError(t, err, "unmarshal should not fail")
+	return got
+}
+
+func TestGraphFrontmatter_YAMLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		give GraphFrontmatter
+		want GraphFrontmatter // expected after round-trip (nil slices become empty)
+	}{
+		{
+			name: "fully populated frontmatter",
+			give: GraphFrontmatter{
+				ID:         "page-001",
+				Title:      "Knowledge Graph Basics",
+				EntityType: "concept",
+				Confidence: 0.95,
+				Tags:       []string{"graph", "knowledge", "basics"},
+				Entities: []Entity{
+					{Name: "Graph Theory", Aliases: []string{"graph-theory", "GT"}, Role: "subject"},
+					{Name: "Node", Aliases: []string{}, Role: "component"},
+				},
+				Relationships: []Relationship{
+					{Target: "page-002", Type: "related-to", Strength: 0.8},
+					{Target: "page-003", Type: "depends-on", Strength: 1.0},
+				},
+				Temporal: TemporalInfo{
+					ValidFrom:    "2024-01-01",
+					ValidUntil:   "2025-12-31",
+					LastVerified: "2024-06-15",
+					DecayRate:    0.1,
+				},
+				Provenance: Provenance{
+					Sources:   []string{"https://example.com/graphs", "textbook-ch3"},
+					CreatedBy: "agent-alpha",
+				},
+				SemanticHints:     []string{"foundational", "introductory"},
+				PossibleQuestions: []string{"What is a knowledge graph?", "How do nodes relate?"},
+			},
+			want: GraphFrontmatter{
+				ID:         "page-001",
+				Title:      "Knowledge Graph Basics",
+				EntityType: "concept",
+				Confidence: 0.95,
+				Tags:       []string{"graph", "knowledge", "basics"},
+				Entities: []Entity{
+					{Name: "Graph Theory", Aliases: []string{"graph-theory", "GT"}, Role: "subject"},
+					{Name: "Node", Aliases: []string{}, Role: "component"},
+				},
+				Relationships: []Relationship{
+					{Target: "page-002", Type: "related-to", Strength: 0.8},
+					{Target: "page-003", Type: "depends-on", Strength: 1.0},
+				},
+				Temporal: TemporalInfo{
+					ValidFrom:    "2024-01-01",
+					ValidUntil:   "2025-12-31",
+					LastVerified: "2024-06-15",
+					DecayRate:    0.1,
+				},
+				Provenance: Provenance{
+					Sources:   []string{"https://example.com/graphs", "textbook-ch3"},
+					CreatedBy: "agent-alpha",
+				},
+				SemanticHints:     []string{"foundational", "introductory"},
+				PossibleQuestions: []string{"What is a knowledge graph?", "How do nodes relate?"},
+			},
+		},
+		{
+			name: "zero-value frontmatter round-trips with empty slices",
+			give: GraphFrontmatter{},
+			want: GraphFrontmatter{
+				Tags:              []string{},
+				Entities:          []Entity{},
+				Relationships:     []Relationship{},
+				Provenance:        Provenance{Sources: []string{}},
+				SemanticHints:     []string{},
+				PossibleQuestions: []string{},
+			},
+		},
+		{
+			name: "confidence at boundary zero",
+			give: GraphFrontmatter{
+				ID:         "edge-zero",
+				Confidence: 0.0,
+				Relationships: []Relationship{
+					{Target: "t", Type: "x", Strength: 0.0},
+				},
+				Temporal: TemporalInfo{DecayRate: 0.0},
+			},
+			want: GraphFrontmatter{
+				ID:         "edge-zero",
+				Confidence: 0.0,
+				Tags:              []string{},
+				Entities:          []Entity{},
+				Relationships: []Relationship{
+					{Target: "t", Type: "x", Strength: 0.0},
+				},
+				Temporal:          TemporalInfo{DecayRate: 0.0},
+				Provenance:        Provenance{Sources: []string{}},
+				SemanticHints:     []string{},
+				PossibleQuestions: []string{},
+			},
+		},
+		{
+			name: "confidence at boundary one",
+			give: GraphFrontmatter{
+				ID:         "edge-one",
+				Confidence: 1.0,
+				Relationships: []Relationship{
+					{Target: "t", Type: "x", Strength: 1.0},
+				},
+				Temporal: TemporalInfo{DecayRate: 1.0},
+			},
+			want: GraphFrontmatter{
+				ID:         "edge-one",
+				Confidence: 1.0,
+				Tags:              []string{},
+				Entities:          []Entity{},
+				Relationships: []Relationship{
+					{Target: "t", Type: "x", Strength: 1.0},
+				},
+				Temporal:          TemporalInfo{DecayRate: 1.0},
+				Provenance:        Provenance{Sources: []string{}},
+				SemanticHints:     []string{},
+				PossibleQuestions: []string{},
+			},
+		},
+		{
+			name: "empty slices are stable through round-trip",
+			give: GraphFrontmatter{
+				ID:                "empty-slices",
+				Tags:              []string{},
+				Entities:          []Entity{},
+				Relationships:     []Relationship{},
+				SemanticHints:     []string{},
+				PossibleQuestions: []string{},
+				Provenance:        Provenance{Sources: []string{}},
+			},
+			want: GraphFrontmatter{
+				ID:                "empty-slices",
+				Tags:              []string{},
+				Entities:          []Entity{},
+				Relationships:     []Relationship{},
+				SemanticHints:     []string{},
+				PossibleQuestions: []string{},
+				Provenance:        Provenance{Sources: []string{}},
+			},
+		},
+		{
+			name: "entity aliases round-trip",
+			give: GraphFrontmatter{
+				ID: "alias-test",
+				Entities: []Entity{
+					{Name: "Solo", Aliases: []string{}, Role: "primary"},
+					{Name: "Multi", Aliases: []string{"a", "b"}, Role: "secondary"},
+				},
+			},
+			want: GraphFrontmatter{
+				ID:   "alias-test",
+				Tags: []string{},
+				Entities: []Entity{
+					{Name: "Solo", Aliases: []string{}, Role: "primary"},
+					{Name: "Multi", Aliases: []string{"a", "b"}, Role: "secondary"},
+				},
+				Relationships:     []Relationship{},
+				Provenance:        Provenance{Sources: []string{}},
+				SemanticHints:     []string{},
+				PossibleQuestions: []string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := yamlRoundTrip(t, tt.give)
+			require.Equal(t, tt.want, got, "round-trip should produce expected struct")
+		})
+	}
+}
+
+func TestGraphFrontmatter_YAMLIdempotent(t *testing.T) {
+	// Verify that a second round-trip produces the same result as the first,
+	// proving the serialization is stable/idempotent.
+	original := GraphFrontmatter{
+		ID:         "idempotent-test",
+		Title:      "Stability Check",
+		EntityType: "test",
+		Confidence: 0.5,
+		Tags:       []string{"stable"},
+		Entities: []Entity{
+			{Name: "A", Aliases: []string{"a1"}, Role: "r"},
+		},
+		Relationships: []Relationship{
+			{Target: "b", Type: "links", Strength: 0.9},
+		},
+		Temporal: TemporalInfo{
+			ValidFrom:    "2024-01-01",
+			ValidUntil:   "2024-12-31",
+			LastVerified: "2024-06-01",
+			DecayRate:    0.05,
+		},
+		Provenance: Provenance{
+			Sources:   []string{"test"},
+			CreatedBy: "tester",
+		},
+		SemanticHints:     []string{"hint"},
+		PossibleQuestions: []string{"question?"},
+	}
+
+	first := yamlRoundTrip(t, original)
+	second := yamlRoundTrip(t, first)
+	require.Equal(t, first, second, "second round-trip should be identical to first")
+}
+
+func TestEntity_YAMLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		give Entity
+		want Entity
+	}{
+		{
+			name: "full entity",
+			give: Entity{Name: "Go", Aliases: []string{"golang", "Go language"}, Role: "language"},
+			want: Entity{Name: "Go", Aliases: []string{"golang", "Go language"}, Role: "language"},
+		},
+		{
+			name: "entity with nil aliases becomes empty",
+			give: Entity{Name: "Rust", Role: "language"},
+			want: Entity{Name: "Rust", Aliases: []string{}, Role: "language"},
+		},
+		{
+			name: "zero value entity",
+			give: Entity{},
+			want: Entity{Aliases: []string{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := yamlRoundTrip(t, tt.give)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRelationship_YAMLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		give Relationship
+	}{
+		{
+			name: "normal relationship",
+			give: Relationship{Target: "page-99", Type: "cites", Strength: 0.75},
+		},
+		{
+			name: "zero strength",
+			give: Relationship{Target: "t", Type: "weak", Strength: 0.0},
+		},
+		{
+			name: "max strength",
+			give: Relationship{Target: "t", Type: "strong", Strength: 1.0},
+		},
+		{
+			name: "zero value",
+			give: Relationship{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := yamlRoundTrip(t, tt.give)
+			// Relationship has no slice fields, so round-trip is exact.
+			require.Equal(t, tt.give, got)
+		})
+	}
+}
+
+func TestTemporalInfo_YAMLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		give TemporalInfo
+	}{
+		{
+			name: "full temporal",
+			give: TemporalInfo{
+				ValidFrom:    "2024-01-01",
+				ValidUntil:   "2025-12-31",
+				LastVerified: "2024-06-15",
+				DecayRate:    0.05,
+			},
+		},
+		{
+			name: "zero value",
+			give: TemporalInfo{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := yamlRoundTrip(t, tt.give)
+			// TemporalInfo has no slice fields, so round-trip is exact.
+			require.Equal(t, tt.give, got)
+		})
+	}
+}
+
+func TestProvenance_YAMLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		give Provenance
+		want Provenance
+	}{
+		{
+			name: "full provenance",
+			give: Provenance{Sources: []string{"src1", "src2"}, CreatedBy: "bot"},
+			want: Provenance{Sources: []string{"src1", "src2"}, CreatedBy: "bot"},
+		},
+		{
+			name: "nil sources becomes empty",
+			give: Provenance{CreatedBy: "human"},
+			want: Provenance{Sources: []string{}, CreatedBy: "human"},
+		},
+		{
+			name: "zero value",
+			give: Provenance{},
+			want: Provenance{Sources: []string{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := yamlRoundTrip(t, tt.give)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Closes #1

## Summary

- Initialized `go.mod` with module `github.com/KHAEntertainment/markedup` (go 1.22.0) and direct dependencies (testify, yaml.v3; cobra/isatty/x-sync will be added when imported by later issues)
- Created `doc.go` with package-level documentation for the root `markedup` package
- Implemented `schema/types.go` exporting all 6 core types: `GraphFrontmatter`, `Entity`, `Relationship`, `TemporalInfo`, `Provenance`, `Page`
- All YAML struct tags use kebab-case (`entity-type`, `valid-from`, `semantic-hints`, etc.)
- Created `schema/types_test.go` with table-driven tests using testify verifying YAML round-trip for every type, including boundary values (0.0/1.0 confidence/strength), zero values, empty slices, and nil-to-empty coercion

## Self-Check Results

| Check | Result |
|-------|--------|
| `go test -race ./schema/...` | PASS |
| `go vet ./schema/...` | PASS (clean) |
| `go build ./...` | PASS |
| `go.sum` populated | Yes (10 lines) |
| YAML kebab-case tags | Verified on all struct fields |
| Round-trip idempotency | Verified (marshal→unmarshal→marshal→unmarshal stable) |
| Nil slice handling | Documented: yaml.v3 coerces nil slices to empty slices on unmarshal; tests account for this |

## Test Coverage

- **GraphFrontmatter**: fully populated, zero values, boundary confidence (0/1), empty slices, entity alias variants, idempotency
- **Entity**: full, nil aliases, zero value
- **Relationship**: normal, zero/max strength, zero value
- **TemporalInfo**: full, zero value
- **Provenance**: full, nil sources, zero value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced markdown-as-knowledge-graph toolkit with YAML frontmatter interpretation
  * Added support for relationship traversal between knowledge graph nodes
  * Enabled temporal confidence decay and multi-signal search scoring without vector databases

* **Tests**
  * Added comprehensive test coverage validating data model serialization and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->