### PR TITLE
[Issue #17] Fix duplicate validation errors in check command

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -38,22 +38,17 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	var errorFiles []fileErrors
+	var parseErrors []index.LoadWarning
 	for _, w := range result.Warnings {
 		if len(w.Errors) > 0 {
 			errorFiles = append(errorFiles, fileErrors{path: w.Path, errs: w.Errors})
+		} else if w.Message != "" {
+			// Parse errors have a message but no structured validation errors.
+			parseErrors = append(parseErrors, w)
 		}
 	}
 
-	// Also validate pages that loaded successfully (they may have been counted
-	// but warnings only appear for parse errors when WithIgnoreErrors is used).
-	for _, page := range result.Index.All() {
-		errs := schema.ValidatePage(page)
-		if len(errs) > 0 {
-			errorFiles = append(errorFiles, fileErrors{path: page.SourcePath, errs: errs})
-		}
-	}
-
-	totalErrors := 0
+	totalErrors := len(parseErrors)
 	for _, fe := range errorFiles {
 		totalErrors += len(fe.errs)
 	}
@@ -68,6 +63,8 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	}
+
+	totalFiles := len(errorFiles) + len(parseErrors)
 
 	// Print errors.
 	if jsonOutput {
@@ -87,7 +84,15 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		jc := jsonCheck{
 			Pages:  totalPages,
 			Errors: totalErrors,
-			Files:  len(errorFiles),
+			Files:  totalFiles,
+		}
+		for _, pe := range parseErrors {
+			jc.Issues = append(jc.Issues, jsonErr{
+				File:    pe.Path,
+				Field:   "frontmatter",
+				Message: pe.Message,
+				Fix:     "check YAML syntax between --- delimiters",
+			})
 		}
 		for _, fe := range errorFiles {
 			for _, e := range fe.errs {
@@ -103,10 +108,13 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(out, string(b))
 	} else {
 		fmt.Fprintf(out, "Errors found:\n\n")
+		for _, pe := range parseErrors {
+			fmt.Fprintf(out, "  %s\n    - frontmatter: %s\n      Fix: check YAML syntax between --- delimiters\n", pe.Path, pe.Message)
+		}
 		for _, fe := range errorFiles {
 			fmt.Fprint(out, formatValidationErrors(fe.path, fe.errs))
 		}
-		fmt.Fprintf(out, "\n%d pages checked. %d errors in %d files.\n", totalPages, totalErrors, len(errorFiles))
+		fmt.Fprintf(out, "\n%d pages checked. %d errors in %d files.\n", totalPages, totalErrors, totalFiles)
 		fmt.Fprintln(out, "Fix errors above, then run `markedup check` again.")
 	}
 


### PR DESCRIPTION
## Summary

Closes #17

- Removed the redundant `schema.ValidatePage()` loop in `check.go` that re-validated pages already validated by `index.Load(WithIgnoreErrors(true))`
- Used `result.Warnings` directly to collect all validation errors, eliminating duplicates
- Added reporting of parse errors (e.g. broken YAML) that were previously silently dropped

## Root Cause

`index.Load()` with `WithIgnoreErrors(true)` already calls `schema.ValidatePage()` on each parsed page and collects validation errors as `LoadWarning` entries. The check command then looped over `result.Index.All()` and called `ValidatePage()` again, producing every validation error twice.

## Fix

Removed lines 48-54 in `check.go` (the redundant `ValidatePage` loop). The `result.Warnings` from the loader already contain all validation errors. Also added handling for parse-error warnings (those with a message but no structured `ValidationError` entries) so that files like `broken-yaml.md` are now reported.

## Test Output

**Invalid testdata** — each error appears exactly once:
```
$ markedup check testdata/invalid/
Errors found:

  testdata/invalid/broken-yaml.md
    - frontmatter: markdown: unmarshal frontmatter: yaml: line 1: did not find expected ',' or ']'
      Fix: check YAML syntax between --- delimiters
  testdata/invalid/bad-confidence.md
    - confidence: confidence must be in [0, 1], got 1.5
      Fix: set confidence to a value between 0.0 and 1.0
  testdata/invalid/missing-id.md
    - id: id is required
      Fix: add a non-empty 'id' field to the frontmatter

2 pages checked. 3 errors in 3 files.
```

**Valid testdata** — exits 0:
```
$ markedup check testdata/valid/
6 pages checked. All valid.
```

**All tests pass**: `go test -race ./...` — all OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting to distinguish between syntax errors and validation errors
  * Parse errors now displayed separately in the output for improved visibility
  * Updated error file counts for accuracy across all error types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->