### PR TITLE
[Issue #4] KnowledgeIndex and concurrent filesystem loader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/KHAEntertainment/markedup
 
-go 1.22.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/index/index.go
+++ b/index/index.go
@@ -1,0 +1,138 @@
+// Package index provides the in-memory KnowledgeIndex for the markedup
+// knowledge graph. It holds parsed pages and supports O(1) lookups by ID,
+// tag-based filtering, and forward/reverse adjacency traversal.
+package index
+
+import (
+	"sort"
+
+	"github.com/KHAEntertainment/markedup/schema"
+)
+
+// KnowledgeIndex is the core read-only index over all parsed pages. It is
+// built by Load and is safe for concurrent reads after construction (no
+// internal mutation methods are exposed).
+type KnowledgeIndex struct {
+	byID       map[string]*schema.Page
+	byTag      map[string][]*schema.Page
+	adjacency  map[string][]schema.Relationship // forward: source ID → relationships
+	reverseAdj map[string][]string              // reverse: target ID → source IDs
+	allTags    []string                         // sorted, deduplicated
+	sortedIDs  []string                         // sorted page IDs for deterministic All()
+}
+
+// Get returns the page with the given ID and true, or nil and false if the
+// ID is not in the index.
+func (idx *KnowledgeIndex) Get(id string) (*schema.Page, bool) {
+	p, ok := idx.byID[id]
+	return p, ok
+}
+
+// All returns every page in the index, sorted by ID for deterministic output.
+func (idx *KnowledgeIndex) All() []*schema.Page {
+	pages := make([]*schema.Page, 0, len(idx.sortedIDs))
+	for _, id := range idx.sortedIDs {
+		pages = append(pages, idx.byID[id])
+	}
+	return pages
+}
+
+// Pages returns the number of pages in the index.
+func (idx *KnowledgeIndex) Pages() int {
+	return len(idx.byID)
+}
+
+// Entities returns the count of unique entity names across all pages.
+func (idx *KnowledgeIndex) Entities() int {
+	seen := make(map[string]struct{})
+	for _, p := range idx.byID {
+		for _, e := range p.Frontmatter.Entities {
+			seen[e.Name] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+// Relationships returns the total number of relationships across all pages.
+func (idx *KnowledgeIndex) Relationships() int {
+	total := 0
+	for _, rels := range idx.adjacency {
+		total += len(rels)
+	}
+	return total
+}
+
+// Tags returns all tags across all pages, sorted and deduplicated.
+func (idx *KnowledgeIndex) Tags() []string {
+	out := make([]string, len(idx.allTags))
+	copy(out, idx.allTags)
+	return out
+}
+
+// ByTag returns all pages that have the given tag. Returns nil if the tag
+// is not found.
+func (idx *KnowledgeIndex) ByTag(tag string) []*schema.Page {
+	return idx.byTag[tag]
+}
+
+// ForwardRels returns the outgoing relationships from the page with the
+// given ID. Returns nil if the ID is not in the index.
+func (idx *KnowledgeIndex) ForwardRels(id string) []schema.Relationship {
+	return idx.adjacency[id]
+}
+
+// ReverseRefs returns the IDs of pages that have a relationship targeting
+// the given ID. Returns nil if no pages reference the target.
+func (idx *KnowledgeIndex) ReverseRefs(id string) []string {
+	return idx.reverseAdj[id]
+}
+
+// buildIndex constructs a KnowledgeIndex from a slice of parsed pages.
+// This is called single-threaded after all concurrent parsing is complete.
+func buildIndex(pages []*schema.Page) *KnowledgeIndex {
+	idx := &KnowledgeIndex{
+		byID:       make(map[string]*schema.Page, len(pages)),
+		byTag:      make(map[string][]*schema.Page),
+		adjacency:  make(map[string][]schema.Relationship),
+		reverseAdj: make(map[string][]string),
+	}
+
+	tagSet := make(map[string]struct{})
+
+	for _, p := range pages {
+		id := p.Frontmatter.ID
+		idx.byID[id] = p
+
+		// Index tags.
+		for _, tag := range p.Frontmatter.Tags {
+			idx.byTag[tag] = append(idx.byTag[tag], p)
+			tagSet[tag] = struct{}{}
+		}
+
+		// Build forward adjacency.
+		if len(p.Frontmatter.Relationships) > 0 {
+			idx.adjacency[id] = p.Frontmatter.Relationships
+		}
+
+		// Build reverse adjacency.
+		for _, rel := range p.Frontmatter.Relationships {
+			idx.reverseAdj[rel.Target] = append(idx.reverseAdj[rel.Target], id)
+		}
+	}
+
+	// Sort and deduplicate tags.
+	idx.allTags = make([]string, 0, len(tagSet))
+	for tag := range tagSet {
+		idx.allTags = append(idx.allTags, tag)
+	}
+	sort.Strings(idx.allTags)
+
+	// Pre-compute sorted IDs for deterministic All().
+	idx.sortedIDs = make([]string, 0, len(idx.byID))
+	for id := range idx.byID {
+		idx.sortedIDs = append(idx.sortedIDs, id)
+	}
+	sort.Strings(idx.sortedIDs)
+
+	return idx
+}

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -1,0 +1,185 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/KHAEntertainment/markedup/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testPages() []*schema.Page {
+	return []*schema.Page{
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "page-a",
+				Title:      "Page A",
+				EntityType: "concept",
+				Confidence: 0.9,
+				Tags:       []string{"go", "testing"},
+				Entities: []schema.Entity{
+					{Name: "Go Language", Role: "subject"},
+					{Name: "Testing", Role: "topic"},
+				},
+				Relationships: []schema.Relationship{
+					{Target: "page-b", Type: "related-to", Strength: 0.8},
+				},
+			},
+			Body:       "Page A body",
+			SourcePath: "/tmp/page-a.md",
+		},
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "page-b",
+				Title:      "Page B",
+				EntityType: "tool",
+				Confidence: 0.7,
+				Tags:       []string{"go", "concurrency"},
+				Entities: []schema.Entity{
+					{Name: "Go Language", Role: "subject"},
+					{Name: "Goroutines", Role: "topic"},
+				},
+				Relationships: []schema.Relationship{
+					{Target: "page-a", Type: "depends-on", Strength: 0.6},
+					{Target: "page-c", Type: "extends", Strength: 0.5},
+				},
+			},
+			Body:       "Page B body",
+			SourcePath: "/tmp/page-b.md",
+		},
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "page-c",
+				Title:      "Page C",
+				EntityType: "concept",
+				Confidence: 0.8,
+				Tags:       []string{"testing"},
+				Entities: []schema.Entity{
+					{Name: "Benchmarks", Role: "topic"},
+				},
+			},
+			Body:       "Page C body",
+			SourcePath: "/tmp/page-c.md",
+		},
+	}
+}
+
+func TestBuildIndex(t *testing.T) {
+	idx := buildIndex(testPages())
+	require.NotNil(t, idx)
+
+	t.Run("Pages", func(t *testing.T) {
+		assert.Equal(t, 3, idx.Pages())
+	})
+
+	t.Run("Get existing", func(t *testing.T) {
+		p, ok := idx.Get("page-a")
+		require.True(t, ok)
+		assert.Equal(t, "Page A", p.Frontmatter.Title)
+	})
+
+	t.Run("Get non-existent", func(t *testing.T) {
+		p, ok := idx.Get("page-z")
+		assert.False(t, ok)
+		assert.Nil(t, p)
+	})
+
+	t.Run("All sorted by ID", func(t *testing.T) {
+		all := idx.All()
+		require.Len(t, all, 3)
+		assert.Equal(t, "page-a", all[0].Frontmatter.ID)
+		assert.Equal(t, "page-b", all[1].Frontmatter.ID)
+		assert.Equal(t, "page-c", all[2].Frontmatter.ID)
+	})
+
+	t.Run("Entities unique count", func(t *testing.T) {
+		// Go Language (deduped), Testing, Goroutines, Benchmarks = 4
+		assert.Equal(t, 4, idx.Entities())
+	})
+
+	t.Run("Relationships total", func(t *testing.T) {
+		// page-a has 1, page-b has 2, page-c has 0 = 3
+		assert.Equal(t, 3, idx.Relationships())
+	})
+
+	t.Run("Tags sorted and deduplicated", func(t *testing.T) {
+		tags := idx.Tags()
+		assert.Equal(t, []string{"concurrency", "go", "testing"}, tags)
+	})
+
+	t.Run("ByTag", func(t *testing.T) {
+		goPages := idx.ByTag("go")
+		require.Len(t, goPages, 2)
+
+		testingPages := idx.ByTag("testing")
+		require.Len(t, testingPages, 2)
+
+		assert.Nil(t, idx.ByTag("nonexistent"))
+	})
+
+	t.Run("ForwardRels", func(t *testing.T) {
+		rels := idx.ForwardRels("page-b")
+		require.Len(t, rels, 2)
+		assert.Equal(t, "page-a", rels[0].Target)
+		assert.Equal(t, "page-c", rels[1].Target)
+
+		assert.Nil(t, idx.ForwardRels("page-c"))
+		assert.Nil(t, idx.ForwardRels("nonexistent"))
+	})
+
+	t.Run("ReverseRefs", func(t *testing.T) {
+		// page-a is targeted by page-b
+		refs := idx.ReverseRefs("page-a")
+		require.Len(t, refs, 1)
+		assert.Equal(t, "page-b", refs[0])
+
+		// page-b is targeted by page-a
+		refs = idx.ReverseRefs("page-b")
+		require.Len(t, refs, 1)
+		assert.Equal(t, "page-a", refs[0])
+
+		// page-c is targeted by page-b
+		refs = idx.ReverseRefs("page-c")
+		require.Len(t, refs, 1)
+		assert.Equal(t, "page-b", refs[0])
+
+		assert.Nil(t, idx.ReverseRefs("nonexistent"))
+	})
+}
+
+func TestBuildIndexEmpty(t *testing.T) {
+	idx := buildIndex(nil)
+	require.NotNil(t, idx)
+	assert.Equal(t, 0, idx.Pages())
+	assert.Empty(t, idx.All())
+	assert.Equal(t, 0, idx.Entities())
+	assert.Equal(t, 0, idx.Relationships())
+	assert.Empty(t, idx.Tags())
+}
+
+func TestBuildIndexSinglePage(t *testing.T) {
+	pages := []*schema.Page{
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "solo",
+				Title:      "Solo Page",
+				EntityType: "note",
+				Confidence: 1.0,
+				Tags:       []string{"alpha", "beta"},
+			},
+			Body: "solo body",
+		},
+	}
+	idx := buildIndex(pages)
+	assert.Equal(t, 1, idx.Pages())
+	assert.Equal(t, []string{"alpha", "beta"}, idx.Tags())
+}
+
+func TestTagsReturnsCopy(t *testing.T) {
+	idx := buildIndex(testPages())
+	tags1 := idx.Tags()
+	tags2 := idx.Tags()
+	// Modifying one should not affect the other.
+	tags1[0] = "MODIFIED"
+	assert.NotEqual(t, tags1[0], tags2[0])
+}

--- a/index/load.go
+++ b/index/load.go
@@ -1,0 +1,225 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/KHAEntertainment/markedup/markdown"
+	"github.com/KHAEntertainment/markedup/schema"
+	"golang.org/x/sync/errgroup"
+)
+
+// CacheProvider is a Phase 2 hook for caching parsed pages. Implementations
+// can short-circuit parsing by returning a cached page for a given path and
+// modification time.
+type CacheProvider interface {
+	Get(path string, modTime time.Time) (*schema.Page, bool)
+	Set(path string, modTime time.Time, page *schema.Page)
+}
+
+// LoadWarning represents a non-fatal issue encountered during loading.
+type LoadWarning struct {
+	Path    string
+	Message string
+	Errors  []schema.ValidationError
+}
+
+// LoadResult carries the built index along with any warnings collected
+// during the load process.
+type LoadResult struct {
+	Index    *KnowledgeIndex
+	Warnings []LoadWarning
+}
+
+// loadConfig holds options for Load.
+type loadConfig struct {
+	concurrency  int
+	filePattern  string
+	ignoreErrors bool
+	cache        CacheProvider
+}
+
+// LoadOption configures the behaviour of Load.
+type LoadOption func(*loadConfig)
+
+// WithConcurrency sets the maximum number of concurrent file parsers.
+// Values less than 1 are treated as 1.
+func WithConcurrency(n int) LoadOption {
+	return func(c *loadConfig) {
+		if n < 1 {
+			n = 1
+		}
+		c.concurrency = n
+	}
+}
+
+// WithFilePattern sets the glob pattern used to match markdown files.
+// The default is "*.md".
+func WithFilePattern(pattern string) LoadOption {
+	return func(c *loadConfig) {
+		c.filePattern = pattern
+	}
+}
+
+// WithIgnoreErrors causes Load to collect parse/validation errors as
+// warnings instead of failing. Valid pages are still indexed.
+func WithIgnoreErrors(ignore bool) LoadOption {
+	return func(c *loadConfig) {
+		c.ignoreErrors = ignore
+	}
+}
+
+// WithCache sets a CacheProvider for the loader. This is a Phase 2 hook;
+// passing nil (the default) disables caching.
+func WithCache(cp CacheProvider) LoadOption {
+	return func(c *loadConfig) {
+		c.cache = cp
+	}
+}
+
+// Load walks root to discover markdown files, parses them concurrently
+// using bounded workers, validates each page, and builds a KnowledgeIndex.
+//
+// Dangling relationships (target ID not found in the index) produce
+// warnings, not errors. Parse or validation failures are collected as
+// warnings when WithIgnoreErrors is true; otherwise the first parse error
+// causes Load to return an error.
+func Load(ctx context.Context, root string, opts ...LoadOption) (*LoadResult, error) {
+	cfg := loadConfig{
+		concurrency: 8,
+		filePattern: "*.md",
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	// 1. Collect file paths.
+	var paths []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		matched, matchErr := filepath.Match(cfg.filePattern, d.Name())
+		if matchErr != nil {
+			return fmt.Errorf("index: bad file pattern %q: %w", cfg.filePattern, matchErr)
+		}
+		if matched {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("index: walk %s: %w", root, err)
+	}
+
+	// 2. Parse concurrently.
+	type parseResult struct {
+		page *schema.Page
+		warn *LoadWarning
+	}
+
+	results := make([]parseResult, len(paths))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(cfg.concurrency)
+
+	var mu sync.Mutex
+	var firstErr error
+
+	for i, p := range paths {
+		i, p := i, p
+		g.Go(func() error {
+			// Check context cancellation.
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+
+			page, parseErr := markdown.ParseFile(p)
+			if parseErr != nil {
+				if cfg.ignoreErrors {
+					mu.Lock()
+					results[i] = parseResult{
+						warn: &LoadWarning{
+							Path:    p,
+							Message: parseErr.Error(),
+						},
+					}
+					mu.Unlock()
+					return nil
+				}
+				return fmt.Errorf("index: parse %s: %w", p, parseErr)
+			}
+
+			// Validate.
+			valErrs := schema.ValidatePage(page)
+			if len(valErrs) > 0 && !cfg.ignoreErrors {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("index: validation errors in %s: %s", p, valErrs[0].Error())
+				}
+				mu.Unlock()
+				// Still store the page — we'll check firstErr after the group.
+			}
+
+			r := parseResult{page: page}
+			if len(valErrs) > 0 {
+				r.warn = &LoadWarning{
+					Path:    p,
+					Message: fmt.Sprintf("%d validation error(s)", len(valErrs)),
+					Errors:  valErrs,
+				}
+			}
+
+			mu.Lock()
+			results[i] = r
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	// 3. Collect valid pages and warnings.
+	var pages []*schema.Page
+	var warnings []LoadWarning
+
+	for _, r := range results {
+		if r.warn != nil {
+			warnings = append(warnings, *r.warn)
+		}
+		if r.page != nil {
+			pages = append(pages, r.page)
+		}
+	}
+
+	// 4. Build index single-threaded.
+	idx := buildIndex(pages)
+
+	// 5. Check for dangling relationships.
+	for _, p := range pages {
+		for _, rel := range p.Frontmatter.Relationships {
+			if _, ok := idx.byID[rel.Target]; !ok {
+				warnings = append(warnings, LoadWarning{
+					Path:    p.SourcePath,
+					Message: fmt.Sprintf("dangling relationship: target %q not found in index", rel.Target),
+				})
+			}
+		}
+	}
+
+	return &LoadResult{
+		Index:    idx,
+		Warnings: warnings,
+	}, nil
+}

--- a/index/load_test.go
+++ b/index/load_test.go
@@ -1,0 +1,316 @@
+package index
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validMD = `---
+id: test-page
+title: Test Page
+entity-type: concept
+confidence: 0.9
+tags:
+  - go
+  - testing
+entities:
+  - name: Go Language
+    role: subject
+relationships:
+  - target: other-page
+    type: related-to
+    strength: 0.8
+temporal:
+  valid-from: "2024-01-01"
+  last-verified: "2024-06-15"
+  decay-rate: 0.1
+provenance:
+  sources:
+    - https://example.com
+  created-by: test
+---
+# Test Page
+
+This is the body.
+`
+
+const validMD2 = `---
+id: other-page
+title: Other Page
+entity-type: tool
+confidence: 0.8
+tags:
+  - go
+entities:
+  - name: Tooling
+    role: subject
+temporal:
+  valid-from: "2024-02-01"
+  last-verified: "2024-06-15"
+  decay-rate: 0.05
+provenance:
+  sources:
+    - https://example.com
+  created-by: test
+---
+# Other Page
+
+Other body content.
+`
+
+const invalidMD = `This is not valid markdown frontmatter at all.
+No YAML delimiters here.
+`
+
+const validationFailMD = `---
+id: ""
+title: ""
+entity-type: ""
+confidence: 2.0
+---
+Body with invalid frontmatter.
+`
+
+func writeTestFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		err := os.MkdirAll(filepath.Dir(path), 0o755)
+		require.NoError(t, err)
+		err = os.WriteFile(path, []byte(content), 0o644)
+		require.NoError(t, err)
+	}
+}
+
+func TestLoadBasic(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFiles(t, dir, map[string]string{
+		"test-page.md":  validMD,
+		"other-page.md": validMD2,
+	})
+
+	result, err := Load(context.Background(), dir)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Index)
+
+	idx := result.Index
+	assert.Equal(t, 2, idx.Pages())
+
+	p, ok := idx.Get("test-page")
+	require.True(t, ok)
+	assert.Equal(t, "Test Page", p.Frontmatter.Title)
+
+	p2, ok := idx.Get("other-page")
+	require.True(t, ok)
+	assert.Equal(t, "Other Page", p2.Frontmatter.Title)
+
+	// Forward/reverse relationships.
+	rels := idx.ForwardRels("test-page")
+	require.Len(t, rels, 1)
+	assert.Equal(t, "other-page", rels[0].Target)
+
+	refs := idx.ReverseRefs("other-page")
+	require.Len(t, refs, 1)
+	assert.Equal(t, "test-page", refs[0])
+
+	// Tags.
+	tags := idx.Tags()
+	assert.Equal(t, []string{"go", "testing"}, tags)
+
+	// No dangling warnings since other-page exists.
+	danglingCount := 0
+	for _, w := range result.Warnings {
+		if w.Message != "" && len(w.Errors) == 0 {
+			danglingCount++
+		}
+	}
+	assert.Equal(t, 0, danglingCount)
+}
+
+func TestLoadEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	result, err := Load(context.Background(), dir)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 0, result.Index.Pages())
+	assert.Empty(t, result.Warnings)
+}
+
+func TestLoadNonExistentDirectory(t *testing.T) {
+	_, err := Load(context.Background(), "/nonexistent/dir/that/does/not/exist")
+	require.Error(t, err)
+}
+
+func TestLoadInvalidFileWithIgnoreErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFiles(t, dir, map[string]string{
+		"valid.md":   validMD,
+		"invalid.md": invalidMD,
+	})
+
+	result, err := Load(context.Background(), dir, WithIgnoreErrors(true))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Only the valid page should be indexed.
+	assert.Equal(t, 1, result.Index.Pages())
+	_, ok := result.Index.Get("test-page")
+	assert.True(t, ok)
+
+	// Should have a warning for the invalid file.
+	require.True(t, len(result.Warnings) >= 1)
+	foundParseWarning := false
+	for _, w := range result.Warnings {
+		if filepath.Base(w.Path) == "invalid.md" {
+			foundParseWarning = true
+		}
+	}
+	assert.True(t, foundParseWarning, "expected warning for invalid.md")
+}
+
+func TestLoadInvalidFileWithoutIgnoreErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFiles(t, dir, map[string]string{
+		"invalid.md": invalidMD,
+	})
+
+	_, err := Load(context.Background(), dir)
+	require.Error(t, err)
+}
+
+func TestLoadValidationErrorsWithIgnoreErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFiles(t, dir, map[string]string{
+		"valid.md":   validMD,
+		"invalid.md": validationFailMD,
+	})
+
+	result, err := Load(context.Background(), dir, WithIgnoreErrors(true))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Both should be indexed (validation errors are warnings in ignore mode).
+	assert.Equal(t, 2, result.Index.Pages())
+
+	// Should have validation warnings.
+	require.True(t, len(result.Warnings) >= 1)
+}
+
+func TestLoadValidationErrorsWithoutIgnoreErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFiles(t, dir, map[string]string{
+		"bad.md": validationFailMD,
+	})
+
+	_, err := Load(context.Background(), dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validation")
+}
+
+func TestLoadDanglingRelationship(t *testing.T) {
+	dir := t.TempDir()
+	// test-page references "other-page" which does not exist.
+	writeTestFiles(t, dir, map[string]string{
+		"test-page.md": validMD,
+	})
+
+	result, err := Load(context.Background(), dir)
+	require.NoError(t, err)
+
+	// Should have a dangling relationship warning.
+	found := false
+	for _, w := range result.Warnings {
+		if w.Message != "" && assert.ObjectsAreEqual("dangling relationship: target \"other-page\" not found in index", w.Message) {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected dangling relationship warning")
+}
+
+func TestLoadWithConcurrency(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFiles(t, dir, map[string]string{
+		"page1.md": validMD,
+		"page2.md": validMD2,
+	})
+
+	result, err := Load(context.Background(), dir, WithConcurrency(1))
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Index.Pages())
+}
+
+func TestLoadWithFilePattern(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFiles(t, dir, map[string]string{
+		"included.md":  validMD,
+		"excluded.txt": validMD2,
+	})
+
+	result, err := Load(context.Background(), dir, WithFilePattern("*.md"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Index.Pages())
+}
+
+func TestLoadSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFiles(t, dir, map[string]string{
+		"root.md":          validMD,
+		"subdir/nested.md": validMD2,
+	})
+
+	result, err := Load(context.Background(), dir)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Index.Pages())
+}
+
+func TestLoadConcurrentRace(t *testing.T) {
+	// This test is meaningful under -race flag.
+	dir := t.TempDir()
+	// Create multiple files to exercise concurrency.
+	files := make(map[string]string)
+	for i := 0; i < 20; i++ {
+		name := filepath.Join(dir, "page"+string(rune('a'+i))+".md")
+		_ = name
+		files["page"+string(rune('a'+i))+".md"] = validMD
+	}
+	writeTestFiles(t, dir, files)
+
+	result, err := Load(context.Background(), dir, WithConcurrency(4))
+	require.NoError(t, err)
+	// All files have the same ID ("test-page"), so only the last one wins
+	// in the map. But we still exercise the concurrent path.
+	require.NotNil(t, result.Index)
+}
+
+func TestLoadContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFiles(t, dir, map[string]string{
+		"page.md": validMD,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	// With a cancelled context, Load may still succeed if the walk and parse
+	// complete before the context check, or it may fail. Either is acceptable.
+	_, _ = Load(ctx, dir)
+}
+
+func TestWithConcurrencyMinimum(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFiles(t, dir, map[string]string{
+		"page.md": validMD,
+	})
+
+	// Concurrency of 0 should be clamped to 1.
+	result, err := Load(context.Background(), dir, WithConcurrency(0))
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Index.Pages())
+}


### PR DESCRIPTION
## Summary

- Implements `KnowledgeIndex` struct with O(1) lookups by ID, tag-based filtering, and forward/reverse adjacency maps for graph traversal
- Adds concurrent `Load()` function using `errgroup` with bounded workers (default 8) for filesystem scanning and parallel markdown parsing
- Includes `LoadOption` pattern (`WithConcurrency`, `WithFilePattern`, `WithIgnoreErrors`, `WithCache`) and `LoadResult` carrying both index and warnings

## Details

**index/index.go** — `KnowledgeIndex` with methods: `Get`, `All` (sorted by ID), `Pages`, `Entities` (unique count), `Relationships` (total), `Tags` (sorted, deduplicated), `ByTag`, `ForwardRels`, `ReverseRefs`

**index/load.go** — `Load(ctx, root, ...LoadOption)` walks directories, parses `.md` files concurrently, validates pages, builds index single-threaded. Dangling relationships produce warnings, not errors. `CacheProvider` interface defined as Phase 2 hook.

## Test results

```
$ go test -race -count=3 ./index/...
ok  github.com/KHAEntertainment/markedup/index  1.349s

$ go test ./...
ok  github.com/KHAEntertainment/markedup/index     0.154s
ok  github.com/KHAEntertainment/markedup/markdown   0.114s
ok  github.com/KHAEntertainment/markedup/schema     0.100s
ok  github.com/KHAEntertainment/markedup/temporal   0.099s
```

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new knowledge index system enabling efficient in-memory lookups of pages by ID, tags, and relationships.
  * Implemented concurrent markdown file loader with configurable patterns, caching support, and flexible error handling options.

* **Chores**
  * Updated Go toolchain to version 1.25.0 and added new dependency for concurrency utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->