### PR TITLE
[Issue #19] Embedder interface + OpenAI-compatible provider

### DIFF
--- a/embed/embedder.go
+++ b/embed/embedder.go
@@ -1,0 +1,90 @@
+// Package embed provides interfaces and implementations for text embedding.
+package embed
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Embedder produces vector embeddings from text.
+type Embedder interface {
+	// Embed returns one embedding vector per input text.
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+
+	// Dimensions returns the dimensionality of the embedding vectors.
+	Dimensions() int
+
+	// Model returns the model identifier used for embedding.
+	Model() string
+}
+
+// Config configures an OpenAI-compatible embedder.
+type Config struct {
+	// Endpoint is the base URL of the API (e.g. "http://localhost:11434").
+	// The /v1/embeddings path is appended automatically.
+	Endpoint string
+
+	// ModelName is the embedding model to request (e.g. "text-embedding-3-small").
+	ModelName string
+
+	// APIKey is the bearer token for API authentication (optional for local backends).
+	APIKey string
+
+	// Token is reserved for future OAuth integration (e.g. OpenRouter OAuth).
+	Token string
+
+	// BatchSize controls how many texts are sent per request.
+	// Defaults to DefaultBatchSize if zero or negative.
+	BatchSize int
+
+	// Dims is the expected dimensionality of the embedding vectors.
+	Dims int
+
+	// HTTPClient overrides the default HTTP client. If nil, http.DefaultClient is used.
+	HTTPClient *http.Client
+}
+
+// DefaultBatchSize is the default number of texts per embedding request.
+const DefaultBatchSize = 100
+
+// ErrAuth indicates an authentication or authorization failure (HTTP 401/403).
+var ErrAuth = errors.New("embed: authentication error")
+
+// ErrServer indicates a server-side failure (HTTP 5xx).
+var ErrServer = errors.New("embed: server error")
+
+// AuthError wraps ErrAuth with the HTTP status code and response body.
+type AuthError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *AuthError) Error() string {
+	return fmt.Sprintf("embed: authentication error (HTTP %d): %s", e.StatusCode, e.Body)
+}
+
+func (e *AuthError) Unwrap() error { return ErrAuth }
+
+// ServerError wraps ErrServer with the HTTP status code and response body.
+type ServerError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *ServerError) Error() string {
+	return fmt.Sprintf("embed: server error (HTTP %d): %s", e.StatusCode, e.Body)
+}
+
+func (e *ServerError) Unwrap() error { return ErrServer }
+
+// RequestError represents an unexpected HTTP error that is neither auth nor server.
+type RequestError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *RequestError) Error() string {
+	return fmt.Sprintf("embed: request error (HTTP %d): %s", e.StatusCode, e.Body)
+}

--- a/embed/openai_compat.go
+++ b/embed/openai_compat.go
@@ -1,0 +1,166 @@
+package embed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// embeddingRequest is the OpenAI-compatible /v1/embeddings request body.
+type embeddingRequest struct {
+	Input []string `json:"input"`
+	Model string   `json:"model"`
+}
+
+// embeddingResponse is the OpenAI-compatible /v1/embeddings response body.
+type embeddingResponse struct {
+	Data []embeddingData `json:"data"`
+}
+
+// embeddingData holds a single embedding vector with its index.
+type embeddingData struct {
+	Index     int       `json:"index"`
+	Embedding []float32 `json:"embedding"`
+}
+
+// OpenAICompatibleEmbedder implements Embedder using any OpenAI-compatible
+// /v1/embeddings endpoint (OpenAI, ollama, llama.cpp, OpenRouter, etc.).
+type OpenAICompatibleEmbedder struct {
+	endpoint   string // base URL without trailing slash
+	model      string
+	apiKey     string
+	token      string
+	batchSize  int
+	dims       int
+	httpClient *http.Client
+}
+
+// NewOpenAICompatible creates an OpenAICompatibleEmbedder from the given config.
+func NewOpenAICompatible(cfg Config) *OpenAICompatibleEmbedder {
+	batchSize := cfg.BatchSize
+	if batchSize <= 0 {
+		batchSize = DefaultBatchSize
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	endpoint := strings.TrimRight(cfg.Endpoint, "/")
+	return &OpenAICompatibleEmbedder{
+		endpoint:   endpoint,
+		model:      cfg.ModelName,
+		apiKey:     cfg.APIKey,
+		token:      cfg.Token,
+		batchSize:  batchSize,
+		dims:       cfg.Dims,
+		httpClient: client,
+	}
+}
+
+// Embed sends texts in batches to the /v1/embeddings endpoint and returns
+// the resulting embedding vectors. The returned slice is ordered to match
+// the input texts.
+func (e *OpenAICompatibleEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	result := make([][]float32, len(texts))
+
+	for start := 0; start < len(texts); start += e.batchSize {
+		end := start + e.batchSize
+		if end > len(texts) {
+			end = len(texts)
+		}
+		batch := texts[start:end]
+
+		embeddings, err := e.sendBatch(ctx, batch)
+		if err != nil {
+			return nil, err
+		}
+
+		for i, emb := range embeddings {
+			result[start+i] = emb
+		}
+	}
+
+	return result, nil
+}
+
+// Dimensions returns the configured embedding dimensionality.
+func (e *OpenAICompatibleEmbedder) Dimensions() int { return e.dims }
+
+// Model returns the model identifier.
+func (e *OpenAICompatibleEmbedder) Model() string { return e.model }
+
+// sendBatch sends a single batch of texts to the embedding endpoint.
+func (e *OpenAICompatibleEmbedder) sendBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	reqBody := embeddingRequest{
+		Input: texts,
+		Model: e.model,
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("embed: marshal request: %w", err)
+	}
+
+	url := e.endpoint + "/v1/embeddings"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("embed: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Auth: prefer APIKey, fall back to Token (future OAuth).
+	if e.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+e.apiKey)
+	} else if e.token != "" {
+		req.Header.Set("Authorization", "Bearer "+e.token)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embed: send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("embed: read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, &AuthError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+	if resp.StatusCode >= 500 {
+		return nil, &ServerError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &RequestError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+
+	var embResp embeddingResponse
+	if err := json.Unmarshal(respBody, &embResp); err != nil {
+		return nil, fmt.Errorf("embed: unmarshal response: %w", err)
+	}
+
+	if len(embResp.Data) != len(texts) {
+		return nil, fmt.Errorf("embed: expected %d embeddings, got %d", len(texts), len(embResp.Data))
+	}
+
+	// Re-order by index to handle out-of-order responses.
+	embeddings := make([][]float32, len(texts))
+	for _, d := range embResp.Data {
+		if d.Index < 0 || d.Index >= len(texts) {
+			return nil, fmt.Errorf("embed: invalid embedding index %d for batch size %d", d.Index, len(texts))
+		}
+		embeddings[d.Index] = d.Embedding
+	}
+
+	return embeddings, nil
+}

--- a/embed/openai_compat_test.go
+++ b/embed/openai_compat_test.go
@@ -1,0 +1,270 @@
+package embed
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestServer creates an httptest.Server that responds to /v1/embeddings.
+// The handler function receives the decoded request and returns a status code
+// and response body bytes.
+func newTestServer(t *testing.T, handler func(req embeddingRequest) (int, []byte)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/embeddings", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var req embeddingRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+
+		code, body := handler(req)
+		w.WriteHeader(code)
+		_, _ = w.Write(body)
+	}))
+}
+
+// makeEmbeddingResponse builds a valid JSON embedding response for the given
+// number of inputs, each with the specified dimensionality.
+func makeEmbeddingResponse(n, dims int) []byte {
+	resp := embeddingResponse{Data: make([]embeddingData, n)}
+	for i := 0; i < n; i++ {
+		vec := make([]float32, dims)
+		for d := 0; d < dims; d++ {
+			vec[d] = float32(i*dims + d)
+		}
+		resp.Data[i] = embeddingData{Index: i, Embedding: vec}
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func TestEmbed_HappyPath(t *testing.T) {
+	dims := 3
+	srv := newTestServer(t, func(req embeddingRequest) (int, []byte) {
+		return http.StatusOK, makeEmbeddingResponse(len(req.Input), dims)
+	})
+	defer srv.Close()
+
+	emb := NewOpenAICompatible(Config{
+		Endpoint:  srv.URL,
+		ModelName: "test-model",
+		Dims:      dims,
+	})
+
+	vecs, err := emb.Embed(context.Background(), []string{"hello world"})
+	require.NoError(t, err)
+	require.Len(t, vecs, 1)
+	assert.Len(t, vecs[0], dims)
+	assert.Equal(t, "test-model", emb.Model())
+	assert.Equal(t, dims, emb.Dimensions())
+}
+
+func TestEmbed_EmptyInput(t *testing.T) {
+	emb := NewOpenAICompatible(Config{
+		Endpoint:  "http://unused",
+		ModelName: "m",
+	})
+	vecs, err := emb.Embed(context.Background(), []string{})
+	require.NoError(t, err)
+	assert.Nil(t, vecs)
+}
+
+func TestEmbed_NilInput(t *testing.T) {
+	emb := NewOpenAICompatible(Config{
+		Endpoint:  "http://unused",
+		ModelName: "m",
+	})
+	vecs, err := emb.Embed(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, vecs)
+}
+
+func TestEmbed_CanceledContext(t *testing.T) {
+	srv := newTestServer(t, func(req embeddingRequest) (int, []byte) {
+		return http.StatusOK, makeEmbeddingResponse(1, 3)
+	})
+	defer srv.Close()
+
+	emb := NewOpenAICompatible(Config{
+		Endpoint:  srv.URL,
+		ModelName: "m",
+		Dims:      3,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := emb.Embed(ctx, []string{"hello"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got: %v", err)
+}
+
+func TestEmbed_AuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid api key"}`))
+	}))
+	defer srv.Close()
+
+	emb := NewOpenAICompatible(Config{
+		Endpoint:  srv.URL,
+		ModelName: "m",
+		APIKey:    "bad-key",
+	})
+
+	_, err := emb.Embed(context.Background(), []string{"hello"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAuth), "expected ErrAuth, got: %v", err)
+
+	var authErr *AuthError
+	require.True(t, errors.As(err, &authErr))
+	assert.Equal(t, http.StatusUnauthorized, authErr.StatusCode)
+	assert.Contains(t, authErr.Body, "invalid api key")
+}
+
+func TestEmbed_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal"}`))
+	}))
+	defer srv.Close()
+
+	emb := NewOpenAICompatible(Config{
+		Endpoint:  srv.URL,
+		ModelName: "m",
+	})
+
+	_, err := emb.Embed(context.Background(), []string{"hello"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrServer), "expected ErrServer, got: %v", err)
+
+	var srvErr *ServerError
+	require.True(t, errors.As(err, &srvErr))
+	assert.Equal(t, http.StatusInternalServerError, srvErr.StatusCode)
+}
+
+func TestEmbed_Batching(t *testing.T) {
+	dims := 2
+	var batchCount atomic.Int32
+
+	srv := newTestServer(t, func(req embeddingRequest) (int, []byte) {
+		batchCount.Add(1)
+		return http.StatusOK, makeEmbeddingResponse(len(req.Input), dims)
+	})
+	defer srv.Close()
+
+	emb := NewOpenAICompatible(Config{
+		Endpoint:  srv.URL,
+		ModelName: "m",
+		BatchSize: 3,
+		Dims:      dims,
+	})
+
+	// 7 texts with batch size 3 → 3 batches (3+3+1)
+	texts := make([]string, 7)
+	for i := range texts {
+		texts[i] = "text"
+	}
+
+	vecs, err := emb.Embed(context.Background(), texts)
+	require.NoError(t, err)
+	require.Len(t, vecs, 7)
+	assert.Equal(t, int32(3), batchCount.Load(), "expected 3 batch requests")
+
+	// Verify each vector has correct dimensions.
+	for i, v := range vecs {
+		assert.Len(t, v, dims, "vector %d has wrong dimensions", i)
+	}
+}
+
+func TestEmbed_AuthHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiKey   string
+		token    string
+		wantAuth string
+	}{
+		{"api key", "sk-123", "", "Bearer sk-123"},
+		{"token", "", "oauth-tok", "Bearer oauth-tok"},
+		{"api key takes precedence", "sk-123", "oauth-tok", "Bearer sk-123"},
+		{"no auth", "", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got := r.Header.Get("Authorization")
+				assert.Equal(t, tc.wantAuth, got)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(makeEmbeddingResponse(1, 2))
+			}))
+			defer srv.Close()
+
+			emb := NewOpenAICompatible(Config{
+				Endpoint:  srv.URL,
+				ModelName: "m",
+				APIKey:    tc.apiKey,
+				Token:     tc.token,
+				Dims:      2,
+			})
+
+			_, err := emb.Embed(context.Background(), []string{"hi"})
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestEmbed_DefaultBatchSize(t *testing.T) {
+	emb := NewOpenAICompatible(Config{
+		Endpoint:  "http://unused",
+		ModelName: "m",
+	})
+	assert.Equal(t, DefaultBatchSize, emb.batchSize)
+}
+
+func TestEmbed_ForbiddenIsAuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer srv.Close()
+
+	emb := NewOpenAICompatible(Config{
+		Endpoint:  srv.URL,
+		ModelName: "m",
+	})
+
+	_, err := emb.Embed(context.Background(), []string{"hello"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAuth))
+}
+
+func TestEmbed_UnexpectedStatusCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer srv.Close()
+
+	emb := NewOpenAICompatible(Config{
+		Endpoint:  srv.URL,
+		ModelName: "m",
+	})
+
+	_, err := emb.Embed(context.Background(), []string{"hello"})
+	require.Error(t, err)
+
+	var reqErr *RequestError
+	require.True(t, errors.As(err, &reqErr))
+	assert.Equal(t, http.StatusTooManyRequests, reqErr.StatusCode)
+}


### PR DESCRIPTION
Closes #19

## Summary
- New `embed/` package with clean `Embedder` interface (`Embed`, `Dimensions`, `Model`)
- `OpenAICompatibleEmbedder` implementation targeting `/v1/embeddings` endpoint (works with OpenAI, ollama, llama.cpp, OpenRouter)
- Typed error hierarchy: `ErrAuth` (401/403), `ErrServer` (5xx), `RequestError` (other)
- Configurable batching, auth via `APIKey` or `Token` (future OAuth)

## Files
- `embed/embedder.go` — interface, config, typed errors
- `embed/openai_compat.go` — implementation with batching
- `embed/openai_compat_test.go` — 11 table-driven tests with mock HTTP server

## Self-Check Results
| Acceptance Criterion | Status |
|---|---|
| Embedder interface with Embed/Dimensions/Model | ✅ |
| OpenAICompatibleEmbedder with configurable endpoint/model/key | ✅ |
| POST /v1/embeddings correctly marshaled | ✅ |
| Batching with configurable batch size | ✅ |
| Embed against mock server returns expected [][]float32 | ✅ |
| Canceled context returns context error | ✅ |
| 401 returns typed auth error | ✅ |
| 500 returns typed server error | ✅ |
| Config supports APIKey + Token fields | ✅ |
| All tests pass with -race, no lint errors | ✅ |

## Test Output
```
ok  github.com/KHAEntertainment/markedup/embed  1.301s (11 tests, -race)
ok  github.com/KHAEntertainment/markedup         3.258s (full suite, no regressions)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for embedding text using OpenAI-compatible embedding services with configurable API endpoints, model selection, and authentication.
  * Implemented automatic request batching to optimize API usage while maintaining result ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->