### PR TITLE
[Issue #22] Cache provider — vector tier

### DIFF
--- a/cache/vector_cache.go
+++ b/cache/vector_cache.go
@@ -1,0 +1,288 @@
+// Package cache provides the vector tier of the two-tier .knowledge/ cache
+// system. It stores and retrieves embedding vectors per file using efficient
+// binary encoding, with model-aware invalidation.
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// EmbedderInfo provides the model metadata needed by VectorCache for
+// model-change detection. This mirrors the relevant subset of the
+// embed.Embedder interface (Issue #19) so that this package compiles
+// standalone before that package is merged.
+type EmbedderInfo interface {
+	// Model returns the model identifier used for embedding.
+	Model() string
+
+	// Dimensions returns the dimensionality of the embedding vectors.
+	Dimensions() int
+}
+
+// KnowledgeIndexInfo provides the minimal interface to query which files
+// exist in the knowledge index. This avoids importing the index package
+// directly, allowing standalone compilation before PR #28 merges.
+type KnowledgeIndexInfo interface {
+	// AllFileIDs returns all file IDs in the index.
+	AllFileIDs() []string
+
+	// ContentHash returns the content hash for a file ID, or "" if unknown.
+	ContentHash(fileID string) string
+}
+
+// VectorMeta stores metadata about the cached vectors in meta.json.
+type VectorMeta struct {
+	Model      string `json:"model"`
+	Dimensions int    `json:"dimensions"`
+	Version    int    `json:"version"`
+	CreatedAt  string `json:"created_at"`
+}
+
+// VectorCache manages the storage and retrieval of embedding vectors in
+// the .knowledge/vectors/ directory. It uses binary encoding for float32
+// slices and tracks model metadata for invalidation.
+type VectorCache struct {
+	dir string // project root directory
+}
+
+// NewVectorCache creates a VectorCache rooted at the given project directory.
+// The .knowledge/vectors/ subdirectory is created lazily on first write.
+func NewVectorCache(dir string) *VectorCache {
+	return &VectorCache{dir: dir}
+}
+
+const (
+	vectorsDir = "vectors"
+	metaFile   = "meta.json"
+	metaVersion = 1
+)
+
+// vectorsPath returns the path to .knowledge/vectors/ under the project root.
+func (vc *VectorCache) vectorsPath() string {
+	return filepath.Join(vc.dir, ".knowledge", vectorsDir)
+}
+
+// metaPath returns the path to .knowledge/meta.json.
+func (vc *VectorCache) metaPath() string {
+	return filepath.Join(vc.dir, ".knowledge", metaFile)
+}
+
+// vecFilePath returns the path to the vector file for a given fileID and
+// contentHash. The filename is the SHA-256 of "fileID:contentHash" to
+// produce a deterministic, filesystem-safe name.
+func (vc *VectorCache) vecFilePath(fileID, contentHash string) string {
+	h := sha256.Sum256([]byte(fileID + ":" + contentHash))
+	name := hex.EncodeToString(h[:]) + ".vec"
+	return filepath.Join(vc.vectorsPath(), name)
+}
+
+// SaveVectors writes embedding vectors for a file to the cache using
+// efficient binary encoding (4-byte little-endian float32, no headers).
+// The vectors directory is created if it does not exist.
+func (vc *VectorCache) SaveVectors(fileID string, contentHash string, vectors []float32) error {
+	if fileID == "" {
+		return fmt.Errorf("cache: fileID must not be empty")
+	}
+	if contentHash == "" {
+		return fmt.Errorf("cache: contentHash must not be empty")
+	}
+
+	vp := vc.vectorsPath()
+	if err := os.MkdirAll(vp, 0o755); err != nil {
+		return fmt.Errorf("cache: create vectors dir: %w", err)
+	}
+
+	path := vc.vecFilePath(fileID, contentHash)
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("cache: create vector file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	if err := binary.Write(f, binary.LittleEndian, vectors); err != nil {
+		return fmt.Errorf("cache: write vectors: %w", err)
+	}
+
+	return nil
+}
+
+// LoadVectors reads embedding vectors for a file from the cache. Returns
+// an error if the cached vectors do not exist or cannot be read. The
+// number of float32 values is inferred from the file size.
+func (vc *VectorCache) LoadVectors(fileID string, contentHash string) ([]float32, error) {
+	if fileID == "" {
+		return nil, fmt.Errorf("cache: fileID must not be empty")
+	}
+	if contentHash == "" {
+		return nil, fmt.Errorf("cache: contentHash must not be empty")
+	}
+
+	path := vc.vecFilePath(fileID, contentHash)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("cache: no cached vectors for %s: %w", fileID, err)
+		}
+		return nil, fmt.Errorf("cache: read vector file %s: %w", path, err)
+	}
+
+	if len(data)%4 != 0 {
+		return nil, fmt.Errorf("cache: corrupt vector file %s: size %d not divisible by 4", path, len(data))
+	}
+
+	n := len(data) / 4
+	vectors := make([]float32, n)
+	for i := 0; i < n; i++ {
+		vectors[i] = float32FromBytes(data[i*4 : (i+1)*4])
+	}
+
+	return vectors, nil
+}
+
+// HasVectors checks if cached vectors exist for the given fileID and
+// contentHash. Returns false if the vector file does not exist (indicating
+// the file needs (re-)embedding due to content change or missing cache).
+func (vc *VectorCache) HasVectors(fileID string, contentHash string) bool {
+	if fileID == "" || contentHash == "" {
+		return false
+	}
+	path := vc.vecFilePath(fileID, contentHash)
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Size() > 0
+}
+
+// EnsureMeta checks or initializes the meta.json file. If meta.json exists
+// and the model or dimensions differ from the provided embedder config,
+// all cached vectors are invalidated (the vectors directory is cleared)
+// and a new meta.json is written. If meta.json does not exist, it is created.
+// Returns true if vectors were invalidated.
+func (vc *VectorCache) EnsureMeta(info EmbedderInfo) (invalidated bool, err error) {
+	if info == nil {
+		return false, fmt.Errorf("cache: embedder info must not be nil")
+	}
+
+	existing, loadErr := vc.loadMeta()
+	if loadErr == nil {
+		// Meta exists — check for model change.
+		if existing.Model == info.Model() && existing.Dimensions == info.Dimensions() {
+			return false, nil // no change
+		}
+		// Model changed — invalidate all vectors.
+		if err := vc.clearVectors(); err != nil {
+			return false, fmt.Errorf("cache: clear vectors on model change: %w", err)
+		}
+		invalidated = true
+	} else if !errors.Is(loadErr, os.ErrNotExist) {
+		return false, fmt.Errorf("cache: load meta: %w", loadErr)
+	}
+
+	// Write new meta.json.
+	meta := VectorMeta{
+		Model:      info.Model(),
+		Dimensions: info.Dimensions(),
+		Version:    metaVersion,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := vc.saveMeta(meta); err != nil {
+		return invalidated, err
+	}
+
+	return invalidated, nil
+}
+
+// PendingEmbeddings returns file IDs from the index that need (re-)embedding.
+// A file needs embedding if its vectors are not cached for its current
+// content hash.
+func (vc *VectorCache) PendingEmbeddings(idx KnowledgeIndexInfo) []string {
+	if idx == nil {
+		return nil
+	}
+
+	fileIDs := idx.AllFileIDs()
+	var pending []string
+	for _, fid := range fileIDs {
+		hash := idx.ContentHash(fid)
+		if hash == "" {
+			// No content hash available — needs embedding.
+			pending = append(pending, fid)
+			continue
+		}
+		if !vc.HasVectors(fid, hash) {
+			pending = append(pending, fid)
+		}
+	}
+
+	sort.Strings(pending)
+	return pending
+}
+
+// loadMeta reads and parses .knowledge/meta.json.
+func (vc *VectorCache) loadMeta() (VectorMeta, error) {
+	var meta VectorMeta
+	data, err := os.ReadFile(vc.metaPath())
+	if err != nil {
+		return meta, err
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return meta, fmt.Errorf("cache: parse meta.json: %w", err)
+	}
+	return meta, nil
+}
+
+// saveMeta writes the VectorMeta to .knowledge/meta.json.
+func (vc *VectorCache) saveMeta(meta VectorMeta) error {
+	knowledgeDir := filepath.Join(vc.dir, ".knowledge")
+	if err := os.MkdirAll(knowledgeDir, 0o755); err != nil {
+		return fmt.Errorf("cache: create .knowledge dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cache: marshal meta.json: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile(vc.metaPath(), data, 0o644); err != nil {
+		return fmt.Errorf("cache: write meta.json: %w", err)
+	}
+	return nil
+}
+
+// clearVectors removes all .vec files from the vectors directory.
+func (vc *VectorCache) clearVectors() error {
+	vp := vc.vectorsPath()
+	entries, err := os.ReadDir(vp)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // nothing to clear
+		}
+		return err
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".vec" {
+			if err := os.Remove(filepath.Join(vp, e.Name())); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// float32FromBytes converts 4 little-endian bytes to a float32.
+func float32FromBytes(b []byte) float32 {
+	bits := binary.LittleEndian.Uint32(b)
+	return math.Float32frombits(bits)
+}

--- a/cache/vector_cache_test.go
+++ b/cache/vector_cache_test.go
@@ -1,0 +1,482 @@
+package cache
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubEmbedderInfo implements EmbedderInfo for testing.
+type stubEmbedderInfo struct {
+	model string
+	dims  int
+}
+
+func (s *stubEmbedderInfo) Model() string  { return s.model }
+func (s *stubEmbedderInfo) Dimensions() int { return s.dims }
+
+// stubIndexInfo implements KnowledgeIndexInfo for testing.
+type stubIndexInfo struct {
+	files  []string
+	hashes map[string]string
+}
+
+func (s *stubIndexInfo) AllFileIDs() []string { return s.files }
+func (s *stubIndexInfo) ContentHash(fileID string) string {
+	return s.hashes[fileID]
+}
+
+func TestSaveAndLoadVectorsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	vectors := []float32{1.0, 2.5, -3.14, 0.0, math.MaxFloat32, math.SmallestNonzeroFloat32}
+	err := vc.SaveVectors("file-a", "hash123", vectors)
+	require.NoError(t, err)
+
+	loaded, err := vc.LoadVectors("file-a", "hash123")
+	require.NoError(t, err)
+	assert.Equal(t, vectors, loaded)
+}
+
+func TestSaveVectors_EmptySlice(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	err := vc.SaveVectors("file-a", "hash123", []float32{})
+	require.NoError(t, err)
+
+	// HasVectors should return false for empty vector file (size 0).
+	assert.False(t, vc.HasVectors("file-a", "hash123"))
+}
+
+func TestSaveVectors_NilSlice(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	err := vc.SaveVectors("file-a", "hash123", nil)
+	require.NoError(t, err)
+
+	assert.False(t, vc.HasVectors("file-a", "hash123"))
+}
+
+func TestSaveVectors_EmptyFileID(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	err := vc.SaveVectors("", "hash123", []float32{1.0})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fileID must not be empty")
+}
+
+func TestSaveVectors_EmptyContentHash(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	err := vc.SaveVectors("file-a", "", []float32{1.0})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "contentHash must not be empty")
+}
+
+func TestLoadVectors_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	_, err := vc.LoadVectors("nonexistent", "hash123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no cached vectors")
+}
+
+func TestLoadVectors_EmptyFileID(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	_, err := vc.LoadVectors("", "hash123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fileID must not be empty")
+}
+
+func TestLoadVectors_EmptyContentHash(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	_, err := vc.LoadVectors("file-a", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "contentHash must not be empty")
+}
+
+func TestLoadVectors_CorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	// Save valid vectors first, then corrupt the file.
+	err := vc.SaveVectors("file-a", "hash123", []float32{1.0, 2.0})
+	require.NoError(t, err)
+
+	// Write 5 bytes (not divisible by 4) to the vector file.
+	path := vc.vecFilePath("file-a", "hash123")
+	require.NoError(t, os.WriteFile(path, []byte{1, 2, 3, 4, 5}, 0o644))
+
+	_, err = vc.LoadVectors("file-a", "hash123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "corrupt vector file")
+}
+
+func TestHasVectors(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	// No vectors yet.
+	assert.False(t, vc.HasVectors("file-a", "hash123"))
+
+	// Save vectors.
+	require.NoError(t, vc.SaveVectors("file-a", "hash123", []float32{1.0}))
+	assert.True(t, vc.HasVectors("file-a", "hash123"))
+
+	// Different content hash → false.
+	assert.False(t, vc.HasVectors("file-a", "hash456"))
+
+	// Empty fileID → false.
+	assert.False(t, vc.HasVectors("", "hash123"))
+
+	// Empty contentHash → false.
+	assert.False(t, vc.HasVectors("file-a", ""))
+}
+
+func TestHasVectors_ContentHashMismatch(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	require.NoError(t, vc.SaveVectors("file-a", "hash-v1", []float32{1.0, 2.0}))
+
+	// Old hash matches.
+	assert.True(t, vc.HasVectors("file-a", "hash-v1"))
+
+	// New hash (content changed) → stale, returns false.
+	assert.False(t, vc.HasVectors("file-a", "hash-v2"))
+}
+
+func TestEnsureMeta_CreateNew(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	info := &stubEmbedderInfo{model: "text-embedding-3-small", dims: 1536}
+	invalidated, err := vc.EnsureMeta(info)
+	require.NoError(t, err)
+	assert.False(t, invalidated)
+
+	// Verify meta.json was created.
+	meta, err := vc.loadMeta()
+	require.NoError(t, err)
+	assert.Equal(t, "text-embedding-3-small", meta.Model)
+	assert.Equal(t, 1536, meta.Dimensions)
+	assert.Equal(t, 1, meta.Version)
+	assert.NotEmpty(t, meta.CreatedAt)
+}
+
+func TestEnsureMeta_SameModel(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	info := &stubEmbedderInfo{model: "model-a", dims: 768}
+	_, err := vc.EnsureMeta(info)
+	require.NoError(t, err)
+
+	// Save some vectors.
+	require.NoError(t, vc.SaveVectors("file-a", "hash1", []float32{1.0}))
+
+	// Same model again — no invalidation.
+	invalidated, err := vc.EnsureMeta(info)
+	require.NoError(t, err)
+	assert.False(t, invalidated)
+
+	// Vectors still exist.
+	assert.True(t, vc.HasVectors("file-a", "hash1"))
+}
+
+func TestEnsureMeta_ModelChange(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	info1 := &stubEmbedderInfo{model: "model-a", dims: 768}
+	_, err := vc.EnsureMeta(info1)
+	require.NoError(t, err)
+
+	// Save some vectors.
+	require.NoError(t, vc.SaveVectors("file-a", "hash1", []float32{1.0, 2.0}))
+	assert.True(t, vc.HasVectors("file-a", "hash1"))
+
+	// Change model.
+	info2 := &stubEmbedderInfo{model: "model-b", dims: 1536}
+	invalidated, err := vc.EnsureMeta(info2)
+	require.NoError(t, err)
+	assert.True(t, invalidated)
+
+	// Vectors should be cleared.
+	assert.False(t, vc.HasVectors("file-a", "hash1"))
+
+	// Meta should reflect new model.
+	meta, err := vc.loadMeta()
+	require.NoError(t, err)
+	assert.Equal(t, "model-b", meta.Model)
+	assert.Equal(t, 1536, meta.Dimensions)
+}
+
+func TestEnsureMeta_DimensionsChange(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	info1 := &stubEmbedderInfo{model: "model-a", dims: 768}
+	_, err := vc.EnsureMeta(info1)
+	require.NoError(t, err)
+
+	require.NoError(t, vc.SaveVectors("file-a", "hash1", []float32{1.0}))
+
+	// Same model name, different dimensions.
+	info2 := &stubEmbedderInfo{model: "model-a", dims: 1536}
+	invalidated, err := vc.EnsureMeta(info2)
+	require.NoError(t, err)
+	assert.True(t, invalidated)
+	assert.False(t, vc.HasVectors("file-a", "hash1"))
+}
+
+func TestEnsureMeta_NilEmbedder(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	_, err := vc.EnsureMeta(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "embedder info must not be nil")
+}
+
+func TestPendingEmbeddings_AllPending(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	idx := &stubIndexInfo{
+		files:  []string{"file-a", "file-b", "file-c"},
+		hashes: map[string]string{"file-a": "h1", "file-b": "h2", "file-c": "h3"},
+	}
+
+	pending := vc.PendingEmbeddings(idx)
+	assert.Equal(t, []string{"file-a", "file-b", "file-c"}, pending)
+}
+
+func TestPendingEmbeddings_SomeCached(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	// Cache vectors for file-b.
+	require.NoError(t, vc.SaveVectors("file-b", "h2", []float32{1.0}))
+
+	idx := &stubIndexInfo{
+		files:  []string{"file-a", "file-b", "file-c"},
+		hashes: map[string]string{"file-a": "h1", "file-b": "h2", "file-c": "h3"},
+	}
+
+	pending := vc.PendingEmbeddings(idx)
+	assert.Equal(t, []string{"file-a", "file-c"}, pending)
+}
+
+func TestPendingEmbeddings_NoneNeeded(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	require.NoError(t, vc.SaveVectors("file-a", "h1", []float32{1.0}))
+	require.NoError(t, vc.SaveVectors("file-b", "h2", []float32{2.0}))
+
+	idx := &stubIndexInfo{
+		files:  []string{"file-a", "file-b"},
+		hashes: map[string]string{"file-a": "h1", "file-b": "h2"},
+	}
+
+	pending := vc.PendingEmbeddings(idx)
+	assert.Empty(t, pending)
+}
+
+func TestPendingEmbeddings_StaleContent(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	// Cache with old hash.
+	require.NoError(t, vc.SaveVectors("file-a", "old-hash", []float32{1.0}))
+
+	idx := &stubIndexInfo{
+		files:  []string{"file-a"},
+		hashes: map[string]string{"file-a": "new-hash"},
+	}
+
+	pending := vc.PendingEmbeddings(idx)
+	assert.Equal(t, []string{"file-a"}, pending)
+}
+
+func TestPendingEmbeddings_EmptyHash(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	idx := &stubIndexInfo{
+		files:  []string{"file-a"},
+		hashes: map[string]string{}, // no hash for file-a
+	}
+
+	pending := vc.PendingEmbeddings(idx)
+	assert.Equal(t, []string{"file-a"}, pending)
+}
+
+func TestPendingEmbeddings_NilIndex(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	pending := vc.PendingEmbeddings(nil)
+	assert.Nil(t, pending)
+}
+
+func TestBinaryEncoding_Correctness(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	vectors := []float32{1.0, -1.0, 0.0, 3.14159, math.MaxFloat32}
+	require.NoError(t, vc.SaveVectors("test", "hash", vectors))
+
+	// Read the raw file and verify binary format.
+	path := vc.vecFilePath("test", "hash")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	// Each float32 is 4 bytes, little-endian.
+	assert.Len(t, data, len(vectors)*4)
+
+	for i, expected := range vectors {
+		bits := binary.LittleEndian.Uint32(data[i*4 : (i+1)*4])
+		actual := math.Float32frombits(bits)
+		assert.Equal(t, expected, actual, "vector[%d] mismatch", i)
+	}
+}
+
+func TestConcurrentSaveLoad(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			fileID := "file-" + string(rune('a'+n))
+			hash := "hash-" + string(rune('0'+n))
+			vectors := []float32{float32(n), float32(n * 2)}
+
+			err := vc.SaveVectors(fileID, hash, vectors)
+			assert.NoError(t, err)
+
+			loaded, err := vc.LoadVectors(fileID, hash)
+			assert.NoError(t, err)
+			assert.Equal(t, vectors, loaded)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestVecFilePath_DeterministicAndSafe(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	// Same inputs → same path.
+	path1 := vc.vecFilePath("file-a", "hash123")
+	path2 := vc.vecFilePath("file-a", "hash123")
+	assert.Equal(t, path1, path2)
+
+	// Different inputs → different path.
+	path3 := vc.vecFilePath("file-b", "hash123")
+	assert.NotEqual(t, path1, path3)
+
+	// Path should be a .vec file in the vectors directory.
+	assert.Equal(t, ".vec", filepath.Ext(path1))
+	assert.Equal(t, vc.vectorsPath(), filepath.Dir(path1))
+}
+
+func TestClearVectors(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	require.NoError(t, vc.SaveVectors("file-a", "h1", []float32{1.0}))
+	require.NoError(t, vc.SaveVectors("file-b", "h2", []float32{2.0}))
+
+	assert.True(t, vc.HasVectors("file-a", "h1"))
+	assert.True(t, vc.HasVectors("file-b", "h2"))
+
+	require.NoError(t, vc.clearVectors())
+
+	assert.False(t, vc.HasVectors("file-a", "h1"))
+	assert.False(t, vc.HasVectors("file-b", "h2"))
+}
+
+func TestClearVectors_NoDir(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	// Should not error if vectors directory doesn't exist.
+	err := vc.clearVectors()
+	assert.NoError(t, err)
+}
+
+func TestLargeVectorSet(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	// 1536 dimensions (typical for text-embedding-3-small).
+	dims := 1536
+	vectors := make([]float32, dims)
+	for i := range vectors {
+		vectors[i] = float32(i) * 0.001
+	}
+
+	require.NoError(t, vc.SaveVectors("large-file", "hash", vectors))
+
+	loaded, err := vc.LoadVectors("large-file", "hash")
+	require.NoError(t, err)
+	assert.Equal(t, vectors, loaded)
+
+	// Verify file size is exactly dims * 4 bytes.
+	path := vc.vecFilePath("large-file", "hash")
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, int64(dims*4), info.Size())
+}
+
+func TestPendingEmbeddings_Sorted(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	idx := &stubIndexInfo{
+		files:  []string{"z-file", "a-file", "m-file"},
+		hashes: map[string]string{"z-file": "h1", "a-file": "h2", "m-file": "h3"},
+	}
+
+	pending := vc.PendingEmbeddings(idx)
+	assert.True(t, sort.StringsAreSorted(pending), "pending should be sorted")
+	assert.Equal(t, []string{"a-file", "m-file", "z-file"}, pending)
+}
+
+func TestSpecialCharactersInFileID(t *testing.T) {
+	dir := t.TempDir()
+	vc := NewVectorCache(dir)
+
+	// File IDs with special characters should be handled via SHA-256 hashing.
+	fileID := "path/to/file with spaces & symbols!.md"
+	vectors := []float32{1.0, 2.0}
+
+	require.NoError(t, vc.SaveVectors(fileID, "hash", vectors))
+	assert.True(t, vc.HasVectors(fileID, "hash"))
+
+	loaded, err := vc.LoadVectors(fileID, "hash")
+	require.NoError(t, err)
+	assert.Equal(t, vectors, loaded)
+}


### PR DESCRIPTION
Closes #22

## Summary
- Adds `cache/vector_cache.go` with `VectorCache` struct implementing the vector tier of the `.knowledge/` cache
- `SaveVectors` / `LoadVectors` / `HasVectors` — binary-encoded float32 vectors stored at `.knowledge/vectors/<sha256>.vec`
- `EnsureMeta` — manages `.knowledge/meta.json` with model/dimensions/version/created_at; invalidates all vectors on model change
- `PendingEmbeddings` — returns file IDs needing (re-)embedding based on content hash comparison
- Defines `EmbedderInfo` and `KnowledgeIndexInfo` interfaces locally for standalone compilation (will use `embed.Embedder` and `index.KnowledgeIndex` after PRs #26 and #28 merge)

## Design Decisions
- **Binary format**: Raw little-endian float32, no headers — dimensions known from meta.json (per issue spec)
- **File naming**: SHA-256 of `fileID:contentHash` for deterministic, filesystem-safe paths
- **Model invalidation**: `EnsureMeta` compares model name + dimensions; clears all `.vec` files on mismatch
- **Content invalidation**: `HasVectors` uses content hash in the file path — content change = different path = cache miss

## Depends On
- PR #26 (Issue #19): `embed/` package — `Embedder` interface with `Model()` and `Dimensions()`
- PR #28 (Issue #21): `cache/` package — graph tier with `.knowledge/` directory structure

## Self-Check
- [x] All 30 tests pass with `-race` flag
- [x] Full repo test suite passes (`go test -race ./...`)
- [x] `go build ./...` and `go vet ./...` clean
- [x] Null/nil inputs handled with clear errors
- [x] Empty values (empty slices, empty strings) handled correctly
- [x] Boundary values (MaxFloat32, SmallestNonzeroFloat32) round-trip correctly
- [x] Corrupt files (non-4-byte-aligned) detected with clear error
- [x] Concurrent access tested (10 goroutines, race detector clean)
- [x] Special characters in file IDs handled via SHA-256 hashing
- [x] All acceptance criteria verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)