### PR TITLE
[Issue #6] Iterative BFS/DFS graph traversal

### DIFF
--- a/index/traverse.go
+++ b/index/traverse.go
@@ -1,0 +1,246 @@
+package index
+
+import (
+	"fmt"
+
+	"github.com/KHAEntertainment/markedup/schema"
+)
+
+// TraversalStrategy selects between breadth-first and depth-first traversal.
+type TraversalStrategy int
+
+const (
+	// BFS performs a breadth-first traversal (default).
+	BFS TraversalStrategy = iota
+	// DFS performs a depth-first traversal.
+	DFS
+)
+
+// TraversalDirection controls which adjacency edges are followed.
+type TraversalDirection int
+
+const (
+	// Forward follows outgoing relationships (adjacency map).
+	Forward TraversalDirection = iota
+	// Reverse follows incoming relationships (reverse adjacency map).
+	Reverse
+	// Both merges forward and reverse neighbors.
+	Both
+)
+
+// TraversalNode pairs a page with the depth at which it was discovered.
+type TraversalNode struct {
+	Page  *schema.Page
+	Depth int
+}
+
+// TraversalEdge represents a directed edge discovered during traversal.
+type TraversalEdge struct {
+	From         string
+	To           string
+	Relationship schema.Relationship
+}
+
+// TraversalResult holds the output of a graph traversal.
+type TraversalResult struct {
+	Root  string
+	Nodes []TraversalNode
+	Edges []TraversalEdge
+	Depth int
+}
+
+// TraverseOption configures a Traverse call.
+type TraverseOption func(*traverseConfig)
+
+type traverseConfig struct {
+	maxDepth          int
+	strategy          TraversalStrategy
+	direction         TraversalDirection
+	relationshipTypes []string // nil = all types
+}
+
+// WithDepth sets the maximum traversal depth. Default is 2.
+func WithDepth(n int) TraverseOption {
+	return func(c *traverseConfig) {
+		c.maxDepth = n
+	}
+}
+
+// WithStrategy selects BFS or DFS. Default is BFS.
+func WithStrategy(s TraversalStrategy) TraverseOption {
+	return func(c *traverseConfig) {
+		c.strategy = s
+	}
+}
+
+// WithDirection sets the traversal direction. Default is Forward.
+func WithDirection(d TraversalDirection) TraverseOption {
+	return func(c *traverseConfig) {
+		c.direction = d
+	}
+}
+
+// WithRelationshipTypes restricts traversal to edges whose Type is in the
+// provided list. Passing nil or an empty slice follows all relationship types.
+func WithRelationshipTypes(types []string) TraverseOption {
+	return func(c *traverseConfig) {
+		c.relationshipTypes = types
+	}
+}
+
+// queueEntry is used internally for BFS/DFS traversal.
+type queueEntry struct {
+	id    string
+	depth int
+}
+
+// Traverse performs an iterative graph traversal starting from the node with
+// the given ID. It is cycle-safe: a visited set prevents revisiting nodes.
+// Returns an error if the starting node is not found in the index.
+func Traverse(idx *KnowledgeIndex, from string, opts ...TraverseOption) (*TraversalResult, error) {
+	cfg := traverseConfig{
+		maxDepth:  2,
+		strategy:  BFS,
+		direction: Forward,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	// Verify the starting node exists.
+	rootPage, ok := idx.Get(from)
+	if !ok {
+		return nil, fmt.Errorf("traverse: node %q not found in index", from)
+	}
+
+	// Build the relationship type filter set.
+	var typeFilter map[string]struct{}
+	if len(cfg.relationshipTypes) > 0 {
+		typeFilter = make(map[string]struct{}, len(cfg.relationshipTypes))
+		for _, t := range cfg.relationshipTypes {
+			typeFilter[t] = struct{}{}
+		}
+	}
+
+	visited := map[string]bool{from: true}
+	result := &TraversalResult{
+		Root:  from,
+		Nodes: []TraversalNode{{Page: rootPage, Depth: 0}},
+	}
+
+	// stack/queue — append to end; BFS pops from front, DFS pops from back.
+	work := []queueEntry{{id: from, depth: 0}}
+
+	for len(work) > 0 {
+		var current queueEntry
+		if cfg.strategy == BFS {
+			current = work[0]
+			work = work[1:]
+		} else {
+			current = work[len(work)-1]
+			work = work[:len(work)-1]
+		}
+
+		if current.depth >= cfg.maxDepth {
+			continue
+		}
+
+		// Collect neighbors.
+		neighbors := neighborsFor(idx, current.id, cfg.direction, typeFilter)
+
+		for _, n := range neighbors {
+			// Record the edge regardless of visited status.
+			result.Edges = append(result.Edges, TraversalEdge{
+				From:         n.edgeFrom,
+				To:           n.edgeTo,
+				Relationship: n.rel,
+			})
+
+			targetID := n.visitID
+			if visited[targetID] {
+				continue
+			}
+			visited[targetID] = true
+
+			targetPage, exists := idx.Get(targetID)
+			if !exists {
+				// Dangling reference — skip but edge is still recorded.
+				continue
+			}
+
+			nextDepth := current.depth + 1
+			result.Nodes = append(result.Nodes, TraversalNode{
+				Page:  targetPage,
+				Depth: nextDepth,
+			})
+			if nextDepth > result.Depth {
+				result.Depth = nextDepth
+			}
+
+			work = append(work, queueEntry{id: targetID, depth: nextDepth})
+		}
+	}
+
+	return result, nil
+}
+
+// neighborInfo bundles an edge discovered during traversal.
+// visitID is the node to add to the work queue (the "next hop").
+type neighborInfo struct {
+	edgeFrom string              // edge source in the original graph
+	edgeTo   string              // edge target in the original graph
+	visitID  string              // the node we are moving to
+	rel      schema.Relationship // the relationship on this edge
+}
+
+// neighborsFor returns the neighbors reachable from nodeID in the given
+// direction, filtered by relationship type if typeFilter is non-nil.
+func neighborsFor(idx *KnowledgeIndex, nodeID string, dir TraversalDirection, typeFilter map[string]struct{}) []neighborInfo {
+	var neighbors []neighborInfo
+
+	if dir == Forward || dir == Both {
+		for _, rel := range idx.ForwardRels(nodeID) {
+			if typeFilter != nil {
+				if _, ok := typeFilter[rel.Type]; !ok {
+					continue
+				}
+			}
+			neighbors = append(neighbors, neighborInfo{
+				edgeFrom: nodeID,
+				edgeTo:   rel.Target,
+				visitID:  rel.Target,
+				rel:      rel,
+			})
+		}
+	}
+
+	if dir == Reverse || dir == Both {
+		for _, srcID := range idx.ReverseRefs(nodeID) {
+			// Find the original relationship from srcID → nodeID.
+			syntheticRel := schema.Relationship{
+				Target:   nodeID,
+				Type:     "reverse-ref",
+				Strength: 0.0,
+			}
+			for _, rel := range idx.ForwardRels(srcID) {
+				if rel.Target == nodeID {
+					syntheticRel = rel
+					break
+				}
+			}
+			if typeFilter != nil {
+				if _, ok := typeFilter[syntheticRel.Type]; !ok {
+					continue
+				}
+			}
+			neighbors = append(neighbors, neighborInfo{
+				edgeFrom: srcID,
+				edgeTo:   nodeID,
+				visitID:  srcID, // traverse into the source node
+				rel:      syntheticRel,
+			})
+		}
+	}
+
+	return neighbors
+}

--- a/index/traverse_test.go
+++ b/index/traverse_test.go
@@ -1,0 +1,267 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/KHAEntertainment/markedup/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// traverseTestPages returns a small graph:
+//
+//	alice --related-to--> bob
+//	alice --describes-->  concept-graph
+//	bob   --related-to--> concept-graph
+//	bob   --depends-on--> alice  (creates a cycle)
+func traverseTestPages() []*schema.Page {
+	return []*schema.Page{
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "alice",
+				Title:      "Alice",
+				EntityType: "person",
+				Confidence: 0.9,
+				Tags:       []string{"people"},
+				Relationships: []schema.Relationship{
+					{Target: "bob", Type: "related-to", Strength: 0.8},
+					{Target: "concept-graph", Type: "describes", Strength: 0.7},
+				},
+			},
+			Body: "Alice body",
+		},
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "bob",
+				Title:      "Bob",
+				EntityType: "person",
+				Confidence: 0.85,
+				Tags:       []string{"people"},
+				Relationships: []schema.Relationship{
+					{Target: "concept-graph", Type: "related-to", Strength: 0.6},
+					{Target: "alice", Type: "depends-on", Strength: 0.5},
+				},
+			},
+			Body: "Bob body",
+		},
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "concept-graph",
+				Title:      "Concept Graph",
+				EntityType: "concept",
+				Confidence: 0.95,
+				Tags:       []string{"concept"},
+			},
+			Body: "Concept graph body",
+		},
+	}
+}
+
+func buildTraverseIndex(pages []*schema.Page) *KnowledgeIndex {
+	return buildIndex(pages)
+}
+
+func nodeIDs(nodes []TraversalNode) []string {
+	ids := make([]string, len(nodes))
+	for i, n := range nodes {
+		ids[i] = n.Page.Frontmatter.ID
+	}
+	return ids
+}
+
+func TestTraverse(t *testing.T) {
+	tests := []struct {
+		name          string
+		pages         []*schema.Page
+		from          string
+		opts          []TraverseOption
+		wantErr       string
+		wantNodeIDs   []string // expected node IDs (order may vary for some)
+		wantRootDepth int      // expected max depth in result
+		checkExact    bool     // if true, node order must match exactly
+	}{
+		{
+			name:  "BFS from alice depth 1",
+			pages: traverseTestPages(),
+			from:  "alice",
+			opts:  []TraverseOption{WithDepth(1)},
+			wantNodeIDs: []string{
+				"alice", "bob", "concept-graph",
+			},
+			wantRootDepth: 1,
+			checkExact:    true, // BFS: alice (0), then bob, concept-graph (1)
+		},
+		{
+			name:  "DFS from alice depth 1",
+			pages: traverseTestPages(),
+			from:  "alice",
+			opts:  []TraverseOption{WithDepth(1), WithStrategy(DFS)},
+			// Nodes are added at discovery time (during neighbor scan), so
+			// order matches relationship declaration order: bob, concept-graph.
+			// DFS vs BFS difference manifests at deeper levels.
+			wantNodeIDs:   []string{"alice", "bob", "concept-graph"},
+			wantRootDepth: 1,
+		},
+		{
+			name:  "BFS from alice default depth 2",
+			pages: traverseTestPages(),
+			from:  "alice",
+			// default depth=2, strategy=BFS, direction=Forward
+			wantNodeIDs:   []string{"alice", "bob", "concept-graph"},
+			wantRootDepth: 1, // all reachable at depth 1
+		},
+		{
+			name:          "depth 0 returns only root",
+			pages:         traverseTestPages(),
+			from:          "alice",
+			opts:          []TraverseOption{WithDepth(0)},
+			wantNodeIDs:   []string{"alice"},
+			wantRootDepth: 0,
+			checkExact:    true,
+		},
+		{
+			name:  "cycle detection A→B→A",
+			pages: traverseTestPages(),
+			from:  "alice",
+			opts:  []TraverseOption{WithDepth(10)}, // deep enough to loop if no cycle detection
+			// alice→bob, alice→concept-graph, bob→concept-graph, bob→alice(visited)
+			wantNodeIDs:   []string{"alice", "bob", "concept-graph"},
+			wantRootDepth: 1,
+		},
+		{
+			name:  "reverse traversal from concept-graph",
+			pages: traverseTestPages(),
+			from:  "concept-graph",
+			opts:  []TraverseOption{WithDirection(Reverse), WithDepth(1)},
+			// concept-graph is targeted by alice and bob
+			wantNodeIDs:   []string{"concept-graph", "alice", "bob"},
+			wantRootDepth: 1,
+		},
+		{
+			name:  "both direction from bob depth 1",
+			pages: traverseTestPages(),
+			from:  "bob",
+			opts:  []TraverseOption{WithDirection(Both), WithDepth(1)},
+			// Forward: bob→concept-graph, bob→alice
+			// Reverse: bob is targeted by alice (already visited via forward)
+			wantNodeIDs:   []string{"bob", "concept-graph", "alice"},
+			wantRootDepth: 1,
+		},
+		{
+			name:  "WithRelationshipTypes filtering",
+			pages: traverseTestPages(),
+			from:  "alice",
+			opts:  []TraverseOption{WithRelationshipTypes([]string{"describes"}), WithDepth(2)},
+			// alice --describes--> concept-graph only
+			wantNodeIDs:   []string{"alice", "concept-graph"},
+			wantRootDepth: 1,
+			checkExact:    true,
+		},
+		{
+			name:    "non-existent from ID",
+			pages:   traverseTestPages(),
+			from:    "nonexistent",
+			wantErr: `traverse: node "nonexistent" not found in index`,
+		},
+		{
+			name:    "empty graph",
+			pages:   nil,
+			from:    "anything",
+			wantErr: `traverse: node "anything" not found in index`,
+		},
+		{
+			name:  "reverse traversal filters by relationship type",
+			pages: traverseTestPages(),
+			from:  "alice",
+			opts: []TraverseOption{
+				WithDirection(Reverse),
+				WithRelationshipTypes([]string{"depends-on"}),
+				WithDepth(1),
+			},
+			// alice is targeted by bob with "depends-on"
+			wantNodeIDs:   []string{"alice", "bob"},
+			wantRootDepth: 1,
+			checkExact:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := buildTraverseIndex(tt.pages)
+			result, err := Traverse(idx, tt.from, tt.opts...)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantErr, err.Error())
+				assert.Nil(t, result)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.from, result.Root)
+			assert.Equal(t, tt.wantRootDepth, result.Depth)
+
+			gotIDs := nodeIDs(result.Nodes)
+			if tt.checkExact {
+				assert.Equal(t, tt.wantNodeIDs, gotIDs)
+			} else {
+				assert.ElementsMatch(t, tt.wantNodeIDs, gotIDs)
+			}
+
+			// Root is always first and at depth 0.
+			require.NotEmpty(t, result.Nodes)
+			assert.Equal(t, tt.from, result.Nodes[0].Page.Frontmatter.ID)
+			assert.Equal(t, 0, result.Nodes[0].Depth)
+		})
+	}
+}
+
+func TestTraverse_EdgesRecorded(t *testing.T) {
+	idx := buildTraverseIndex(traverseTestPages())
+	result, err := Traverse(idx, "alice", WithDepth(1))
+	require.NoError(t, err)
+
+	// alice has 2 forward relationships: bob and concept-graph.
+	require.Len(t, result.Edges, 2)
+
+	edgeTargets := make([]string, len(result.Edges))
+	for i, e := range result.Edges {
+		assert.Equal(t, "alice", e.From)
+		edgeTargets[i] = e.To
+	}
+	assert.ElementsMatch(t, []string{"bob", "concept-graph"}, edgeTargets)
+}
+
+func TestTraverse_CycleEdgesStillRecorded(t *testing.T) {
+	idx := buildTraverseIndex(traverseTestPages())
+	result, err := Traverse(idx, "alice", WithDepth(2))
+	require.NoError(t, err)
+
+	// Edges should include the back-edge bob→alice even though alice is visited.
+	var foundBackEdge bool
+	for _, e := range result.Edges {
+		if e.From == "bob" && e.To == "alice" {
+			foundBackEdge = true
+		}
+	}
+	assert.True(t, foundBackEdge, "expected back-edge bob→alice to be recorded")
+}
+
+func TestTraverse_SingleNodeNoRelationships(t *testing.T) {
+	pages := []*schema.Page{
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:    "lonely",
+				Title: "Lonely Node",
+			},
+		},
+	}
+	idx := buildTraverseIndex(pages)
+	result, err := Traverse(idx, "lonely")
+	require.NoError(t, err)
+	assert.Len(t, result.Nodes, 1)
+	assert.Equal(t, "lonely", result.Nodes[0].Page.Frontmatter.ID)
+	assert.Empty(t, result.Edges)
+	assert.Equal(t, 0, result.Depth)
+}


### PR DESCRIPTION
## Summary

Closes #6

- Adds `index/traverse.go` with iterative BFS/DFS graph traversal over `KnowledgeIndex` adjacency maps
- Cycle-safe via `visited` set (prevents revisiting nodes)
- Functional options: `WithDepth(n)`, `WithStrategy(BFS|DFS)`, `WithDirection(Forward|Reverse|Both)`, `WithRelationshipTypes([]string)`
- Forward follows `ForwardRels`, Reverse follows `ReverseRefs` (with original relationship metadata), Both merges neighbors
- Returns error if starting node is not found in index

## Test results

```
$ go test -race ./index/...
ok  	github.com/KHAEntertainment/markedup/index	1.135s

$ go vet ./...
(clean)

$ go build ./...
(clean)
```

Table-driven tests in `index/traverse_test.go` cover:
- BFS from alice (finds bob and concept-graph at depth 1)
- DFS from alice (same nodes, discovery-order preserved)
- Default depth 2
- Depth 0 (only root)
- Cycle detection (A→B→A does not loop)
- Reverse traversal
- Both direction
- WithRelationshipTypes filtering
- Non-existent from ID → error
- Empty graph → error
- Edge recording (including back-edges for cycles)
- Single node with no relationships

## Test plan
- [x] `go test -race ./index/...` passes
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] No regressions in existing index tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)