### PR TITLE
[KHA-275] Compact graph export + markedup_get_structure MCP tool

### DIFF
--- a/index/graph_summary.go
+++ b/index/graph_summary.go
@@ -1,0 +1,194 @@
+package index
+
+import (
+	"sort"
+
+	"github.com/KHAEntertainment/markedup/schema"
+)
+
+// GraphSummary is a compact, token-efficient representation of the knowledge
+// graph. It intentionally excludes body text, entities, provenance, and
+// enrichment metadata — those are available via per-page retrieval.
+type GraphSummary struct {
+	Stats SummaryStats  `json:"stats"`
+	Pages []SummaryNode `json:"pages"`
+}
+
+// SummaryStats provides aggregate counts for the graph.
+type SummaryStats struct {
+	Pages         int      `json:"pages"`
+	Relationships int      `json:"relationships"`
+	EntityTypes   []string `json:"entity_types"`
+	Tags          []string `json:"tags"`
+}
+
+// SummaryNode is a compact representation of a single page in the graph.
+type SummaryNode struct {
+	ID            string                `json:"id"`
+	Title         string                `json:"title"`
+	EntityType    string                `json:"entity_type"`
+	Tags          []string              `json:"tags"`
+	Confidence    float64               `json:"confidence"`
+	Relationships []SummaryRelationship `json:"relationships,omitempty"`
+
+	// Temporal fields are only included when WithTemporal(true) is set.
+	ValidFrom    string `json:"valid_from,omitempty"`
+	ValidUntil   string `json:"valid_until,omitempty"`
+	LastVerified string `json:"last_verified,omitempty"`
+}
+
+// SummaryRelationship is a compact edge representation.
+type SummaryRelationship struct {
+	Target   string  `json:"target"`
+	Type     string  `json:"type"`
+	Strength float64 `json:"strength"`
+}
+
+// summaryConfig holds the options for CompactGraphSummary.
+type summaryConfig struct {
+	entityTypeFilter string
+	tagFilter        string
+	includeRels      bool
+	includeTemporal  bool
+	maxPages         int
+}
+
+// SummaryOption configures the behavior of CompactGraphSummary.
+type SummaryOption func(*summaryConfig)
+
+// WithEntityTypeFilter restricts the summary to pages matching the given
+// entity type (case-sensitive match against the page's entity-type field).
+func WithEntityTypeFilter(et string) SummaryOption {
+	return func(c *summaryConfig) { c.entityTypeFilter = et }
+}
+
+// WithTagFilter restricts the summary to pages that contain the given tag.
+func WithTagFilter(tag string) SummaryOption {
+	return func(c *summaryConfig) { c.tagFilter = tag }
+}
+
+// WithRelationships controls whether relationship edges are included in
+// each SummaryNode. Default is true.
+func WithRelationships(include bool) SummaryOption {
+	return func(c *summaryConfig) { c.includeRels = include }
+}
+
+// WithTemporal controls whether temporal metadata (valid-from, valid-until,
+// last-verified) is included in each SummaryNode. Default is false.
+func WithTemporal(include bool) SummaryOption {
+	return func(c *summaryConfig) { c.includeTemporal = include }
+}
+
+// WithMaxPages limits the number of pages in the summary. A value of 0 or
+// negative means no limit. Pages are returned in sorted-ID order; the limit
+// is applied after filtering.
+func WithMaxPages(n int) SummaryOption {
+	return func(c *summaryConfig) { c.maxPages = n }
+}
+
+// CompactGraphSummary builds a token-efficient summary of the knowledge
+// graph. It is used by both the MCP markedup_get_structure tool and the
+// CLI export --compact command.
+func (idx *KnowledgeIndex) CompactGraphSummary(opts ...SummaryOption) *GraphSummary {
+	cfg := summaryConfig{
+		includeRels: true,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	// Collect matching pages (deterministic order via sortedIDs).
+	var filtered []*schema.Page
+	for _, id := range idx.sortedIDs {
+		p := idx.byID[id]
+		if cfg.entityTypeFilter != "" && p.Frontmatter.EntityType != cfg.entityTypeFilter {
+			continue
+		}
+		if cfg.tagFilter != "" && !hasTag(p.Frontmatter.Tags, cfg.tagFilter) {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+
+	// Apply max-pages limit.
+	if cfg.maxPages > 0 && len(filtered) > cfg.maxPages {
+		filtered = filtered[:cfg.maxPages]
+	}
+
+	// Build stats from filtered set.
+	entityTypeSet := make(map[string]struct{})
+	tagSet := make(map[string]struct{})
+	totalRels := 0
+	for _, p := range filtered {
+		if p.Frontmatter.EntityType != "" {
+			entityTypeSet[p.Frontmatter.EntityType] = struct{}{}
+		}
+		for _, t := range p.Frontmatter.Tags {
+			tagSet[t] = struct{}{}
+		}
+		totalRels += len(p.Frontmatter.Relationships)
+	}
+
+	stats := SummaryStats{
+		Pages:         len(filtered),
+		Relationships: totalRels,
+		EntityTypes:   sortedKeys(entityTypeSet),
+		Tags:          sortedKeys(tagSet),
+	}
+
+	// Build compact nodes.
+	nodes := make([]SummaryNode, 0, len(filtered))
+	for _, p := range filtered {
+		fm := p.Frontmatter
+		node := SummaryNode{
+			ID:         fm.ID,
+			Title:      fm.Title,
+			EntityType: fm.EntityType,
+			Tags:       fm.Tags,
+			Confidence: fm.Confidence,
+		}
+
+		if cfg.includeRels {
+			for _, r := range fm.Relationships {
+				node.Relationships = append(node.Relationships, SummaryRelationship{
+					Target:   r.Target,
+					Type:     r.Type,
+					Strength: r.Strength,
+				})
+			}
+		}
+
+		if cfg.includeTemporal {
+			node.ValidFrom = fm.Temporal.ValidFrom
+			node.ValidUntil = fm.Temporal.ValidUntil
+			node.LastVerified = fm.Temporal.LastVerified
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return &GraphSummary{
+		Stats: stats,
+		Pages: nodes,
+	}
+}
+
+// hasTag checks whether the given tag is present in the slice.
+func hasTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedKeys returns the keys of a string set in sorted order.
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/index/graph_summary_test.go
+++ b/index/graph_summary_test.go
@@ -1,0 +1,169 @@
+package index
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadTestIndex(t *testing.T) *KnowledgeIndex {
+	t.Helper()
+	result, err := Load(context.Background(), "../testdata/valid")
+	require.NoError(t, err)
+	require.NotNil(t, result.Index)
+	return result.Index
+}
+
+func TestCompactGraphSummary_Unfiltered(t *testing.T) {
+	idx := loadTestIndex(t)
+	summary := idx.CompactGraphSummary()
+
+	assert.Equal(t, idx.Pages(), summary.Stats.Pages)
+	assert.Greater(t, summary.Stats.Relationships, 0)
+	assert.NotEmpty(t, summary.Stats.EntityTypes)
+	assert.NotEmpty(t, summary.Stats.Tags)
+
+	// All page IDs should be present.
+	ids := make(map[string]bool)
+	for _, n := range summary.Pages {
+		ids[n.ID] = true
+	}
+	for _, p := range idx.All() {
+		assert.True(t, ids[p.Frontmatter.ID], "missing page ID: %s", p.Frontmatter.ID)
+	}
+
+	// Compact nodes should NOT contain body, entities, or provenance — these
+	// are structural guarantees of the SummaryNode type (no such fields exist).
+	// We verify relationships are included by default.
+	for _, n := range summary.Pages {
+		if n.ID == "alice" {
+			assert.NotEmpty(t, n.Relationships, "alice should have relationships by default")
+		}
+	}
+
+	// Temporal fields should be empty by default.
+	for _, n := range summary.Pages {
+		assert.Empty(t, n.ValidFrom, "temporal should be excluded by default for %s", n.ID)
+		assert.Empty(t, n.ValidUntil, "temporal should be excluded by default for %s", n.ID)
+		assert.Empty(t, n.LastVerified, "temporal should be excluded by default for %s", n.ID)
+	}
+}
+
+func TestCompactGraphSummary_EntityTypeFilter(t *testing.T) {
+	idx := loadTestIndex(t)
+	summary := idx.CompactGraphSummary(WithEntityTypeFilter("person"))
+
+	for _, n := range summary.Pages {
+		assert.Equal(t, "person", n.EntityType, "all pages should be person type")
+	}
+	// testdata/valid has alice and bob as person type.
+	assert.Equal(t, 2, summary.Stats.Pages)
+}
+
+func TestCompactGraphSummary_TagFilter(t *testing.T) {
+	idx := loadTestIndex(t)
+	summary := idx.CompactGraphSummary(WithTagFilter("ai-researcher"))
+
+	assert.Greater(t, summary.Stats.Pages, 0)
+	for _, n := range summary.Pages {
+		assert.Contains(t, n.Tags, "ai-researcher")
+	}
+	// Only alice has "ai-researcher" tag.
+	assert.Equal(t, 1, summary.Stats.Pages)
+	assert.Equal(t, "alice", summary.Pages[0].ID)
+}
+
+func TestCompactGraphSummary_NoRelationships(t *testing.T) {
+	idx := loadTestIndex(t)
+	summary := idx.CompactGraphSummary(WithRelationships(false))
+
+	for _, n := range summary.Pages {
+		assert.Empty(t, n.Relationships, "relationships should be nil/empty for %s", n.ID)
+	}
+}
+
+func TestCompactGraphSummary_WithTemporal(t *testing.T) {
+	idx := loadTestIndex(t)
+	summary := idx.CompactGraphSummary(WithTemporal(true))
+
+	// event-launch and stale-doc have temporal metadata.
+	found := false
+	for _, n := range summary.Pages {
+		if n.ID == "event-launch" {
+			assert.Equal(t, "2024-03-15", n.ValidFrom)
+			assert.Equal(t, "2024-03-17", n.ValidUntil)
+			assert.Equal(t, "2024-03-17", n.LastVerified)
+			found = true
+		}
+	}
+	assert.True(t, found, "event-launch should be in the summary")
+
+	// alice has valid-from and last-verified but no valid-until.
+	for _, n := range summary.Pages {
+		if n.ID == "alice" {
+			assert.Equal(t, "2023-01-01", n.ValidFrom)
+			assert.Empty(t, n.ValidUntil)
+			assert.Equal(t, "2026-04-01", n.LastVerified)
+		}
+	}
+}
+
+func TestCompactGraphSummary_MaxPages(t *testing.T) {
+	idx := loadTestIndex(t)
+	summary := idx.CompactGraphSummary(WithMaxPages(2))
+
+	assert.Equal(t, 2, summary.Stats.Pages)
+	assert.Len(t, summary.Pages, 2)
+}
+
+func TestCompactGraphSummary_CombinedFilters(t *testing.T) {
+	idx := loadTestIndex(t)
+
+	// Entity type + tag filter.
+	summary := idx.CompactGraphSummary(
+		WithEntityTypeFilter("person"),
+		WithTagFilter("engineer"),
+	)
+	// Both alice and bob are person + engineer.
+	assert.Equal(t, 2, summary.Stats.Pages)
+
+	// Entity type + tag + max pages.
+	summary = idx.CompactGraphSummary(
+		WithEntityTypeFilter("person"),
+		WithTagFilter("engineer"),
+		WithMaxPages(1),
+	)
+	assert.Equal(t, 1, summary.Stats.Pages)
+}
+
+func TestCompactGraphSummary_EmptyIndex(t *testing.T) {
+	idx := buildIndex(nil)
+	summary := idx.CompactGraphSummary()
+
+	assert.Equal(t, 0, summary.Stats.Pages)
+	assert.Equal(t, 0, summary.Stats.Relationships)
+	assert.Empty(t, summary.Stats.EntityTypes)
+	assert.Empty(t, summary.Stats.Tags)
+	assert.Empty(t, summary.Pages)
+}
+
+func TestCompactGraphSummary_NoMatchFilter(t *testing.T) {
+	idx := loadTestIndex(t)
+	summary := idx.CompactGraphSummary(WithEntityTypeFilter("nonexistent"))
+
+	assert.Equal(t, 0, summary.Stats.Pages)
+	assert.Empty(t, summary.Pages)
+}
+
+func TestCompactGraphSummary_StatsEntityTypes(t *testing.T) {
+	idx := loadTestIndex(t)
+	summary := idx.CompactGraphSummary()
+
+	// testdata/valid has: person, concept, project, event.
+	assert.Contains(t, summary.Stats.EntityTypes, "person")
+	assert.Contains(t, summary.Stats.EntityTypes, "concept")
+	assert.Contains(t, summary.Stats.EntityTypes, "project")
+	assert.Contains(t, summary.Stats.EntityTypes, "event")
+}

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/KHAEntertainment/markedup/index"
+	"github.com/spf13/cobra"
+)
+
+var (
+	exportCompact    bool
+	exportEntityType string
+	exportTag        string
+	exportTemporal   bool
+)
+
+func newExportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export [path]",
+		Short: "Export the knowledge graph",
+		Long:  "Export the knowledge graph in various formats. Use --compact for a token-efficient summary suitable for LLM consumption.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  runExport,
+	}
+
+	cmd.Flags().BoolVar(&exportCompact, "compact", false, "export compact graph summary (no body text)")
+	cmd.Flags().StringVar(&exportEntityType, "entity-type", "", "filter by entity type")
+	cmd.Flags().StringVar(&exportTag, "tag", "", "filter by tag")
+	cmd.Flags().BoolVar(&exportTemporal, "temporal", false, "include temporal metadata")
+
+	return cmd
+}
+
+func runExport(cmd *cobra.Command, args []string) error {
+	if !exportCompact {
+		return fmt.Errorf("export requires --compact flag (other formats not yet supported)")
+	}
+
+	path := "."
+	if len(args) > 0 {
+		path = args[0]
+	}
+
+	result, err := index.Load(context.Background(), path, index.WithIgnoreErrors(true))
+	if err != nil {
+		return fmt.Errorf("failed to load %s: %w", path, err)
+	}
+
+	var opts []index.SummaryOption
+	if exportEntityType != "" {
+		opts = append(opts, index.WithEntityTypeFilter(exportEntityType))
+	}
+	if exportTag != "" {
+		opts = append(opts, index.WithTagFilter(exportTag))
+	}
+	if exportTemporal {
+		opts = append(opts, index.WithTemporal(true))
+	}
+
+	summary := result.Index.CompactGraphSummary(opts...)
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(summary); err != nil {
+		return fmt.Errorf("failed to encode JSON: %w", err)
+	}
+
+	return nil
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -40,6 +40,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newTUICmd())
 	root.AddCommand(newEmbedCmd())
 	root.AddCommand(newEnrichCmd())
+	root.AddCommand(newExportCmd())
 
 	return root
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -45,6 +45,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	s.AddTool(srv.searchToolDef(), srv.toolSearch)
 	s.AddTool(srv.getPageToolDef(), srv.toolGetPage)
 	s.AddTool(srv.traverseToolDef(), srv.toolTraverse)
+	s.AddTool(srv.getStructureToolDef(), srv.toolGetStructure)
 	s.AddTool(srv.embedStatusToolDef(), srv.toolEmbedStatus)
 	s.AddTool(srv.embedFileToolDef(), srv.toolEmbedFile)
 
@@ -114,6 +115,24 @@ func (s *mcpServer) embedFileToolDef() mcp.Tool {
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("File path or page ID to embed"),
+		),
+	)
+}
+
+func (s *mcpServer) getStructureToolDef() mcp.Tool {
+	return mcp.NewTool("markedup_get_structure",
+		mcp.WithDescription("Get a compact summary of the knowledge graph structure (no body text). Call this first to understand the graph, then use markedup_get_page for specific pages."),
+		mcp.WithString("filter_entity_type",
+			mcp.Description("Filter to pages with this entity type (e.g. person, concept, project)"),
+		),
+		mcp.WithString("filter_tag",
+			mcp.Description("Filter to pages containing this tag"),
+		),
+		mcp.WithBoolean("include_relationships",
+			mcp.Description("Include relationship edges in each node (default true)"),
+		),
+		mcp.WithBoolean("include_temporal",
+			mcp.Description("Include temporal metadata (valid-from, valid-until, last-verified) in each node (default false)"),
 		),
 	)
 }
@@ -233,6 +252,41 @@ func (s *mcpServer) toolEmbedStatus(ctx context.Context, request mcp.CallToolReq
 	}
 
 	b, _ := json.MarshalIndent(status, "", "  ")
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+func (s *mcpServer) toolGetStructure(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	var params struct {
+		FilterEntityType     string `json:"filter_entity_type"`
+		FilterTag            string `json:"filter_tag"`
+		IncludeRelationships *bool  `json:"include_relationships"`
+		IncludeTemporal      bool   `json:"include_temporal"`
+	}
+	if err := request.BindArguments(&params); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Invalid arguments: %s", err.Error())), nil
+	}
+
+	var opts []index.SummaryOption
+	if params.FilterEntityType != "" {
+		opts = append(opts, index.WithEntityTypeFilter(params.FilterEntityType))
+	}
+	if params.FilterTag != "" {
+		opts = append(opts, index.WithTagFilter(params.FilterTag))
+	}
+	// include_relationships defaults to true; only disable if explicitly false.
+	if params.IncludeRelationships != nil && !*params.IncludeRelationships {
+		opts = append(opts, index.WithRelationships(false))
+	}
+	if params.IncludeTemporal {
+		opts = append(opts, index.WithTemporal(true))
+	}
+
+	summary := s.idx.CompactGraphSummary(opts...)
+	b, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal summary: %s", err.Error())), nil
+	}
+
 	return mcp.NewToolResultText(string(b)), nil
 }
 


### PR DESCRIPTION
## Summary
- Add `CompactGraphSummary()` method to `index/` package with functional options (`WithEntityTypeFilter`, `WithTagFilter`, `WithRelationships`, `WithTemporal`, `WithMaxPages`)
- Add `markedup_get_structure` MCP tool for token-efficient graph browsing (agents call this first, then `get_page` for specific pages)
- Add `markedup export --compact` CLI command with `--entity-type`, `--tag`, `--temporal` flags

## Files Changed
| File | Action |
|------|--------|
| `index/graph_summary.go` | **New** — `GraphSummary` types + `CompactGraphSummary()` + functional options |
| `index/graph_summary_test.go` | **New** — 9 tests covering all filter combinations, empty index, no-match |
| `internal/cli/export.go` | **New** — `markedup export --compact` command |
| `internal/cli/serve.go` | **Modified** — added `markedup_get_structure` tool definition + handler |
| `internal/cli/root.go` | **Modified** — registered export command |

## Self-Check Results

### Acceptance Criteria
- [x] `idx.CompactGraphSummary()` on testdata/valid returns correct page count, all IDs, no body/entities/provenance
- [x] `WithEntityTypeFilter("person")` returns only person-type pages (2 pages)
- [x] `WithTagFilter("ai-researcher")` returns only alice
- [x] `WithRelationships(false)` returns nodes with nil/empty relationships
- [x] `WithTemporal(true)` returns nodes with valid-from/valid-until/last-verified
- [x] `markedup export --compact testdata/valid` outputs valid JSON to stdout
- [x] `markedup export --compact --entity-type person testdata/valid` outputs filtered JSON
- [x] MCP `markedup_get_structure {}` returns compact JSON (no body text)
- [x] MCP `markedup_get_structure {"filter_entity_type":"person"}` returns filtered result
- [x] `go test ./...` all pass, no regressions

### Test Output
```
ok  github.com/KHAEntertainment/markedup/index      0.127s
ok  github.com/KHAEntertainment/markedup/internal/cli 0.133s
(all 12 packages pass, 0 failures)
```

### `go vet ./...` — clean, no issues

## Test plan
- [ ] Verify `go test ./index/... ./internal/cli/...` passes
- [ ] Run `markedup export --compact testdata/valid` and verify JSON structure
- [ ] Run `markedup export --compact --entity-type person testdata/valid` and verify filtering
- [ ] Start MCP server and call `markedup_get_structure` tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added knowledge graph export functionality in a compact, token-efficient format.
  * Export supports filtering by entity type and tags, with optional relationship edges and temporal metadata.
  * Configure exports with entity type filters, tag filters, relationship inclusion, temporal fields, and page limits.
  * New `export` CLI command for exporting knowledge graphs.
  * Added MCP tool for retrieving graph structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->