### PR TITLE
[#48] Local model E2E tests + smoke script + docs

### DIFF
--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -1,0 +1,167 @@
+# Local Model Testing
+
+## Overview
+
+markedup supports local model inference for all AI-powered features:
+
+- **Embeddings** — `/v1/embeddings` compatible server (LM Studio, ollama, llama.cpp)
+- **LLM enrichment** — `/v1/chat/completions` compatible server for Tier 2 extraction and page summaries
+- **Triplex extraction** — `/v1/chat/completions` server running the SciPhi Triplex model (fine-tuned for structured knowledge extraction)
+- **Reranking** — `/v1/rerank` compatible server (infinity-emb, Jina AI API, or a self-hosted Jina reranker)
+
+This document covers the smoke test script and Go E2E test suite for validating local endpoints before running the full pipeline.
+
+---
+
+## Prerequisites
+
+- [LM Studio](https://lmstudio.ai) (for embedding and LLM models) — or any OpenAI-compatible server
+- [infinity-emb](https://github.com/michaelfeil/infinity) (for the Jina reranker)
+- Go 1.22+
+- `curl` (for the smoke test script)
+
+---
+
+## Reference Models
+
+The following models have been tested with markedup. Any OpenAI-compatible endpoint should work.
+
+| Purpose        | Recommended Model                                   | Server Port | Env Vars                                               |
+|----------------|-----------------------------------------------------|-------------|--------------------------------------------------------|
+| Embeddings     | `text-embedding-granite-embedding-278m-multilingual` | 1234 (LM Studio) | `MARKEDUP_EMBED_ENDPOINT`, `MARKEDUP_EMBED_MODEL` |
+| LLM chat       | `granite-3-3-8b-instruct`                           | 1234 (LM Studio) | `MARKEDUP_LLM_ENDPOINT`, `MARKEDUP_LLM_MODEL`     |
+| LLM (small)    | `granite-4-h-tiny` (fast, lower accuracy)           | 1234 (LM Studio) | `MARKEDUP_LLM_ENDPOINT`, `MARKEDUP_LLM_MODEL`     |
+| Triplex        | `sciphi-triplex`                                    | 1234 (separate LM Studio or llama.cpp instance) | `MARKEDUP_TRIPLEX_ENDPOINT`, `MARKEDUP_TRIPLEX_MODEL` |
+| Reranking      | `jina-reranker-v2-base-multilingual`                | 8091 (infinity-emb) | `MARKEDUP_RERANK_ENDPOINT`, `MARKEDUP_RERANK_MODEL` |
+
+---
+
+## Environment Setup
+
+Export the env vars for whichever endpoints you have running. All are optional — tests and the smoke script skip any endpoint whose env var is unset.
+
+```sh
+# Embedding server (LM Studio or ollama)
+export MARKEDUP_EMBED_ENDPOINT=http://192.168.1.152:1234
+export MARKEDUP_EMBED_MODEL=text-embedding-granite-embedding-278m-multilingual
+
+# LLM enrichment server
+export MARKEDUP_LLM_ENDPOINT=http://192.168.1.152:1234
+export MARKEDUP_LLM_MODEL=granite-3-3-8b-instruct
+
+# Triplex extraction server (can be same or different port/instance)
+export MARKEDUP_TRIPLEX_ENDPOINT=http://192.168.1.152:1234
+export MARKEDUP_TRIPLEX_MODEL=sciphi-triplex
+
+# Reranker server (infinity-emb or other /v1/rerank server)
+export MARKEDUP_RERANK_ENDPOINT=http://192.168.1.152:8091
+export MARKEDUP_RERANK_MODEL=jina-reranker-v2-base-multilingual
+```
+
+Put these in your shell profile or a local `.env` file (gitignored) for convenience.
+
+---
+
+## Quick Start
+
+1. **Start LM Studio** — load the desired model and verify the API server is running (default port 1234).
+
+2. **Run the smoke test** to verify all configured endpoints respond correctly:
+
+   ```sh
+   ./scripts/smoke-test.sh
+   ```
+
+   Expected output when all endpoints are configured and running:
+
+   ```
+   === markedup local model smoke test ===
+
+   [PASS] embed endpoint
+   [PASS] llm endpoint
+   [PASS] triplex endpoint
+   [PASS] rerank endpoint
+
+   === Results: 4 passed, 0 failed, 0 skipped ===
+   ```
+
+3. **Run the full E2E test suite** with the `localmodel` build tag:
+
+   ```sh
+   go test -tags=localmodel -v ./...
+   ```
+
+   Tests skip gracefully if their corresponding env var is not set.
+
+---
+
+## Running Individual Tests
+
+Run a single test by name:
+
+```sh
+# Test the embedding endpoint only
+go test -tags=localmodel -run TestEmbedLocalModel -v ./...
+
+# Test the LLM summary generation
+go test -tags=localmodel -run TestEnrichSummaryLocalModel -v ./...
+
+# Test Triplex structured extraction (strict — must return valid JSON)
+go test -tags=localmodel -run TestEnrichExtractTriplex -v ./...
+
+# Test generic LLM extraction (lenient — JSON parse failures are logged, not failed)
+go test -tags=localmodel -run TestEnrichExtractLLM -v ./...
+
+# Test the reranker
+go test -tags=localmodel -run TestRerankLocalModel -v ./...
+```
+
+---
+
+## Test Behavior Reference
+
+| Test | Env Vars Required | Pass Condition | Leniency |
+|------|-------------------|----------------|----------|
+| `TestEmbedLocalModel` | `MARKEDUP_EMBED_ENDPOINT`, `MARKEDUP_EMBED_MODEL` | Returns 1 vector with finite values | Strict |
+| `TestEnrichSummaryLocalModel` | `MARKEDUP_LLM_ENDPOINT`, `MARKEDUP_LLM_MODEL` | Summary > 10 chars | Strict |
+| `TestEnrichExtractLLM` | `MARKEDUP_LLM_ENDPOINT`, `MARKEDUP_LLM_MODEL` | No network error; JSON parse errors logged | Lenient |
+| `TestEnrichExtractTriplex` | `MARKEDUP_TRIPLEX_ENDPOINT`, `MARKEDUP_TRIPLEX_MODEL` | Valid JSON, non-empty entity_type, at least one entity or hint | Strict |
+| `TestRerankLocalModel` | `MARKEDUP_RERANK_ENDPOINT`, `MARKEDUP_RERANK_MODEL` | At least one ranked result returned | Strict |
+
+---
+
+## Troubleshooting
+
+**"skipping: MARKEDUP_EMBED_ENDPOINT not set"**
+The env var is not exported in the current shell. Export it and re-run.
+
+**"skipping: ... endpoint unreachable"**
+The server is not running or not reachable at the configured address. Check that LM Studio or infinity-emb is started and the API server is enabled.
+
+**`[FAIL] embed endpoint — HTTP 000`**
+`curl` could not connect (timeout or connection refused). Check firewall rules if using a remote IP.
+
+**`[FAIL] embed endpoint — HTTP 422`**
+The model name is wrong or the server does not recognize the request body format. Verify `MARKEDUP_EMBED_MODEL` matches the model loaded in LM Studio.
+
+**TestEnrichExtractLLM logs "model did not return valid JSON"**
+This is expected for small models (e.g. `granite-4-h-tiny`). Use `granite-3-3-8b-instruct` or larger for reliable JSON extraction. The Triplex model (`TestEnrichExtractTriplex`) is specifically fine-tuned for this task and should always return valid JSON.
+
+**TestRerankLocalModel skips even though the server is running**
+The rerank test does not probe `/v1/models` (many rerankers don't serve this route). If the env var is set, the test will attempt the actual rerank call. A connection error at POST time will produce a hard test failure with a clear message.
+
+---
+
+## Notes on Triplex
+
+[SciPhi Triplex](https://huggingface.co/SciPhi/Triplex) is a fine-tuned LLM specifically trained to output structured knowledge graph JSON. It should reliably return the JSON format required by markedup's `enrich.Extract()`. If Triplex returns malformed JSON, it is treated as a hard test failure (unlike the lenient `TestEnrichExtractLLM`).
+
+Triplex can be served from the same LM Studio instance as the main LLM by loading it as an alternative model, or from a separate llama.cpp process. Point `MARKEDUP_TRIPLEX_ENDPOINT` to whichever address is serving Triplex.
+
+---
+
+## Notes on Reranker
+
+The reranker uses the Jina API format (`/v1/rerank` with `{"query": ..., "documents": [...], "model": ...}`). infinity-emb supports this format natively when loaded with a compatible cross-encoder checkpoint (e.g. `cross-encoder/ms-marco-MiniLM-L-6-v2` or `jinaai/jina-reranker-v2-base-multilingual`).
+
+The Jina AI cloud API is also compatible — set `MARKEDUP_RERANK_ENDPOINT=https://api.jina.ai` and provide `MARKEDUP_RERANK_MODEL=jina-reranker-v2-base-multilingual` along with a valid Jina API key (auth is not exercised by the E2E tests but would be needed for production use).

--- a/e2e_localmodel_test.go
+++ b/e2e_localmodel_test.go
@@ -1,0 +1,246 @@
+//go:build localmodel
+
+package markedup_test
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KHAEntertainment/markedup/embed"
+	"github.com/KHAEntertainment/markedup/enrich"
+	"github.com/KHAEntertainment/markedup/markdown"
+	"github.com/KHAEntertainment/markedup/rerank"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// skipIfNoEndpoint skips the test if the env var is unset or the endpoint is
+// unreachable. Returns the endpoint URL if reachable.
+func skipIfNoEndpoint(t *testing.T, envVar string) string {
+	t.Helper()
+	endpoint := os.Getenv(envVar)
+	if endpoint == "" {
+		t.Skipf("skipping: %s not set", envVar)
+	}
+	// Quick reachability check via GET /v1/models.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/v1/models", nil)
+	if err != nil {
+		t.Skipf("skipping: %s endpoint %s — could not build request: %v", envVar, endpoint, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode >= 500 {
+		t.Skipf("skipping: %s endpoint %s unreachable (%v)", envVar, endpoint, err)
+	}
+	resp.Body.Close()
+	return endpoint
+}
+
+// skipIfNoEndpointNoProbe skips if the env var is unset but does NOT probe for
+// reachability. Used for the reranker which may not serve GET /v1/models.
+func skipIfNoEndpointNoProbe(t *testing.T, envVar string) string {
+	t.Helper()
+	endpoint := os.Getenv(envVar)
+	if endpoint == "" {
+		t.Skipf("skipping: %s not set", envVar)
+	}
+	return endpoint
+}
+
+// TestEmbedLocalModel tests the OpenAI-compatible embedder against a local
+// embedding server. Set MARKEDUP_EMBED_ENDPOINT and MARKEDUP_EMBED_MODEL.
+func TestEmbedLocalModel(t *testing.T) {
+	endpoint := skipIfNoEndpoint(t, "MARKEDUP_EMBED_ENDPOINT")
+
+	model := os.Getenv("MARKEDUP_EMBED_MODEL")
+	if model == "" {
+		t.Skip("skipping: MARKEDUP_EMBED_MODEL not set")
+	}
+
+	embedder := embed.NewOpenAICompatible(embed.Config{
+		Endpoint:  endpoint,
+		ModelName: model,
+		Dims:      0, // no dimensionality validation for E2E
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	texts := []string{"The knowledge graph connects concepts through semantic relationships."}
+	vecs, err := embedder.Embed(ctx, texts)
+	require.NoError(t, err, "Embed() must not error")
+	require.Len(t, vecs, 1, "expected exactly 1 embedding vector")
+	require.NotEmpty(t, vecs[0], "embedding vector must not be empty")
+
+	// Validate all values are finite (not NaN or Inf).
+	for i, v := range vecs[0] {
+		assert.False(t, math.IsNaN(float64(v)), "embedding[%d] is NaN", i)
+		assert.False(t, math.IsInf(float64(v), 0), "embedding[%d] is Inf", i)
+	}
+
+	t.Logf("embed OK: model=%s dims=%d", model, len(vecs[0]))
+}
+
+// TestEnrichSummaryLocalModel tests GenerateSummary against a local LLM.
+// Set MARKEDUP_LLM_ENDPOINT and MARKEDUP_LLM_MODEL.
+func TestEnrichSummaryLocalModel(t *testing.T) {
+	endpoint := skipIfNoEndpoint(t, "MARKEDUP_LLM_ENDPOINT")
+
+	model := os.Getenv("MARKEDUP_LLM_MODEL")
+	if model == "" {
+		t.Skip("skipping: MARKEDUP_LLM_MODEL not set")
+	}
+
+	extractor := enrich.NewModelExtractor(enrich.ModelConfig{
+		Endpoint: endpoint,
+		Model:    model,
+	})
+
+	page, err := markdown.ParseFile("testdata/valid/alice.md")
+	require.NoError(t, err, "failed to parse alice.md")
+
+	fm := page.Frontmatter
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	summary, err := extractor.GenerateSummary(
+		ctx,
+		fm.Title,
+		fm.EntityType,
+		fm.Tags,
+		enrich.BodyPreview(page.Body, 500),
+	)
+	require.NoError(t, err, "GenerateSummary() must not error")
+	assert.Greater(t, len(summary), 10, "summary must be more than 10 characters, got: %q", summary)
+
+	t.Logf("summary OK: model=%s len=%d summary=%q", model, len(summary), summary)
+}
+
+// TestEnrichExtractLLM tests Extract() against a local general-purpose LLM.
+// Small models (e.g. granite-4-h-tiny) often fail to emit valid JSON, so JSON
+// parse failures are treated as warnings rather than hard failures.
+// Set MARKEDUP_LLM_ENDPOINT and MARKEDUP_LLM_MODEL.
+func TestEnrichExtractLLM(t *testing.T) {
+	endpoint := skipIfNoEndpoint(t, "MARKEDUP_LLM_ENDPOINT")
+
+	model := os.Getenv("MARKEDUP_LLM_MODEL")
+	if model == "" {
+		t.Skip("skipping: MARKEDUP_LLM_MODEL not set")
+	}
+
+	extractor := enrich.NewModelExtractor(enrich.ModelConfig{
+		Endpoint: endpoint,
+		Model:    model,
+	})
+
+	page, err := markdown.ParseFile("testdata/valid/alice.md")
+	require.NoError(t, err, "failed to parse alice.md")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	result, err := extractor.Extract(ctx, page.Body, nil, nil)
+	if err != nil {
+		errStr := err.Error()
+		// Lenient: JSON parse failures are expected for small models.
+		if strings.Contains(errStr, "parse model output") {
+			t.Logf("model did not return valid JSON (expected for small models): %v", err)
+			return
+		}
+		// Hard-fail on network/timeout errors.
+		require.NoError(t, err, "Extract() failed with a non-parse error")
+	}
+
+	t.Logf("extract OK: model=%s entity_type=%q entities=%d hints=%d",
+		model, result.EntityType, len(result.Entities), len(result.SemanticHints))
+}
+
+// TestEnrichExtractTriplex tests Extract() against the Triplex model which is
+// specifically fine-tuned for structured JSON knowledge extraction.
+// Set MARKEDUP_TRIPLEX_ENDPOINT and MARKEDUP_TRIPLEX_MODEL.
+func TestEnrichExtractTriplex(t *testing.T) {
+	endpoint := skipIfNoEndpoint(t, "MARKEDUP_TRIPLEX_ENDPOINT")
+
+	model := os.Getenv("MARKEDUP_TRIPLEX_MODEL")
+	if model == "" {
+		t.Skip("skipping: MARKEDUP_TRIPLEX_MODEL not set")
+	}
+
+	extractor := enrich.NewModelExtractor(enrich.ModelConfig{
+		Endpoint: endpoint,
+		Model:    model,
+	})
+
+	page, err := markdown.ParseFile("testdata/valid/alice.md")
+	require.NoError(t, err, "failed to parse alice.md")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	result, err := extractor.Extract(ctx, page.Body, nil, nil)
+	require.NoError(t, err, "Triplex Extract() must not error — model should return valid JSON")
+	require.NotNil(t, result)
+
+	assert.NotEmpty(t, result.EntityType, "Triplex must produce a non-empty entity_type")
+
+	hasEntities := len(result.Entities) > 0
+	hasHints := len(result.SemanticHints) > 0
+	assert.True(t, hasEntities || hasHints,
+		"Triplex must produce at least one entity or semantic hint")
+
+	t.Logf("triplex OK: model=%s entity_type=%q entities=%d hints=%d",
+		model, result.EntityType, len(result.Entities), len(result.SemanticHints))
+}
+
+// TestRerankLocalModel tests the cross-encoder reranker against a local rerank
+// server (e.g. infinity-emb with a jina-reranker model).
+// Set MARKEDUP_RERANK_ENDPOINT and MARKEDUP_RERANK_MODEL.
+func TestRerankLocalModel(t *testing.T) {
+	// Use no-probe variant since rerankers typically don't serve GET /v1/models.
+	endpoint := skipIfNoEndpointNoProbe(t, "MARKEDUP_RERANK_ENDPOINT")
+
+	model := os.Getenv("MARKEDUP_RERANK_MODEL")
+	if model == "" {
+		t.Skip("skipping: MARKEDUP_RERANK_MODEL not set")
+	}
+
+	reranker := rerank.NewCrossEncoder(rerank.Config{
+		Endpoint: endpoint,
+		Model:    model,
+		Format:   rerank.FormatJina,
+	})
+
+	candidates := []rerank.Candidate{
+		{
+			ID:            "alice",
+			Text:          "Alice Chen is a senior AI researcher specializing in knowledge graph construction.",
+			OriginalScore: 0.8,
+		},
+		{
+			ID:            "bob",
+			Text:          "Bob Martinez is a software engineer working on distributed systems.",
+			OriginalScore: 0.6,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	results, err := reranker.Rerank(ctx, "knowledge graph", candidates)
+	require.NoError(t, err, "Rerank() must not error")
+	require.NotEmpty(t, results, "Rerank() must return at least one result")
+
+	t.Logf("rerank OK: model=%s results=%d top=%q score=%.4f",
+		model, len(results), results[0].ID, results[0].Score)
+}
+
+// TestSearchSemanticLocalModel: see embed command for full pipeline test.
+// The embedding E2E is covered by TestEmbedLocalModel; full semantic search
+// pipeline testing requires the embed CLI command or a loaded index with
+// pre-computed vectors.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# smoke-test.sh — validates local model endpoints are reachable and functional.
+#
+# Usage: ./scripts/smoke-test.sh
+#
+# Reads env vars:
+#   MARKEDUP_EMBED_ENDPOINT     — base URL for embedding server (e.g. http://192.168.1.152:1234)
+#   MARKEDUP_EMBED_MODEL        — embedding model name
+#   MARKEDUP_LLM_ENDPOINT       — base URL for LLM chat server
+#   MARKEDUP_LLM_MODEL          — LLM model name
+#   MARKEDUP_TRIPLEX_ENDPOINT   — base URL for Triplex extraction server
+#   MARKEDUP_TRIPLEX_MODEL      — Triplex model name
+#   MARKEDUP_RERANK_ENDPOINT    — base URL for reranker server (e.g. http://192.168.1.152:8091)
+#   MARKEDUP_RERANK_MODEL       — reranker model name
+#
+# Exits 0 if all configured endpoints pass; exits 1 if any configured endpoint fails.
+# Endpoints with unset env vars are skipped with [SKIP].
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# check_endpoint name method url body
+# Sends a curl request and prints [PASS]/[FAIL] based on HTTP status.
+check_endpoint() {
+    local name="$1"
+    local method="$2"
+    local url="$3"
+    local body="$4"
+
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X "$method" \
+        -H "Content-Type: application/json" \
+        -d "$body" \
+        --connect-timeout 5 \
+        --max-time 30 \
+        "$url" 2>/dev/null) || http_code="000"
+
+    if [ "$http_code" = "200" ]; then
+        echo "[PASS] $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $name — HTTP $http_code"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== markedup local model smoke test ==="
+echo ""
+
+# --- Embed endpoint ---
+if [ -z "${MARKEDUP_EMBED_ENDPOINT:-}" ]; then
+    echo "[SKIP] embed endpoint — MARKEDUP_EMBED_ENDPOINT not set"
+    SKIP=$((SKIP + 1))
+else
+    model="${MARKEDUP_EMBED_MODEL:-text-embedding-nomic-embed-text-v1-5}"
+    body="{\"model\":\"${model}\",\"input\":[\"test\"]}"
+    check_endpoint "embed endpoint" "POST" "${MARKEDUP_EMBED_ENDPOINT}/v1/embeddings" "$body"
+fi
+
+# --- LLM chat endpoint ---
+if [ -z "${MARKEDUP_LLM_ENDPOINT:-}" ]; then
+    echo "[SKIP] llm endpoint — MARKEDUP_LLM_ENDPOINT not set"
+    SKIP=$((SKIP + 1))
+else
+    model="${MARKEDUP_LLM_MODEL:-granite-3-3-8b-instruct}"
+    body="{\"model\":\"${model}\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hi\"}]}"
+    check_endpoint "llm endpoint" "POST" "${MARKEDUP_LLM_ENDPOINT}/v1/chat/completions" "$body"
+fi
+
+# --- Triplex endpoint ---
+if [ -z "${MARKEDUP_TRIPLEX_ENDPOINT:-}" ]; then
+    echo "[SKIP] triplex endpoint — MARKEDUP_TRIPLEX_ENDPOINT not set"
+    SKIP=$((SKIP + 1))
+else
+    model="${MARKEDUP_TRIPLEX_MODEL:-sciphi-triplex}"
+    body="{\"model\":\"${model}\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hi\"}]}"
+    check_endpoint "triplex endpoint" "POST" "${MARKEDUP_TRIPLEX_ENDPOINT}/v1/chat/completions" "$body"
+fi
+
+# --- Rerank endpoint ---
+if [ -z "${MARKEDUP_RERANK_ENDPOINT:-}" ]; then
+    echo "[SKIP] rerank endpoint — MARKEDUP_RERANK_ENDPOINT not set"
+    SKIP=$((SKIP + 1))
+else
+    model="${MARKEDUP_RERANK_MODEL:-jina-reranker-v2-base-multilingual}"
+    body="{\"model\":\"${model}\",\"query\":\"test\",\"documents\":[\"a\",\"b\"]}"
+    check_endpoint "rerank endpoint" "POST" "${MARKEDUP_RERANK_ENDPOINT}/v1/rerank" "$body"
+fi
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Closes #48

Adds the local model E2E test infrastructure (KHA-281):

- **`scripts/smoke-test.sh`** — Bash smoke test that curls all 4 endpoints (embed, LLM, Triplex, rerank) via curl, prints `[PASS]`/`[FAIL]`/`[SKIP]` per endpoint, exits 1 on any failure. Reads all config from env vars, skips unconfigured endpoints cleanly.
- **`e2e_localmodel_test.go`** — 5 Go E2E tests gated behind `//go:build localmodel`. Tests: `TestEmbedLocalModel`, `TestEnrichSummaryLocalModel`, `TestEnrichExtractLLM` (lenient for small models), `TestEnrichExtractTriplex` (strict), `TestRerankLocalModel`. All skip gracefully when env vars are unset.
- **`docs/local-testing.md`** — Setup guide with model reference table, env var definitions, quick start, per-test behavior table, and troubleshooting section.

## Self-Check Results

- [AC1] `scripts/smoke-test.sh` exists and is executable (`-rwxr-xr-x`) ✓ PASS
- [AC2] Smoke script prints `[PASS]`/`[FAIL]`/`[SKIP]` per endpoint, exits 1 on failure ✓ PASS
- [AC3] `e2e_localmodel_test.go` has `//go:build localmodel` as first line ✓ PASS
- [AC4] Package is `markedup_test` (matches `integration_test.go`) ✓ PASS
- [AC5] All 5 tests skip cleanly when env vars unset ✓ PASS (see output below)
- [AC6] `go test ./...` (no tag) — all existing tests pass unchanged ✓ PASS (see output below)
- [AC7] `go build ./...` succeeds ✓ PASS
- [AC8] `go vet ./...` clean ✓ PASS

## Test Output

### `go test ./...` (no localmodel tag) — all existing tests pass

```
ok  	github.com/KHAEntertainment/markedup	3.019s
ok  	github.com/KHAEntertainment/markedup/cache	(cached)
?   	github.com/KHAEntertainment/markedup/cmd/markedup	[no test files]
ok  	github.com/KHAEntertainment/markedup/embed	(cached)
ok  	github.com/KHAEntertainment/markedup/enrich	(cached)
ok  	github.com/KHAEntertainment/markedup/index	(cached)
ok  	github.com/KHAEntertainment/markedup/internal/cli	(cached)
ok  	github.com/KHAEntertainment/markedup/internal/tui	(cached)
ok  	github.com/KHAEntertainment/markedup/markdown	(cached)
ok  	github.com/KHAEntertainment/markedup/rerank	(cached)
ok  	github.com/KHAEntertainment/markedup/schema	(cached)
ok  	github.com/KHAEntertainment/markedup/temporal	(cached)
```

### `go test -tags=localmodel -run TestEmbedLocalModel -v ./...` (no env vars set)

```
=== RUN   TestEmbedLocalModel
    e2e_localmodel_test.go:59: skipping: MARKEDUP_EMBED_ENDPOINT not set
--- SKIP: TestEmbedLocalModel (0.00s)
PASS
ok  	github.com/KHAEntertainment/markedup	0.132s
```

### All localmodel tests skip cleanly

```
--- SKIP: TestEmbedLocalModel (0.00s)
--- SKIP: TestEnrichSummaryLocalModel (0.00s)
--- SKIP: TestEnrichExtractLLM (0.00s)
--- SKIP: TestEnrichExtractTriplex (0.00s)
--- SKIP: TestRerankLocalModel (0.00s)
```

## Test plan

- [ ] Set `MARKEDUP_EMBED_ENDPOINT` + `MARKEDUP_EMBED_MODEL` and run `TestEmbedLocalModel` against LM Studio
- [ ] Set `MARKEDUP_LLM_ENDPOINT` + `MARKEDUP_LLM_MODEL` and run `TestEnrichSummaryLocalModel` + `TestEnrichExtractLLM`
- [ ] Set `MARKEDUP_TRIPLEX_ENDPOINT` + `MARKEDUP_TRIPLEX_MODEL` and run `TestEnrichExtractTriplex` with Triplex model
- [ ] Set `MARKEDUP_RERANK_ENDPOINT` + `MARKEDUP_RERANK_MODEL` and run `TestRerankLocalModel` against infinity-emb
- [ ] Run `./scripts/smoke-test.sh` with all endpoints configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added local testing guide covering validation of OpenAI-compatible model endpoints for embeddings, chat completions, and reranking, including prerequisites, setup instructions, and troubleshooting.

* **Tests**
  * Added end-to-end tests for local models validating embeddings, summary generation, entity extraction, and reranking functionality.
  * Added smoke test script for quick endpoint validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->