### PR TITLE
[Issue #5] Multi-signal search scoring pipeline

### DIFF
--- a/index/search.go
+++ b/index/search.go
@@ -1,0 +1,454 @@
+package index
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KHAEntertainment/markedup/schema"
+	"github.com/KHAEntertainment/markedup/temporal"
+)
+
+// MatchType classifies how a query matched a field value.
+type MatchType int
+
+const (
+	// MatchExact means the query equals the field value (case-insensitive).
+	MatchExact MatchType = iota // score multiplier 1.0
+	// MatchPrefix means the field value starts with the query.
+	MatchPrefix // 0.8
+	// MatchContains means the field value contains the query.
+	MatchContains // 0.5
+	// MatchFuzzy means levenshtein distance ≤ 2 between query and field value.
+	MatchFuzzy // 0.3
+)
+
+// matchTypeScore maps a MatchType to its score multiplier.
+func matchTypeScore(mt MatchType) float64 {
+	switch mt {
+	case MatchExact:
+		return 1.0
+	case MatchPrefix:
+		return 0.8
+	case MatchContains:
+		return 0.5
+	case MatchFuzzy:
+		return 0.3
+	default:
+		return 0
+	}
+}
+
+// Match describes a single field-level match between the query and a page.
+type Match struct {
+	Field string
+	Value string
+	Type  MatchType
+}
+
+// Result holds a scored search result with the matched page and match details.
+type Result struct {
+	Page    *schema.Page
+	Score   float64
+	Matches []Match
+}
+
+// FormatForLLM produces a structured text block suitable for LLM consumption.
+func (r Result) FormatForLLM() string {
+	fm := r.Page.Frontmatter
+	var b strings.Builder
+
+	// Title line with entity type.
+	if fm.EntityType != "" {
+		fmt.Fprintf(&b, "# %s (%s)\n", fm.Title, fm.EntityType)
+	} else {
+		fmt.Fprintf(&b, "# %s\n", fm.Title)
+	}
+
+	fmt.Fprintf(&b, "Confidence: %.2f\n", fm.Confidence)
+
+	// Relationships.
+	if len(fm.Relationships) > 0 {
+		parts := make([]string, len(fm.Relationships))
+		for i, rel := range fm.Relationships {
+			parts[i] = fmt.Sprintf("%s (%s)", rel.Target, rel.Type)
+		}
+		fmt.Fprintf(&b, "Relationships: %s\n", strings.Join(parts, ", "))
+	}
+
+	// Semantic hints.
+	if len(fm.SemanticHints) > 0 {
+		fmt.Fprintf(&b, "Semantic hints: %s\n", strings.Join(fm.SemanticHints, ", "))
+	}
+
+	// Body excerpt.
+	body := strings.TrimSpace(r.Page.Body)
+	if body != "" {
+		b.WriteString("\n")
+		if len(body) > 500 {
+			b.WriteString(body[:500])
+		} else {
+			b.WriteString(body)
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// Reranker is a Phase 2 extension point. Implementations can reorder or
+// re-score results using external signals (e.g. embeddings).
+type Reranker interface {
+	Rerank(query string, results []Result) ([]Result, error)
+}
+
+// SearchOption configures the search pipeline.
+type SearchOption func(*searchConfig)
+
+type searchConfig struct {
+	limit    int
+	minScore float64
+	reranker Reranker
+}
+
+// WithLimit sets the maximum number of results returned.
+func WithLimit(n int) SearchOption {
+	return func(cfg *searchConfig) {
+		cfg.limit = n
+	}
+}
+
+// WithMinScore sets the minimum score threshold; results below are discarded.
+func WithMinScore(f float64) SearchOption {
+	return func(cfg *searchConfig) {
+		cfg.minScore = f
+	}
+}
+
+// WithReranker sets a reranker to post-process results (Phase 2 hook).
+func WithReranker(r Reranker) SearchOption {
+	return func(cfg *searchConfig) {
+		cfg.reranker = r
+	}
+}
+
+// Field weights used in scoring.
+const (
+	weightEntityName  = 10
+	weightAlias       = 8
+	weightTitle       = 7
+	weightTag         = 5
+	weightSemanticHint = 3
+	weightRelTarget   = 2
+	weightBody        = 1
+)
+
+// Search scores every page in idx against query using multi-signal field
+// weighting, match-type multipliers, and temporal decay. Results are returned
+// sorted by descending FinalScore.
+func Search(idx *KnowledgeIndex, query string, opts ...SearchOption) []Result {
+	if query == "" {
+		return nil
+	}
+
+	cfg := &searchConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	q := strings.ToLower(strings.TrimSpace(query))
+	now := time.Now()
+
+	var results []Result
+	for _, page := range idx.All() {
+		matches, baseScore := scorePage(page, q)
+		if baseScore == 0 {
+			continue
+		}
+
+		tm := temporalMultiplier(page, now)
+		finalScore := baseScore * tm
+
+		if cfg.minScore > 0 && finalScore < cfg.minScore {
+			continue
+		}
+
+		results = append(results, Result{
+			Page:    page,
+			Score:   finalScore,
+			Matches: matches,
+		})
+	}
+
+	// Sort descending by score, break ties by title for determinism.
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		return results[i].Page.Frontmatter.Title < results[j].Page.Frontmatter.Title
+	})
+
+	// Apply reranker if provided.
+	if cfg.reranker != nil {
+		reranked, err := cfg.reranker.Rerank(query, results)
+		if err == nil {
+			results = reranked
+		}
+	}
+
+	// Apply limit.
+	if cfg.limit > 0 && len(results) > cfg.limit {
+		results = results[:cfg.limit]
+	}
+
+	return results
+}
+
+// scorePage computes the base score for a page against the query. For
+// multi-value fields (tags, entities, aliases, semantic-hints, relationships)
+// the max match score is used (not sum) to prevent stuffing.
+func scorePage(page *schema.Page, q string) ([]Match, float64) {
+	fm := page.Frontmatter
+	var matches []Match
+	var totalScore float64
+
+	// --- Single-value fields: title ---
+	if m, ok := bestMatch(q, fm.Title); ok {
+		matches = append(matches, Match{Field: "title", Value: fm.Title, Type: m})
+		totalScore += float64(weightTitle) * matchTypeScore(m)
+	}
+
+	// --- Multi-value: entity names ---
+	bestEnt, bestEntVal, bestEntMatch := bestOfMulti(q, entityNames(fm.Entities))
+	if bestEnt {
+		matches = append(matches, Match{Field: "entity-name", Value: bestEntVal, Type: bestEntMatch})
+		totalScore += float64(weightEntityName) * matchTypeScore(bestEntMatch)
+	}
+
+	// --- Multi-value: aliases ---
+	bestAl, bestAlVal, bestAlMatch := bestOfMulti(q, entityAliases(fm.Entities))
+	if bestAl {
+		matches = append(matches, Match{Field: "alias", Value: bestAlVal, Type: bestAlMatch})
+		totalScore += float64(weightAlias) * matchTypeScore(bestAlMatch)
+	}
+
+	// --- Multi-value: tags ---
+	bestT, bestTVal, bestTMatch := bestOfMulti(q, fm.Tags)
+	if bestT {
+		matches = append(matches, Match{Field: "tag", Value: bestTVal, Type: bestTMatch})
+		totalScore += float64(weightTag) * matchTypeScore(bestTMatch)
+	}
+
+	// --- Multi-value: semantic hints ---
+	bestSH, bestSHVal, bestSHMatch := bestOfMulti(q, fm.SemanticHints)
+	if bestSH {
+		matches = append(matches, Match{Field: "semantic-hint", Value: bestSHVal, Type: bestSHMatch})
+		totalScore += float64(weightSemanticHint) * matchTypeScore(bestSHMatch)
+	}
+
+	// --- Multi-value: relationship targets ---
+	targets := make([]string, len(fm.Relationships))
+	for i, rel := range fm.Relationships {
+		targets[i] = rel.Target
+	}
+	bestR, bestRVal, bestRMatch := bestOfMulti(q, targets)
+	if bestR {
+		matches = append(matches, Match{Field: "relationship-target", Value: bestRVal, Type: bestRMatch})
+		totalScore += float64(weightRelTarget) * matchTypeScore(bestRMatch)
+	}
+
+	// --- Body: check each word ---
+	if bodyMatch, ok := matchBody(q, page.Body); ok {
+		matches = append(matches, Match{Field: "body", Value: bodyMatch.Value, Type: bodyMatch.Type})
+		totalScore += float64(weightBody) * matchTypeScore(bodyMatch.Type)
+	}
+
+	return matches, totalScore
+}
+
+// temporalMultiplier computes the temporal decay multiplier for a page.
+// If no temporal info is present, returns confidence (or 1.0 if confidence is 0).
+func temporalMultiplier(page *schema.Page, now time.Time) float64 {
+	fm := page.Frontmatter
+	confidence := fm.Confidence
+	decayRate := fm.Temporal.DecayRate
+	lastVerifiedStr := fm.Temporal.LastVerified
+
+	if lastVerifiedStr == "" || decayRate == 0 {
+		if confidence == 0 {
+			return 1.0
+		}
+		return confidence
+	}
+
+	lastVerified, err := time.Parse("2006-01-02", lastVerifiedStr)
+	if err != nil {
+		if confidence == 0 {
+			return 1.0
+		}
+		return confidence
+	}
+
+	return temporal.DecayedConfidenceAt(confidence, decayRate, lastVerified, now)
+}
+
+// bestMatch returns the best MatchType for query against a single value.
+func bestMatch(q, value string) (MatchType, bool) {
+	v := strings.ToLower(value)
+	if v == q {
+		return MatchExact, true
+	}
+	if strings.HasPrefix(v, q) {
+		return MatchPrefix, true
+	}
+	if strings.Contains(v, q) {
+		return MatchContains, true
+	}
+	if levenshtein(q, v) <= 2 {
+		return MatchFuzzy, true
+	}
+	return 0, false
+}
+
+// bestOfMulti finds the best match across multiple values (max, not sum).
+func bestOfMulti(q string, values []string) (found bool, bestVal string, bestMT MatchType) {
+	bestScore := -1.0
+	for _, v := range values {
+		mt, ok := bestMatch(q, v)
+		if !ok {
+			continue
+		}
+		s := matchTypeScore(mt)
+		if s > bestScore {
+			bestScore = s
+			bestVal = v
+			bestMT = mt
+			found = true
+		}
+	}
+	return
+}
+
+// matchBody checks the body text word-by-word for a match. Returns the best
+// single match (max, not sum).
+func matchBody(q, body string) (Match, bool) {
+	words := strings.Fields(strings.ToLower(body))
+	bestScore := -1.0
+	var bestMatch Match
+	found := false
+
+	for _, w := range words {
+		mt, ok := matchWord(q, w)
+		if !ok {
+			continue
+		}
+		s := matchTypeScore(mt)
+		if s > bestScore {
+			bestScore = s
+			bestMatch = Match{Field: "body", Value: w, Type: mt}
+			found = true
+		}
+		if s == 1.0 {
+			break // can't do better than exact
+		}
+	}
+	return bestMatch, found
+}
+
+// matchWord matches a query against a single word.
+func matchWord(q, word string) (MatchType, bool) {
+	if word == q {
+		return MatchExact, true
+	}
+	if strings.HasPrefix(word, q) {
+		return MatchPrefix, true
+	}
+	if strings.Contains(word, q) {
+		return MatchContains, true
+	}
+	if levenshtein(q, word) <= 2 {
+		return MatchFuzzy, true
+	}
+	return 0, false
+}
+
+// entityNames extracts all entity names.
+func entityNames(entities []schema.Entity) []string {
+	names := make([]string, len(entities))
+	for i, e := range entities {
+		names[i] = e.Name
+	}
+	return names
+}
+
+// entityAliases extracts all aliases from all entities.
+func entityAliases(entities []schema.Entity) []string {
+	var aliases []string
+	for _, e := range entities {
+		aliases = append(aliases, e.Aliases...)
+	}
+	return aliases
+}
+
+// levenshtein computes the Levenshtein edit distance between two strings
+// using the iterative Wagner-Fischer algorithm.
+func levenshtein(a, b string) int {
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+
+	// Early termination: if length difference > 2, distance is > 2.
+	diff := len(a) - len(b)
+	if diff > 2 || diff < -2 {
+		if diff < 0 {
+			return -diff
+		}
+		return diff
+	}
+
+	ra := []rune(a)
+	rb := []rune(b)
+	la, lb := len(ra), len(rb)
+
+	// Use single row optimization.
+	prev := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+
+	for i := 1; i <= la; i++ {
+		curr := make([]int, lb+1)
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(
+				prev[j]+1,     // deletion
+				curr[j-1]+1,   // insertion
+				prev[j-1]+cost, // substitution
+			)
+		}
+		prev = curr
+	}
+
+	return prev[lb]
+}
+
+func min3(a, b, c int) int {
+	if a < b {
+		if a < c {
+			return a
+		}
+		return c
+	}
+	if b < c {
+		return b
+	}
+	return c
+}

--- a/index/search_test.go
+++ b/index/search_test.go
@@ -1,0 +1,321 @@
+package index
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/KHAEntertainment/markedup/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testIndex builds a small KnowledgeIndex for search tests.
+func testIndex() *KnowledgeIndex {
+	pages := []*schema.Page{
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "alice",
+				Title:      "Alice Johnson",
+				EntityType: "person",
+				Confidence: 0.95,
+				Tags:       []string{"engineer", "golang"},
+				Entities: []schema.Entity{
+					{Name: "Alice Johnson", Aliases: []string{"AJ", "alice"}, Role: "protagonist"},
+				},
+				Relationships: []schema.Relationship{
+					{Target: "bob", Type: "colleague", Strength: 0.8},
+				},
+				SemanticHints: []string{"software engineer at Acme"},
+				Temporal: schema.TemporalInfo{
+					LastVerified: "2026-04-01",
+					DecayRate:    0.01,
+				},
+			},
+			Body:       "Alice is a senior software engineer who works on distributed systems. She collaborates with Bob on the backend platform.",
+			SourcePath: "alice.md",
+		},
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "bob",
+				Title:      "Bob Smith",
+				EntityType: "person",
+				Confidence: 0.8,
+				Tags:       []string{"engineer", "python"},
+				Entities: []schema.Entity{
+					{Name: "Bob Smith", Aliases: []string{"bobby"}, Role: "support"},
+				},
+				Relationships: []schema.Relationship{
+					{Target: "alice", Type: "colleague", Strength: 0.7},
+				},
+				SemanticHints: []string{"data engineer"},
+			},
+			Body:       "Bob specializes in data pipelines and machine learning infrastructure.",
+			SourcePath: "bob.md",
+		},
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "acme",
+				Title:      "Acme Corp",
+				EntityType: "organization",
+				Confidence: 0.9,
+				Tags:       []string{"company", "tech"},
+				Entities: []schema.Entity{
+					{Name: "Acme Corp", Aliases: []string{"Acme"}, Role: "employer"},
+				},
+				SemanticHints: []string{"technology company"},
+			},
+			Body:       "Acme Corp is a technology company founded in 2020.",
+			SourcePath: "acme.md",
+		},
+	}
+	return buildIndex(pages)
+}
+
+func TestSearchExactMatchHighestScore(t *testing.T) {
+	idx := testIndex()
+	results := Search(idx, "Alice Johnson")
+
+	require.NotEmpty(t, results)
+	assert.Equal(t, "alice", results[0].Page.Frontmatter.ID)
+
+	// Exact match should have the highest score.
+	for i := 1; i < len(results); i++ {
+		assert.Greater(t, results[0].Score, results[i].Score,
+			"exact match should score higher than result %d", i)
+	}
+}
+
+func TestSearchPrefixLowerThanExact(t *testing.T) {
+	idx := testIndex()
+
+	exactResults := Search(idx, "alice")
+	prefixResults := Search(idx, "alic")
+
+	require.NotEmpty(t, exactResults)
+	require.NotEmpty(t, prefixResults)
+
+	// Find alice in both result sets.
+	var exactScore, prefixScore float64
+	for _, r := range exactResults {
+		if r.Page.Frontmatter.ID == "alice" {
+			exactScore = r.Score
+		}
+	}
+	for _, r := range prefixResults {
+		if r.Page.Frontmatter.ID == "alice" {
+			prefixScore = r.Score
+		}
+	}
+
+	assert.Greater(t, exactScore, prefixScore,
+		"exact match score should be higher than prefix match score")
+}
+
+func TestSearchFuzzyLowestNonZero(t *testing.T) {
+	idx := testIndex()
+
+	// "alicx" is levenshtein distance 1 from "alice" — should fuzzy match.
+	results := Search(idx, "alicx")
+
+	require.NotEmpty(t, results)
+	// Find alice page.
+	var found bool
+	for _, r := range results {
+		if r.Page.Frontmatter.ID == "alice" {
+			found = true
+			assert.Greater(t, r.Score, 0.0, "fuzzy match should have non-zero score")
+		}
+	}
+	assert.True(t, found, "alice should appear in fuzzy search results")
+}
+
+func TestMultiFieldMaxNotSum(t *testing.T) {
+	// Create a page with many tags that match; score should use max, not sum.
+	pages := []*schema.Page{
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "multi-tag",
+				Title:      "Something",
+				Confidence: 1.0,
+				Tags:       []string{"go", "go-lang", "go-dev", "go-tools"},
+			},
+			Body: "some body",
+		},
+	}
+	idx := buildIndex(pages)
+	results := Search(idx, "go")
+
+	require.Len(t, results, 1)
+	// With max (not sum), only the best tag match contributes.
+	// "go" exact match on tag = weightTag(5) * 1.0 = 5.
+	// If it were sum, it would be higher (e.g. 5 + 5*0.8 + ...).
+	// Also body may contribute "go-lang" etc. but tag weight is the key check.
+	tagMatches := 0
+	for _, m := range results[0].Matches {
+		if m.Field == "tag" {
+			tagMatches++
+		}
+	}
+	assert.Equal(t, 1, tagMatches, "should have exactly 1 tag match (max, not sum)")
+}
+
+func TestTemporalDecayAffectsScore(t *testing.T) {
+	// Page with recent verification should score higher than old verification.
+	recentPage := &schema.Page{
+		Frontmatter: schema.GraphFrontmatter{
+			ID:         "recent",
+			Title:      "Test Page",
+			Confidence: 0.9,
+			Temporal: schema.TemporalInfo{
+				LastVerified: "2026-04-11",
+				DecayRate:    0.1,
+			},
+		},
+		Body: "test content",
+	}
+	oldPage := &schema.Page{
+		Frontmatter: schema.GraphFrontmatter{
+			ID:         "old",
+			Title:      "Test Page",
+			Confidence: 0.9,
+			Temporal: schema.TemporalInfo{
+				LastVerified: "2025-01-01",
+				DecayRate:    0.1,
+			},
+		},
+		Body: "test content",
+	}
+
+	idxRecent := buildIndex([]*schema.Page{recentPage})
+	idxOld := buildIndex([]*schema.Page{oldPage})
+
+	resultsRecent := Search(idxRecent, "test")
+	resultsOld := Search(idxOld, "test")
+
+	require.NotEmpty(t, resultsRecent)
+	require.NotEmpty(t, resultsOld)
+
+	assert.Greater(t, resultsRecent[0].Score, resultsOld[0].Score,
+		"recently verified page should score higher due to temporal decay")
+}
+
+func TestWithLimitLimitsResults(t *testing.T) {
+	idx := testIndex()
+	results := Search(idx, "engineer", WithLimit(1))
+
+	assert.LessOrEqual(t, len(results), 1)
+}
+
+func TestWithMinScoreFilters(t *testing.T) {
+	idx := testIndex()
+	results := Search(idx, "engineer")
+	require.NotEmpty(t, results)
+
+	// Set min score above all results — should return empty.
+	results = Search(idx, "engineer", WithMinScore(9999))
+	assert.Empty(t, results)
+}
+
+func TestEmptyQueryReturnsEmpty(t *testing.T) {
+	idx := testIndex()
+	results := Search(idx, "")
+	assert.Empty(t, results)
+}
+
+func TestFormatForLLM(t *testing.T) {
+	idx := testIndex()
+	results := Search(idx, "alice")
+	require.NotEmpty(t, results)
+
+	var aliceResult Result
+	for _, r := range results {
+		if r.Page.Frontmatter.ID == "alice" {
+			aliceResult = r
+			break
+		}
+	}
+
+	formatted := aliceResult.FormatForLLM()
+
+	assert.Contains(t, formatted, "# Alice Johnson (person)")
+	assert.Contains(t, formatted, "Confidence: 0.95")
+	assert.Contains(t, formatted, "bob (colleague)")
+	assert.Contains(t, formatted, "software engineer at Acme")
+	assert.Contains(t, formatted, "Alice is a senior software engineer")
+}
+
+func TestSearchAliceReturnsAliceFirst(t *testing.T) {
+	idx := testIndex()
+	results := Search(idx, "alice")
+
+	require.NotEmpty(t, results)
+	assert.Equal(t, "alice", results[0].Page.Frontmatter.ID,
+		"searching for 'alice' should return the alice page first")
+}
+
+func TestLevenshteinDistance(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"a", "", 1},
+		{"", "a", 1},
+		{"kitten", "sitting", 3},
+		{"alice", "alicx", 1},
+		{"alice", "alice", 0},
+		{"go", "goo", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_"+tt.b, func(t *testing.T) {
+			got := levenshtein(tt.a, tt.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFormatForLLMBodyExcerpt(t *testing.T) {
+	longBody := strings.Repeat("x", 600)
+	page := &schema.Page{
+		Frontmatter: schema.GraphFrontmatter{
+			ID:         "long",
+			Title:      "Long Body Page",
+			Confidence: 0.5,
+		},
+		Body: longBody,
+	}
+	result := Result{Page: page, Score: 1.0}
+	formatted := result.FormatForLLM()
+
+	// Body should be truncated to 500 chars.
+	lines := strings.Split(formatted, "\n")
+	// Find the body line (after the blank line).
+	var bodyContent string
+	pastBlank := false
+	for _, line := range lines {
+		if pastBlank && line != "" {
+			bodyContent = line
+			break
+		}
+		if line == "" {
+			pastBlank = true
+		}
+	}
+	assert.LessOrEqual(t, len(bodyContent), 500)
+}
+
+func TestFormatForLLMNoEntityType(t *testing.T) {
+	page := &schema.Page{
+		Frontmatter: schema.GraphFrontmatter{
+			ID:         "no-type",
+			Title:      "No Type",
+			Confidence: 0.5,
+		},
+	}
+	result := Result{Page: page, Score: 1.0}
+	formatted := result.FormatForLLM()
+
+	assert.Contains(t, formatted, "# No Type\n")
+	assert.NotContains(t, formatted, "()")
+}


### PR DESCRIPTION
Closes #5

## Summary

Implements the multi-signal search scoring pipeline for `KnowledgeIndex`:

- **`Search(idx, query, ...opts)`** — scores every page using field weights (entity-name=10, alias=8, title=7, tag=5, semantic-hint=3, relationship-target=2, body=1) and match-type multipliers (exact=1.0, prefix=0.8, contains=0.5, fuzzy/levenshtein≤2=0.3)
- **Temporal decay** — `FinalScore = BaseScore × TemporalMultiplier` using `temporal.DecayedConfidenceAt`
- **Anti-stuffing** — multi-value fields (tags, entities, aliases, hints, relationships) use `max` not `sum`
- **SearchOptions** — `WithLimit(n)`, `WithMinScore(f)`, `WithReranker(r)` (Phase 2 hook)
- **`Result.FormatForLLM()`** — structured output with title, entity-type, confidence, relationships, semantic hints, and body excerpt (≤500 chars)
- **Levenshtein** — iterative Wagner-Fischer algorithm, no external deps

## Test Results

```
$ go test -race ./index/...
ok  github.com/KHAEntertainment/markedup/index  1.131s

$ go vet ./...
(clean)

$ go build ./...
(clean)
```

Tests cover: exact/prefix/fuzzy matching, max-not-sum for multi-value fields, temporal decay, WithLimit, WithMinScore, empty query, FormatForLLM format, body excerpt truncation, and "alice" returning first.