### PR TITLE
[Issue #20] Reranker interface + cross-encoder provider

### DIFF
--- a/rerank/cross_encoder.go
+++ b/rerank/cross_encoder.go
@@ -1,0 +1,272 @@
+package rerank
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+)
+
+// Format specifies the API request/response format for the reranker endpoint.
+type Format int
+
+const (
+	// FormatJina uses the Jina reranker API format: POST /v1/rerank with
+	// {"query": "...", "documents": ["..."], "model": "...", "top_n": N}.
+	FormatJina Format = iota
+
+	// FormatOpenAI uses an OpenAI-compatible reranker format with the same
+	// request structure but potentially different response field names.
+	FormatOpenAI
+)
+
+// Config holds the configuration for a CrossEncoderReranker.
+type Config struct {
+	// Endpoint is the base URL of the reranker API (e.g. "https://api.jina.ai").
+	Endpoint string
+
+	// Model is the reranker model name (e.g. "jina-reranker-v2-base-multilingual").
+	Model string
+
+	// APIKey is sent as "Bearer <APIKey>" in the Authorization header.
+	// Mutually preferred over Token; if both set, APIKey takes precedence.
+	APIKey string
+
+	// Token is an alternative auth credential (e.g. future OAuth token).
+	// Sent as "Bearer <Token>" if APIKey is empty.
+	Token string
+
+	// TopN limits the number of results returned. Zero means return all candidates.
+	TopN int
+
+	// Format selects the API request/response format. Defaults to FormatJina.
+	Format Format
+
+	// HTTPClient allows injecting a custom HTTP client for testing. If nil,
+	// http.DefaultClient is used.
+	HTTPClient *http.Client
+}
+
+// CrossEncoderReranker scores (query, document) pairs via an HTTP reranker API.
+// It implements the Reranker interface.
+type CrossEncoderReranker struct {
+	cfg Config
+}
+
+// NewCrossEncoder creates a new CrossEncoderReranker with the given config.
+func NewCrossEncoder(cfg Config) *CrossEncoderReranker {
+	return &CrossEncoderReranker{cfg: cfg}
+}
+
+// Rerank sends each candidate's text to the configured reranker endpoint along
+// with the query, and returns candidates re-ordered by cross-encoder score.
+// Empty candidates returns an empty slice with no error.
+func (r *CrossEncoderReranker) Rerank(ctx context.Context, query string, candidates []Candidate) ([]RankedResult, error) {
+	if len(candidates) == 0 {
+		return []RankedResult{}, nil
+	}
+
+	// Check context before making HTTP call.
+	if err := ctx.Err(); err != nil {
+		return nil, &APIError{
+			Message: err.Error(),
+			Err:     ErrContext,
+		}
+	}
+
+	topN := r.cfg.TopN
+	if topN <= 0 || topN > len(candidates) {
+		topN = len(candidates)
+	}
+
+	scores, err := r.callAPI(ctx, query, candidates, topN)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildRankedResults(candidates, scores, topN), nil
+}
+
+// jinaRequest is the request body for the Jina reranker API.
+type jinaRequest struct {
+	Query     string   `json:"query"`
+	Documents []string `json:"documents"`
+	Model     string   `json:"model,omitempty"`
+	TopN      int      `json:"top_n,omitempty"`
+}
+
+// jinaResponse is the response body from the Jina reranker API.
+type jinaResponse struct {
+	Results []jinaResult `json:"results"`
+}
+
+type jinaResult struct {
+	Index          int     `json:"index"`
+	RelevanceScore float64 `json:"relevance_score"`
+}
+
+// openAIRerankResponse is the response body for OpenAI-compatible reranker APIs.
+type openAIRerankResponse struct {
+	Results []openAIRerankResult `json:"results"`
+}
+
+type openAIRerankResult struct {
+	Index          int     `json:"index"`
+	RelevanceScore float64 `json:"relevance_score"`
+}
+
+// callAPI sends the rerank request to the configured endpoint and returns
+// a map of candidate index -> score.
+func (r *CrossEncoderReranker) callAPI(ctx context.Context, query string, candidates []Candidate, topN int) (map[int]float64, error) {
+	documents := make([]string, len(candidates))
+	for i, c := range candidates {
+		documents[i] = c.Text
+	}
+
+	reqBody := jinaRequest{
+		Query:     query,
+		Documents: documents,
+		Model:     r.cfg.Model,
+		TopN:      topN,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("rerank: marshal request: %w", err)
+	}
+
+	endpoint := r.cfg.Endpoint + "/v1/rerank"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("rerank: create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	// Set auth header.
+	if r.cfg.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+r.cfg.APIKey)
+	} else if r.cfg.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+r.cfg.Token)
+	}
+
+	client := r.cfg.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// Check if the error is due to context cancellation.
+		if ctx.Err() != nil {
+			return nil, &APIError{
+				Message: ctx.Err().Error(),
+				Err:     ErrContext,
+			}
+		}
+		return nil, fmt.Errorf("rerank: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("rerank: read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    string(respBody),
+			Err:        ErrAuth,
+		}
+	}
+
+	if resp.StatusCode >= 500 {
+		return nil, &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    string(respBody),
+			Err:        ErrServer,
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &APIError{
+			StatusCode: resp.StatusCode,
+			Message:    string(respBody),
+		}
+	}
+
+	return r.parseResponse(respBody)
+}
+
+// parseResponse parses the API response based on the configured format.
+func (r *CrossEncoderReranker) parseResponse(body []byte) (map[int]float64, error) {
+	scores := make(map[int]float64)
+
+	switch r.cfg.Format {
+	case FormatJina:
+		var resp jinaResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("rerank: unmarshal jina response: %w", err)
+		}
+		for _, res := range resp.Results {
+			scores[res.Index] = res.RelevanceScore
+		}
+
+	case FormatOpenAI:
+		var resp openAIRerankResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("rerank: unmarshal openai response: %w", err)
+		}
+		for _, res := range resp.Results {
+			scores[res.Index] = res.RelevanceScore
+		}
+
+	default:
+		return nil, fmt.Errorf("rerank: unsupported format: %d", r.cfg.Format)
+	}
+
+	return scores, nil
+}
+
+// buildRankedResults builds the final ranked results from candidates and their
+// cross-encoder scores, sorted by score descending, limited to topN.
+func buildRankedResults(candidates []Candidate, scores map[int]float64, topN int) []RankedResult {
+	type indexedScore struct {
+		idx   int
+		score float64
+	}
+
+	scored := make([]indexedScore, 0, len(scores))
+	for idx, score := range scores {
+		if idx >= 0 && idx < len(candidates) {
+			scored = append(scored, indexedScore{idx: idx, score: score})
+		}
+	}
+
+	sort.Slice(scored, func(i, j int) bool {
+		if scored[i].score != scored[j].score {
+			return scored[i].score > scored[j].score
+		}
+		return scored[i].idx < scored[j].idx
+	})
+
+	if topN > 0 && len(scored) > topN {
+		scored = scored[:topN]
+	}
+
+	results := make([]RankedResult, len(scored))
+	for i, s := range scored {
+		results[i] = RankedResult{
+			Candidate: candidates[s.idx],
+			Score:     s.score,
+			Rank:      i + 1,
+		}
+	}
+
+	return results
+}

--- a/rerank/cross_encoder_test.go
+++ b/rerank/cross_encoder_test.go
@@ -1,0 +1,335 @@
+package rerank
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestServer creates a mock reranker API server that returns the given
+// results. If statusCode != 200, it returns an error response.
+func newTestServer(t *testing.T, statusCode int, results []jinaResult) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request format.
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/rerank", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var req jinaRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+
+		if statusCode != http.StatusOK {
+			w.WriteHeader(statusCode)
+			w.Write([]byte(`{"error": "test error"}`))
+			return
+		}
+
+		resp := jinaResponse{Results: results}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestCrossEncoder_Rerank_HappyPath(t *testing.T) {
+	// Server returns candidates re-ordered: index 2 highest, then 0, then 1.
+	server := newTestServer(t, http.StatusOK, []jinaResult{
+		{Index: 0, RelevanceScore: 0.5},
+		{Index: 1, RelevanceScore: 0.2},
+		{Index: 2, RelevanceScore: 0.9},
+	})
+	defer server.Close()
+
+	reranker := NewCrossEncoder(Config{
+		Endpoint:   server.URL,
+		Model:      "test-model",
+		HTTPClient: server.Client(),
+	})
+
+	candidates := []Candidate{
+		{ID: "doc-a", Text: "Go programming language", OriginalScore: 10.0},
+		{ID: "doc-b", Text: "Python programming", OriginalScore: 8.0},
+		{ID: "doc-c", Text: "Go concurrency patterns", OriginalScore: 6.0},
+	}
+
+	results, err := reranker.Rerank(context.Background(), "go concurrency", candidates)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	// Verify re-ordering by cross-encoder score.
+	assert.Equal(t, "doc-c", results[0].ID)
+	assert.Equal(t, 0.9, results[0].Score)
+	assert.Equal(t, 1, results[0].Rank)
+
+	assert.Equal(t, "doc-a", results[1].ID)
+	assert.Equal(t, 0.5, results[1].Score)
+	assert.Equal(t, 2, results[1].Rank)
+
+	assert.Equal(t, "doc-b", results[2].ID)
+	assert.Equal(t, 0.2, results[2].Score)
+	assert.Equal(t, 3, results[2].Rank)
+}
+
+func TestCrossEncoder_Rerank_EmptyCandidates(t *testing.T) {
+	reranker := NewCrossEncoder(Config{
+		Endpoint: "http://unused",
+	})
+
+	results, err := reranker.Rerank(context.Background(), "test query", []Candidate{})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	assert.NotNil(t, results) // returns empty slice, not nil
+}
+
+func TestCrossEncoder_Rerank_TopN(t *testing.T) {
+	server := newTestServer(t, http.StatusOK, []jinaResult{
+		{Index: 0, RelevanceScore: 0.9},
+		{Index: 2, RelevanceScore: 0.7},
+	})
+	defer server.Close()
+
+	reranker := NewCrossEncoder(Config{
+		Endpoint:   server.URL,
+		Model:      "test-model",
+		TopN:       2,
+		HTTPClient: server.Client(),
+	})
+
+	candidates := []Candidate{
+		{ID: "doc-a", Text: "First document", OriginalScore: 10.0},
+		{ID: "doc-b", Text: "Second document", OriginalScore: 8.0},
+		{ID: "doc-c", Text: "Third document", OriginalScore: 6.0},
+	}
+
+	results, err := reranker.Rerank(context.Background(), "test", candidates)
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.Equal(t, "doc-a", results[0].ID)
+	assert.Equal(t, "doc-c", results[1].ID)
+}
+
+func TestCrossEncoder_Rerank_ContextCanceled(t *testing.T) {
+	// Use a server that delays so the context cancellation happens during the request.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	reranker := NewCrossEncoder(Config{
+		Endpoint:   server.URL,
+		Model:      "test-model",
+		HTTPClient: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	candidates := []Candidate{
+		{ID: "doc-a", Text: "test", OriginalScore: 1.0},
+	}
+
+	_, err := reranker.Rerank(ctx, "query", candidates)
+	require.Error(t, err)
+
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.True(t, errors.Is(apiErr, ErrContext))
+}
+
+func TestCrossEncoder_Rerank_Unauthorized(t *testing.T) {
+	server := newTestServer(t, http.StatusUnauthorized, nil)
+	defer server.Close()
+
+	reranker := NewCrossEncoder(Config{
+		Endpoint:   server.URL,
+		Model:      "test-model",
+		APIKey:     "bad-key",
+		HTTPClient: server.Client(),
+	})
+
+	candidates := []Candidate{
+		{ID: "doc-a", Text: "test", OriginalScore: 1.0},
+	}
+
+	_, err := reranker.Rerank(context.Background(), "query", candidates)
+	require.Error(t, err)
+
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
+	assert.True(t, errors.Is(apiErr, ErrAuth))
+}
+
+func TestCrossEncoder_Rerank_ServerError(t *testing.T) {
+	server := newTestServer(t, http.StatusInternalServerError, nil)
+	defer server.Close()
+
+	reranker := NewCrossEncoder(Config{
+		Endpoint:   server.URL,
+		Model:      "test-model",
+		HTTPClient: server.Client(),
+	})
+
+	candidates := []Candidate{
+		{ID: "doc-a", Text: "test", OriginalScore: 1.0},
+	}
+
+	_, err := reranker.Rerank(context.Background(), "query", candidates)
+	require.Error(t, err)
+
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, http.StatusInternalServerError, apiErr.StatusCode)
+	assert.True(t, errors.Is(apiErr, ErrServer))
+}
+
+func TestCrossEncoder_Rerank_AuthHeader_APIKey(t *testing.T) {
+	var capturedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		resp := jinaResponse{Results: []jinaResult{{Index: 0, RelevanceScore: 0.5}}}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	reranker := NewCrossEncoder(Config{
+		Endpoint:   server.URL,
+		Model:      "test-model",
+		APIKey:     "my-api-key",
+		HTTPClient: server.Client(),
+	})
+
+	candidates := []Candidate{{ID: "doc-a", Text: "test", OriginalScore: 1.0}}
+	_, err := reranker.Rerank(context.Background(), "query", candidates)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer my-api-key", capturedAuth)
+}
+
+func TestCrossEncoder_Rerank_AuthHeader_Token(t *testing.T) {
+	var capturedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		resp := jinaResponse{Results: []jinaResult{{Index: 0, RelevanceScore: 0.5}}}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	reranker := NewCrossEncoder(Config{
+		Endpoint:   server.URL,
+		Model:      "test-model",
+		Token:      "my-oauth-token",
+		HTTPClient: server.Client(),
+	})
+
+	candidates := []Candidate{{ID: "doc-a", Text: "test", OriginalScore: 1.0}}
+	_, err := reranker.Rerank(context.Background(), "query", candidates)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer my-oauth-token", capturedAuth)
+}
+
+func TestCrossEncoder_Rerank_APIKeyTakesPrecedence(t *testing.T) {
+	var capturedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		resp := jinaResponse{Results: []jinaResult{{Index: 0, RelevanceScore: 0.5}}}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	reranker := NewCrossEncoder(Config{
+		Endpoint:   server.URL,
+		Model:      "test-model",
+		APIKey:     "the-api-key",
+		Token:      "the-oauth-token",
+		HTTPClient: server.Client(),
+	})
+
+	candidates := []Candidate{{ID: "doc-a", Text: "test", OriginalScore: 1.0}}
+	_, err := reranker.Rerank(context.Background(), "query", candidates)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer the-api-key", capturedAuth)
+}
+
+func TestCrossEncoder_Rerank_OpenAIFormat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// OpenAI format uses the same request structure.
+		var req jinaRequest
+		json.NewDecoder(r.Body).Decode(&req)
+
+		// Return in OpenAI-compatible format (same structure).
+		resp := openAIRerankResponse{
+			Results: []openAIRerankResult{
+				{Index: 0, RelevanceScore: 0.3},
+				{Index: 1, RelevanceScore: 0.8},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	reranker := NewCrossEncoder(Config{
+		Endpoint:   server.URL,
+		Model:      "test-model",
+		Format:     FormatOpenAI,
+		HTTPClient: server.Client(),
+	})
+
+	candidates := []Candidate{
+		{ID: "doc-a", Text: "first", OriginalScore: 10.0},
+		{ID: "doc-b", Text: "second", OriginalScore: 5.0},
+	}
+
+	results, err := reranker.Rerank(context.Background(), "query", candidates)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	assert.Equal(t, "doc-b", results[0].ID)
+	assert.Equal(t, 0.8, results[0].Score)
+	assert.Equal(t, 1, results[0].Rank)
+
+	assert.Equal(t, "doc-a", results[1].ID)
+	assert.Equal(t, 0.3, results[1].Score)
+	assert.Equal(t, 2, results[1].Rank)
+}
+
+func TestCrossEncoder_Rerank_RequestBodyFormat(t *testing.T) {
+	var capturedReq jinaRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&capturedReq)
+		resp := jinaResponse{Results: []jinaResult{{Index: 0, RelevanceScore: 0.5}}}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	reranker := NewCrossEncoder(Config{
+		Endpoint:   server.URL,
+		Model:      "jina-reranker-v2",
+		TopN:       1,
+		HTTPClient: server.Client(),
+	})
+
+	candidates := []Candidate{
+		{ID: "doc-a", Text: "Hello world", OriginalScore: 1.0},
+	}
+
+	_, err := reranker.Rerank(context.Background(), "hello", candidates)
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello", capturedReq.Query)
+	assert.Equal(t, []string{"Hello world"}, capturedReq.Documents)
+	assert.Equal(t, "jina-reranker-v2", capturedReq.Model)
+	assert.Equal(t, 1, capturedReq.TopN)
+}
+
+// TestCrossEncoder_Rerank_InterfaceCompliance verifies CrossEncoderReranker
+// satisfies the Reranker interface at compile time.
+var _ Reranker = (*CrossEncoderReranker)(nil)

--- a/rerank/reranker.go
+++ b/rerank/reranker.go
@@ -1,0 +1,59 @@
+// Package rerank provides interfaces and implementations for reranking search
+// candidates using cross-encoder models. Reranking is applied after initial
+// search scoring to refine result ordering using more expensive but more
+// accurate models.
+package rerank
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Candidate represents a single search result candidate to be reranked.
+type Candidate struct {
+	ID            string
+	Text          string
+	OriginalScore float64
+}
+
+// RankedResult holds a reranked candidate with its cross-encoder score and
+// final rank position (1-based).
+type RankedResult struct {
+	Candidate
+	Score float64
+	Rank  int
+}
+
+// Reranker reorders candidates by scoring each (query, document) pair using
+// an external model. Implementations must be safe for concurrent use.
+type Reranker interface {
+	Rerank(ctx context.Context, query string, candidates []Candidate) ([]RankedResult, error)
+}
+
+// Typed errors returned by reranker implementations.
+var (
+	// ErrAuth is returned when the reranker API rejects authentication (401/403).
+	ErrAuth = errors.New("rerank: authentication failed")
+
+	// ErrServer is returned when the reranker API returns a server error (5xx).
+	ErrServer = errors.New("rerank: server error")
+
+	// ErrContext is returned when the context is canceled or deadline exceeded.
+	ErrContext = errors.New("rerank: context error")
+)
+
+// APIError wraps a reranker API error with the HTTP status code.
+type APIError struct {
+	StatusCode int
+	Message    string
+	Err        error
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("rerank: HTTP %d: %s", e.StatusCode, e.Message)
+}
+
+func (e *APIError) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION
Closes #20

## Summary
- Created `rerank/` package with `Reranker` interface, `Candidate` and `RankedResult` structs
- Implemented `CrossEncoderReranker` that calls configurable HTTP reranker endpoints
- Supports both Jina (`/v1/rerank`) and OpenAI-compatible API formats
- Auth via `APIKey` or `Token` (Bearer header), APIKey takes precedence
- `TopN` config limits returned results; defaults to all candidates when zero
- Typed errors: `ErrAuth` (401/403), `ErrServer` (5xx), `ErrContext` (canceled/timeout)

## Self-Check Results

| Acceptance Criterion | Status |
|---|---|
| `Reranker` interface with correct signature | PASS |
| `Candidate` struct (ID, Text, OriginalScore) | PASS |
| `RankedResult` struct (Candidate, Score, Rank) | PASS |
| `CrossEncoderReranker` with configurable HTTP endpoint | PASS |
| Jina API format support | PASS |
| OpenAI-compatible format support | PASS |
| Mock server reranking test | PASS |
| Empty candidates returns empty slice | PASS |
| TopN parameter limits results | PASS |
| Context canceled / 401 / 500 typed errors | PASS |
| Config supports APIKey and Token | PASS |
| All tests pass with `-race` flag | PASS |

### Test Output
```
ok  github.com/KHAEntertainment/markedup/rerank  1.174s (11 tests, -race)
ok  github.com/KHAEntertainment/markedup         3.138s (no regression)
```

## Test plan
- [x] `go test -race ./rerank/` — 11 tests pass
- [x] `go test -race ./...` — full suite passes, no regressions
- [x] `go build ./...` — compiles cleanly
- [x] `go vet ./...` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added a new reranking system that scores and reorders search candidates using external HTTP reranker endpoints
* Support for multiple reranker formats including Jina and OpenAI-compatible services
* Configurable endpoint authentication using API key or bearer token
* Customizable result limits and automatic handling of ranking by relevance score
* Built-in error handling for authentication, server, and network failures with context cancellation support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->