### PR TITLE
[Issue #21] Cache provider — graph tier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .dolt/
 *.db
 .beads-credential-key
+
+# Knowledge cache (graph + vector tiers)
+.knowledge/

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,285 @@
+// Package cache provides the graph tier of the two-tier .knowledge/ cache
+// system. It serializes/deserializes the KnowledgeIndex to gob format and
+// uses SHA-256 content hashes for file-level invalidation.
+package cache
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/gob"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/KHAEntertainment/markedup/index"
+	"github.com/KHAEntertainment/markedup/schema"
+)
+
+func init() {
+	// Register types that appear inside interface{} or map values for gob.
+	gob.Register(&schema.Page{})
+	gob.Register(schema.GraphFrontmatter{})
+	gob.Register(schema.Entity{})
+	gob.Register(schema.Relationship{})
+	gob.Register(schema.TemporalInfo{})
+	gob.Register(schema.Provenance{})
+}
+
+// ErrNoCacheFound is returned when the .knowledge/ cache directory or its
+// required files do not exist. Callers should fall back to a full load.
+var ErrNoCacheFound = errors.New("cache: no cache found")
+
+const (
+	graphDir      = "graph"
+	indexFile     = "index.gob"
+	checksumsFile = "checksums"
+)
+
+// GraphCache provides save/load/stale-check for the graph tier cache.
+type GraphCache struct{}
+
+// graphPath returns the path to .knowledge/graph/ under the given dir.
+func graphPath(dir string) string {
+	return filepath.Join(dir, ".knowledge", graphDir)
+}
+
+// Save serializes the KnowledgeIndex to .knowledge/graph/index.gob under
+// dir and writes per-file SHA-256 checksums to .knowledge/graph/checksums.
+// The .knowledge/ directory is auto-created if it does not exist.
+func (gc *GraphCache) Save(idx *index.KnowledgeIndex, dir string) error {
+	if idx == nil {
+		return fmt.Errorf("cache: cannot save nil index")
+	}
+
+	gp := graphPath(dir)
+	if err := os.MkdirAll(gp, 0o755); err != nil {
+		return fmt.Errorf("cache: create dir %s: %w", gp, err)
+	}
+
+	// Ensure .knowledge is in .gitignore.
+	ensureGitignore(dir)
+
+	// Serialize index to gob.
+	data := idx.Export()
+	gobPath := filepath.Join(gp, indexFile)
+	f, err := os.Create(gobPath)
+	if err != nil {
+		return fmt.Errorf("cache: create %s: %w", gobPath, err)
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	if err := gob.NewEncoder(w).Encode(data); err != nil {
+		return fmt.Errorf("cache: encode index: %w", err)
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("cache: flush %s: %w", gobPath, err)
+	}
+
+	// Compute and write checksums for all source files.
+	checksums, err := computeChecksums(idx)
+	if err != nil {
+		return err
+	}
+	csPath := filepath.Join(gp, checksumsFile)
+	if err := writeChecksums(csPath, checksums); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Load deserializes the KnowledgeIndex from .knowledge/graph/index.gob
+// under dir. Returns ErrNoCacheFound if the cache directory or index file
+// does not exist.
+func (gc *GraphCache) Load(dir string) (*index.KnowledgeIndex, error) {
+	gp := graphPath(dir)
+	gobPath := filepath.Join(gp, indexFile)
+
+	f, err := os.Open(gobPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNoCacheFound
+		}
+		return nil, fmt.Errorf("cache: open %s: %w", gobPath, err)
+	}
+	defer f.Close()
+
+	var data index.IndexData
+	if err := gob.NewDecoder(bufio.NewReader(f)).Decode(&data); err != nil {
+		return nil, fmt.Errorf("cache: decode index: %w", err)
+	}
+
+	return index.Import(&data), nil
+}
+
+// Stale compares current file SHA-256 hashes against the cached checksums
+// and returns which files have changed, been added, or been removed.
+// Returns ErrNoCacheFound if the checksums file does not exist.
+func (gc *GraphCache) Stale(dir string, files []string) (changed, added, removed []string, err error) {
+	gp := graphPath(dir)
+	csPath := filepath.Join(gp, checksumsFile)
+
+	cached, err := readChecksums(csPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil, ErrNoCacheFound
+		}
+		return nil, nil, nil, fmt.Errorf("cache: read checksums: %w", err)
+	}
+
+	// Build current checksums for the provided files.
+	current := make(map[string]string, len(files))
+	for _, path := range files {
+		h, hashErr := hashFile(path)
+		if hashErr != nil {
+			return nil, nil, nil, fmt.Errorf("cache: hash %s: %w", path, hashErr)
+		}
+		current[path] = h
+	}
+
+	// Detect changed and added.
+	for path, curHash := range current {
+		cachedHash, exists := cached[path]
+		if !exists {
+			added = append(added, path)
+		} else if cachedHash != curHash {
+			changed = append(changed, path)
+		}
+	}
+
+	// Detect removed.
+	for path := range cached {
+		if _, exists := current[path]; !exists {
+			removed = append(removed, path)
+		}
+	}
+
+	// Sort for deterministic output.
+	sort.Strings(changed)
+	sort.Strings(added)
+	sort.Strings(removed)
+
+	return changed, added, removed, nil
+}
+
+// hashFile returns the hex-encoded SHA-256 hash of a file's contents.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// computeChecksums generates SHA-256 hashes for all source files in the index.
+func computeChecksums(idx *index.KnowledgeIndex) (map[string]string, error) {
+	pages := idx.All()
+	checksums := make(map[string]string, len(pages))
+	for _, p := range pages {
+		if p.SourcePath == "" {
+			continue
+		}
+		h, err := hashFile(p.SourcePath)
+		if err != nil {
+			return nil, fmt.Errorf("cache: hash %s: %w", p.SourcePath, err)
+		}
+		checksums[p.SourcePath] = h
+	}
+	return checksums, nil
+}
+
+// writeChecksums writes a path→hash mapping as "hash  path\n" lines.
+func writeChecksums(path string, checksums map[string]string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("cache: create %s: %w", path, err)
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	// Write sorted for deterministic output.
+	paths := make([]string, 0, len(checksums))
+	for p := range checksums {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	for _, p := range paths {
+		if _, err := fmt.Fprintf(w, "%s  %s\n", checksums[p], p); err != nil {
+			return fmt.Errorf("cache: write checksum: %w", err)
+		}
+	}
+	return w.Flush()
+}
+
+// readChecksums parses a checksums file into a path→hash map.
+func readChecksums(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	checksums := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		// Format: "hash  path" (two spaces, matching sha256sum format).
+		parts := strings.SplitN(line, "  ", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("cache: malformed checksum line: %q", line)
+		}
+		checksums[parts[1]] = parts[0]
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return checksums, nil
+}
+
+// ensureGitignore adds .knowledge/ to .gitignore in dir if not already present.
+func ensureGitignore(dir string) {
+	giPath := filepath.Join(dir, ".gitignore")
+	entry := ".knowledge/"
+
+	// Check if already present.
+	if data, err := os.ReadFile(giPath); err == nil {
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			if strings.TrimSpace(line) == entry {
+				return
+			}
+		}
+	}
+
+	// Append to .gitignore.
+	f, err := os.OpenFile(giPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return // best effort
+	}
+	defer f.Close()
+
+	// Add a newline before if file is non-empty and doesn't end with newline.
+	if info, err := f.Stat(); err == nil && info.Size() > 0 {
+		// Read last byte to check for trailing newline.
+		if data, err := os.ReadFile(giPath); err == nil && len(data) > 0 && data[len(data)-1] != '\n' {
+			fmt.Fprintln(f)
+		}
+	}
+	fmt.Fprintln(f, entry)
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,352 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KHAEntertainment/markedup/index"
+	"github.com/KHAEntertainment/markedup/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestPages creates test pages backed by real files in dir.
+func makeTestPages(t *testing.T, dir string) []*schema.Page {
+	t.Helper()
+	files := map[string]string{
+		"page-a.md": "---\nid: page-a\ntitle: Page A\n---\nBody A",
+		"page-b.md": "---\nid: page-b\ntitle: Page B\n---\nBody B",
+	}
+	var pages []*schema.Page
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+		pages = append(pages, &schema.Page{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         name[:len(name)-3],
+				Title:      "Page " + string(name[5]),
+				EntityType: "concept",
+				Confidence: 0.9,
+				Tags:       []string{"test"},
+				Entities: []schema.Entity{
+					{Name: "Test Entity", Role: "subject"},
+				},
+				Relationships: nil,
+			},
+			Body:       "Body " + string(name[5]),
+			SourcePath: path,
+		})
+	}
+	return pages
+}
+
+func buildTestIndex(pages []*schema.Page) *index.KnowledgeIndex {
+	data := &index.IndexData{Pages: pages}
+	return index.Import(data)
+}
+
+func TestSaveAndLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	pages := makeTestPages(t, dir)
+	idx := buildTestIndex(pages)
+
+	gc := &GraphCache{}
+
+	// Save.
+	err := gc.Save(idx, dir)
+	require.NoError(t, err)
+
+	// Verify files exist.
+	assert.FileExists(t, filepath.Join(dir, ".knowledge", "graph", "index.gob"))
+	assert.FileExists(t, filepath.Join(dir, ".knowledge", "graph", "checksums"))
+
+	// Load.
+	loaded, err := gc.Load(dir)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	// Deep equal: same number of pages.
+	assert.Equal(t, idx.Pages(), loaded.Pages())
+
+	// Check all pages match.
+	for _, p := range idx.All() {
+		lp, ok := loaded.Get(p.Frontmatter.ID)
+		require.True(t, ok, "page %s not found in loaded index", p.Frontmatter.ID)
+		assert.Equal(t, p.Frontmatter, lp.Frontmatter)
+		assert.Equal(t, p.Body, lp.Body)
+		assert.Equal(t, p.SourcePath, lp.SourcePath)
+	}
+
+	// Tags should match.
+	assert.Equal(t, idx.Tags(), loaded.Tags())
+}
+
+func TestSaveNilIndex(t *testing.T) {
+	gc := &GraphCache{}
+	err := gc.Save(nil, t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil index")
+}
+
+func TestLoadNoCacheFound(t *testing.T) {
+	gc := &GraphCache{}
+	_, err := gc.Load(t.TempDir())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoCacheFound)
+}
+
+func TestStaleNoChanges(t *testing.T) {
+	dir := t.TempDir()
+	pages := makeTestPages(t, dir)
+	idx := buildTestIndex(pages)
+
+	gc := &GraphCache{}
+	require.NoError(t, gc.Save(idx, dir))
+
+	// All files unchanged.
+	var files []string
+	for _, p := range pages {
+		files = append(files, p.SourcePath)
+	}
+
+	changed, added, removed, err := gc.Stale(dir, files)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+	assert.Empty(t, added)
+	assert.Empty(t, removed)
+}
+
+func TestStaleDetectsChanged(t *testing.T) {
+	dir := t.TempDir()
+	pages := makeTestPages(t, dir)
+	idx := buildTestIndex(pages)
+
+	gc := &GraphCache{}
+	require.NoError(t, gc.Save(idx, dir))
+
+	// Modify one file.
+	modPath := pages[0].SourcePath
+	require.NoError(t, os.WriteFile(modPath, []byte("modified content"), 0o644))
+
+	var files []string
+	for _, p := range pages {
+		files = append(files, p.SourcePath)
+	}
+
+	changed, added, removed, err := gc.Stale(dir, files)
+	require.NoError(t, err)
+	assert.Len(t, changed, 1)
+	assert.Contains(t, changed, modPath)
+	assert.Empty(t, added)
+	assert.Empty(t, removed)
+}
+
+func TestStaleDetectsAdded(t *testing.T) {
+	dir := t.TempDir()
+	pages := makeTestPages(t, dir)
+	idx := buildTestIndex(pages)
+
+	gc := &GraphCache{}
+	require.NoError(t, gc.Save(idx, dir))
+
+	// Add a new file.
+	newPath := filepath.Join(dir, "page-c.md")
+	require.NoError(t, os.WriteFile(newPath, []byte("new page"), 0o644))
+
+	files := []string{newPath}
+	for _, p := range pages {
+		files = append(files, p.SourcePath)
+	}
+
+	changed, added, removed, err := gc.Stale(dir, files)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+	assert.Len(t, added, 1)
+	assert.Contains(t, added, newPath)
+	assert.Empty(t, removed)
+}
+
+func TestStaleDetectsRemoved(t *testing.T) {
+	dir := t.TempDir()
+	pages := makeTestPages(t, dir)
+	idx := buildTestIndex(pages)
+
+	gc := &GraphCache{}
+	require.NoError(t, gc.Save(idx, dir))
+
+	// Only provide one of the original files (simulate one removed).
+	files := []string{pages[0].SourcePath}
+
+	changed, added, removed, err := gc.Stale(dir, files)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+	assert.Empty(t, added)
+	assert.Len(t, removed, 1)
+	assert.Contains(t, removed, pages[1].SourcePath)
+}
+
+func TestStaleNoCacheFound(t *testing.T) {
+	gc := &GraphCache{}
+	_, _, _, err := gc.Stale(t.TempDir(), []string{"/nonexistent"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoCacheFound)
+}
+
+func TestEnsureGitignore(t *testing.T) {
+	dir := t.TempDir()
+	giPath := filepath.Join(dir, ".gitignore")
+
+	// First call creates .gitignore with entry.
+	ensureGitignore(dir)
+	data, err := os.ReadFile(giPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), ".knowledge/")
+
+	// Second call is idempotent.
+	ensureGitignore(dir)
+	data2, err := os.ReadFile(giPath)
+	require.NoError(t, err)
+	// Should not duplicate.
+	count := 0
+	for _, line := range filepath.SplitList(string(data2)) {
+		_ = line
+	}
+	// Simple count of occurrences.
+	content := string(data2)
+	for i := 0; i < len(content); {
+		idx := len(content)
+		for j := i; j < len(content)-len(".knowledge/"); j++ {
+			if content[j:j+len(".knowledge/")] == ".knowledge/" {
+				idx = j
+				break
+			}
+		}
+		if idx == len(content) {
+			break
+		}
+		count++
+		i = idx + len(".knowledge/")
+	}
+	assert.Equal(t, 1, count, ".knowledge/ should appear exactly once in .gitignore")
+}
+
+func TestEnsureGitignoreExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	giPath := filepath.Join(dir, ".gitignore")
+
+	// Create .gitignore with existing content (no trailing newline).
+	require.NoError(t, os.WriteFile(giPath, []byte("node_modules/"), 0o644))
+
+	ensureGitignore(dir)
+	data, err := os.ReadFile(giPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), ".knowledge/")
+	assert.Contains(t, string(data), "node_modules/")
+}
+
+func TestRoundTripWithRelationships(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create real files.
+	pathA := filepath.Join(dir, "a.md")
+	pathB := filepath.Join(dir, "b.md")
+	require.NoError(t, os.WriteFile(pathA, []byte("content a"), 0o644))
+	require.NoError(t, os.WriteFile(pathB, []byte("content b"), 0o644))
+
+	pages := []*schema.Page{
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "a",
+				Title:      "A",
+				EntityType: "concept",
+				Confidence: 0.9,
+				Tags:       []string{"go", "test"},
+				Entities: []schema.Entity{
+					{Name: "Go", Aliases: []string{"golang"}, Role: "subject"},
+				},
+				Relationships: []schema.Relationship{
+					{Target: "b", Type: "related-to", Strength: 0.8},
+				},
+				Temporal: schema.TemporalInfo{
+					ValidFrom:    "2024-01-01",
+					ValidUntil:   "2025-01-01",
+					LastVerified: "2024-06-15",
+					DecayRate:    0.1,
+				},
+				Provenance: schema.Provenance{
+					Sources:   []string{"https://example.com"},
+					CreatedBy: "test",
+				},
+				SemanticHints:     []string{"programming language"},
+				PossibleQuestions: []string{"What is Go?"},
+			},
+			Body:       "Body A",
+			SourcePath: pathA,
+		},
+		{
+			Frontmatter: schema.GraphFrontmatter{
+				ID:         "b",
+				Title:      "B",
+				EntityType: "tool",
+				Confidence: 0.7,
+				Tags:       []string{"test"},
+				Relationships: []schema.Relationship{
+					{Target: "a", Type: "depends-on", Strength: 0.6},
+				},
+			},
+			Body:       "Body B",
+			SourcePath: pathB,
+		},
+	}
+
+	idx := buildTestIndex(pages)
+	gc := &GraphCache{}
+
+	require.NoError(t, gc.Save(idx, dir))
+	loaded, err := gc.Load(dir)
+	require.NoError(t, err)
+
+	// Verify relationships are preserved.
+	assert.Equal(t, idx.Relationships(), loaded.Relationships())
+
+	// Verify forward rels.
+	fwdA := loaded.ForwardRels("a")
+	require.Len(t, fwdA, 1)
+	assert.Equal(t, "b", fwdA[0].Target)
+	assert.Equal(t, 0.8, fwdA[0].Strength)
+
+	// Verify reverse refs.
+	revA := loaded.ReverseRefs("a")
+	require.Len(t, revA, 1)
+	assert.Equal(t, "b", revA[0])
+
+	// Verify entities with aliases.
+	pa, ok := loaded.Get("a")
+	require.True(t, ok)
+	require.Len(t, pa.Frontmatter.Entities, 1)
+	assert.Equal(t, []string{"golang"}, pa.Frontmatter.Entities[0].Aliases)
+
+	// Verify temporal info.
+	assert.Equal(t, "2024-01-01", pa.Frontmatter.Temporal.ValidFrom)
+	assert.Equal(t, 0.1, pa.Frontmatter.Temporal.DecayRate)
+
+	// Verify provenance.
+	assert.Equal(t, []string{"https://example.com"}, pa.Frontmatter.Provenance.Sources)
+
+	// Verify semantic hints and possible questions.
+	assert.Equal(t, []string{"programming language"}, pa.Frontmatter.SemanticHints)
+	assert.Equal(t, []string{"What is Go?"}, pa.Frontmatter.PossibleQuestions)
+}
+
+func TestRoundTripEmptyIndex(t *testing.T) {
+	dir := t.TempDir()
+	idx := buildTestIndex(nil)
+
+	gc := &GraphCache{}
+	require.NoError(t, gc.Save(idx, dir))
+
+	loaded, err := gc.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 0, loaded.Pages())
+}

--- a/index/index.go
+++ b/index/index.go
@@ -87,6 +87,27 @@ func (idx *KnowledgeIndex) ReverseRefs(id string) []string {
 	return idx.reverseAdj[id]
 }
 
+// IndexData is the exported, gob-serializable representation of a
+// KnowledgeIndex. It is used by the cache package to persist and restore
+// the index without re-parsing all markdown files.
+type IndexData struct {
+	Pages []*schema.Page
+}
+
+// Export converts a KnowledgeIndex into an IndexData suitable for gob
+// encoding. The full page list is extracted in sorted-ID order.
+func (idx *KnowledgeIndex) Export() *IndexData {
+	return &IndexData{
+		Pages: idx.All(),
+	}
+}
+
+// Import reconstructs a KnowledgeIndex from an IndexData. This is the
+// inverse of Export and is used by the cache package after gob decoding.
+func Import(data *IndexData) *KnowledgeIndex {
+	return buildIndex(data.Pages)
+}
+
 // buildIndex constructs a KnowledgeIndex from a slice of parsed pages.
 // This is called single-threaded after all concurrent parsing is complete.
 func buildIndex(pages []*schema.Page) *KnowledgeIndex {

--- a/index/load.go
+++ b/index/load.go
@@ -21,6 +21,15 @@ type CacheProvider interface {
 	Set(path string, modTime time.Time, page *schema.Page)
 }
 
+// GraphCacheProvider is the interface for the graph tier cache. It provides
+// save/load/stale-check for the entire KnowledgeIndex. Implemented by
+// cache.GraphCache.
+type GraphCacheProvider interface {
+	Save(idx *KnowledgeIndex, dir string) error
+	Load(dir string) (*KnowledgeIndex, error)
+	Stale(dir string, files []string) (changed, added, removed []string, err error)
+}
+
 // LoadWarning represents a non-fatal issue encountered during loading.
 type LoadWarning struct {
 	Path    string
@@ -41,6 +50,8 @@ type loadConfig struct {
 	filePattern  string
 	ignoreErrors bool
 	cache        CacheProvider
+	cacheDir     string
+	graphCache   GraphCacheProvider
 }
 
 // LoadOption configures the behaviour of Load.
@@ -81,6 +92,18 @@ func WithCache(cp CacheProvider) LoadOption {
 	}
 }
 
+// WithCacheDir sets the project root directory and graph cache provider for
+// the graph tier cache. When set, Load will attempt to load a cached
+// KnowledgeIndex from .knowledge/graph/ and only re-parse files whose
+// SHA-256 checksums have changed. After building the index, it is saved
+// back to the cache. An empty dir disables caching.
+func WithCacheDir(dir string, gc GraphCacheProvider) LoadOption {
+	return func(c *loadConfig) {
+		c.cacheDir = dir
+		c.graphCache = gc
+	}
+}
+
 // Load walks root to discover markdown files, parses them concurrently
 // using bounded workers, validates each page, and builds a KnowledgeIndex.
 //
@@ -97,13 +120,16 @@ func Load(ctx context.Context, root string, opts ...LoadOption) (*LoadResult, er
 		o(&cfg)
 	}
 
-	// 1. Collect file paths.
+	// 1. Collect file paths, skipping .knowledge/ cache directory.
 	var paths []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
+			if d.Name() == ".knowledge" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		matched, matchErr := filepath.Match(cfg.filePattern, d.Name())
@@ -119,7 +145,27 @@ func Load(ctx context.Context, root string, opts ...LoadOption) (*LoadResult, er
 		return nil, fmt.Errorf("index: walk %s: %w", root, err)
 	}
 
-	// 2. Parse concurrently.
+	// 2. If graph cache is configured, try to use it.
+	if cfg.cacheDir != "" && cfg.graphCache != nil {
+		cachedIdx, cacheErr := cfg.graphCache.Load(cfg.cacheDir)
+		if cacheErr == nil {
+			// Cache hit — check staleness.
+			changed, added, removed, staleErr := cfg.graphCache.Stale(cfg.cacheDir, paths)
+			if staleErr == nil && len(changed) == 0 && len(added) == 0 && len(removed) == 0 {
+				// Fully cached, no stale files.
+				return &LoadResult{Index: cachedIdx}, nil
+			}
+			// If staleness check succeeded but there are stale files,
+			// we still need a full re-parse to rebuild the index correctly.
+			// Future optimization: merge cached pages with re-parsed stale pages.
+			_ = changed
+			_ = added
+			_ = removed
+		}
+		// Cache miss or stale — fall through to full parse.
+	}
+
+	// 3. Parse concurrently.
 	type parseResult struct {
 		page *schema.Page
 		warn *LoadWarning
@@ -190,7 +236,7 @@ func Load(ctx context.Context, root string, opts ...LoadOption) (*LoadResult, er
 		return nil, firstErr
 	}
 
-	// 3. Collect valid pages and warnings.
+	// 4. Collect valid pages and warnings.
 	var pages []*schema.Page
 	var warnings []LoadWarning
 
@@ -203,10 +249,10 @@ func Load(ctx context.Context, root string, opts ...LoadOption) (*LoadResult, er
 		}
 	}
 
-	// 4. Build index single-threaded.
+	// 5. Build index single-threaded.
 	idx := buildIndex(pages)
 
-	// 5. Check for dangling relationships.
+	// 6. Check for dangling relationships.
 	for _, p := range pages {
 		for _, rel := range p.Frontmatter.Relationships {
 			if _, ok := idx.byID[rel.Target]; !ok {
@@ -216,6 +262,12 @@ func Load(ctx context.Context, root string, opts ...LoadOption) (*LoadResult, er
 				})
 			}
 		}
+	}
+
+	// 7. Save to graph cache if configured.
+	if cfg.cacheDir != "" && cfg.graphCache != nil {
+		// Best-effort save; don't fail the load if cache save fails.
+		_ = cfg.graphCache.Save(idx, cfg.cacheDir)
 	}
 
 	return &LoadResult{


### PR DESCRIPTION
Closes #21

## Summary
- Added `cache/` package with `GraphCache` struct providing `Save`, `Load`, and `Stale` methods
- `Save` serializes `KnowledgeIndex` to `.knowledge/graph/index.gob` using gob encoding and writes per-file SHA-256 content hashes to `.knowledge/graph/checksums`
- `Load` deserializes the index from gob, returning `ErrNoCacheFound` when cache is absent
- `Stale` compares current file hashes against cached checksums, returning changed/added/removed file lists
- Added `IndexData` export type and `Export()`/`Import()` methods on `KnowledgeIndex` for gob serialization of unexported fields
- Added `WithCacheDir(dir, gc)` option to `index.Load()` — loads cached index on cache hit with 0 stale files, saves cache after full parse
- `.knowledge/` is auto-created on first save and auto-added to `.gitignore`
- Walk now skips `.knowledge/` directories

## Self-Check Results

| AC | Status |
|----|--------|
| `cache/` package with `GraphCache` struct | ✅ |
| `Save(idx, dir)` serializes to `.knowledge/graph/index.gob` | ✅ |
| `Load(dir)` deserializes from `.knowledge/graph/index.gob` | ✅ |
| `.knowledge/graph/checksums` stores SHA-256 hashes | ✅ |
| `Stale(dir, files)` returns changed/added/removed | ✅ |
| Missing `.knowledge/` → `ErrNoCacheFound` | ✅ |
| 0 stale files → returns full index, no extra I/O | ✅ |
| N stale files → returns stale list (caller re-parses) | ✅ |
| `WithCacheDir` integrates into `index.Load()` | ✅ |
| `.knowledge/` auto-created + `.gitignore` entry | ✅ |
| Gob round-trip deep equal | ✅ |
| All tests pass with `-race`, no lint errors | ✅ |

```
$ go test ./... -race
ok   github.com/KHAEntertainment/markedup
ok   github.com/KHAEntertainment/markedup/cache
ok   github.com/KHAEntertainment/markedup/index
ok   github.com/KHAEntertainment/markedup/markdown
ok   github.com/KHAEntertainment/markedup/schema
ok   github.com/KHAEntertainment/markedup/temporal

$ go vet ./...
(no issues)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic local caching of knowledge index to accelerate subsequent application loads.
  * Cache is transparently maintained, automatically validated for changes, and excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->