### PR TITLE
feat: KHA-278 markedup_reason — LLM graph reasoning MCP tool

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -439,9 +439,135 @@ If no embedder is configured, the response has `isError: true` with the message 
 
 ---
 
+### `markedup_get_structure`
+
+Get a compact summary of the knowledge graph structure without body text. Use this tool first to understand what pages and relationships exist, then use `markedup_get_page` to retrieve full content for specific pages.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filter_entity_type` | string | No | Filter to pages with this entity type (e.g. `person`, `concept`, `project`). |
+| `filter_tag` | string | No | Filter to pages containing this tag. |
+| `include_relationships` | boolean | No | Include relationship edges in each node (default `true`). |
+| `include_temporal` | boolean | No | Include temporal metadata (`valid-from`, `valid-until`, `last-verified`) in each node (default `false`). |
+
+#### Example Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 15,
+  "method": "tools/call",
+  "params": {
+    "name": "markedup_get_structure",
+    "arguments": {
+      "filter_entity_type": "person",
+      "include_relationships": true
+    }
+  }
+}
+```
+
+#### Example Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 15,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\n  \"stats\": {\"pages\": 2, \"relationships\": 3, \"entity_types\": [\"person\"], \"tags\": [\"engineer\"]},\n  \"pages\": [\n    {\"id\": \"alice\", \"title\": \"Alice Chen\", \"entity_type\": \"person\", \"tags\": [\"engineer\"], \"confidence\": 0.95, \"relationships\": [{\"target\": \"bob\", \"type\": \"colleague\", \"strength\": 0.9}]}\n  ]\n}"
+      }
+    ]
+  }
+}
+```
+
+The `text` field contains a JSON object with:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stats.pages` | integer | Number of pages in the filtered result. |
+| `stats.relationships` | integer | Total relationships across filtered pages. |
+| `stats.entity_types` | array | Sorted list of distinct entity types. |
+| `stats.tags` | array | Sorted list of distinct tags. |
+| `pages` | array | Compact node list; each entry has `id`, `title`, `entity_type`, `tags`, `summary` (if set), `confidence`, and optionally `relationships` and temporal fields. |
+
+---
+
+### `markedup_reason`
+
+Use LLM reasoning over the knowledge graph structure to answer multi-hop, structural, and dependency queries. The tool builds a compact graph summary, sends it to a configured LLM with a graph navigation prompt, then returns the LLM's reasoning trace and the full content of pages it selected.
+
+This tool is most useful for queries like:
+- "Which researchers are connected to Alice through projects active in Q3 2024?"
+- "What are the main topic clusters in this knowledge base?"
+- "Which concept should I study first to understand X?"
+
+Requires `MARKEDUP_LLM_ENDPOINT` and `MARKEDUP_LLM_MODEL` environment variables.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | string | Yes | The question to reason about using the graph structure. |
+| `max_pages` | number | No | Maximum pages to include in graph context (default `20`). Larger values give the LLM more context but use more tokens. |
+| `include_relationships` | boolean | No | Include relationship edges in the graph context (default `true`). |
+| `include_temporal` | boolean | No | Include temporal metadata in the graph context (default `false`). |
+
+#### Example Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 16,
+  "method": "tools/call",
+  "params": {
+    "name": "markedup_reason",
+    "arguments": {
+      "query": "Which concepts does Alice study?",
+      "max_pages": 20
+    }
+  }
+}
+```
+
+#### Example Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 16,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\n  \"reasoning\": \"Alice has a 'studies' relationship to concept-graph with strength 0.8...\",\n  \"selected_page_ids\": [\"alice\", \"concept-graph\"],\n  \"relationship_paths\": [\"alice --studies--> concept-graph\"],\n  \"pages\": [\n    {\"id\": \"alice\", \"page\": {...}},\n    {\"id\": \"concept-graph\", \"page\": {...}}\n  ]\n}"
+      }
+    ]
+  }
+}
+```
+
+The `text` field contains a JSON object with:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reasoning` | string | The LLM's thinking trace explaining which pages were selected and why. |
+| `selected_page_ids` | array | IDs of pages the LLM identified as relevant. |
+| `relationship_paths` | array | Relationship chains the LLM identified (e.g. `"id1 --studies--> id2"`). |
+| `pages` | array | Full page content for each selected ID. Each entry has `id` and `page` (the full page object), or `id` and `missing: true` if the ID was not found in the index. |
+
+If `MARKEDUP_LLM_ENDPOINT` or `MARKEDUP_LLM_MODEL` are not set, the response has `isError: true` with the message `LLM endpoint not configured. Set MARKEDUP_LLM_ENDPOINT and MARKEDUP_LLM_MODEL.`
+
+---
+
 ## Environment Variables
 
-The following environment variables configure optional embedding and reranking backends for `markedup_search` (with `semantic: true` or `rerank: true`) and `embed_file`:
+The following environment variables configure optional backends:
 
 | Variable | Description |
 |----------|-------------|
@@ -451,6 +577,9 @@ The following environment variables configure optional embedding and reranking b
 | `MARKEDUP_RERANK_ENDPOINT` | Reranker API endpoint (e.g. Jina, Cohere). |
 | `MARKEDUP_RERANK_MODEL` | Reranker model name. |
 | `MARKEDUP_RERANK_API_KEY` | API key for the reranker endpoint. |
+| `MARKEDUP_LLM_ENDPOINT` | LLM API endpoint for `markedup_reason` (OpenAI-compatible, e.g. `http://localhost:11434`). |
+| `MARKEDUP_LLM_MODEL` | LLM model name for `markedup_reason` (e.g. `llama3`, `gpt-4o`). |
+| `MARKEDUP_LLM_API_KEY` | API key for the LLM endpoint (optional for local backends). |
 
 ---
 

--- a/enrich/reason.go
+++ b/enrich/reason.go
@@ -1,0 +1,142 @@
+package enrich
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ReasonConfig configures the GraphReasoner.
+type ReasonConfig struct {
+	Endpoint   string
+	Model      string
+	APIKey     string
+	HTTPClient *http.Client
+}
+
+// ReasonResult is the parsed LLM response from a graph reasoning call.
+type ReasonResult struct {
+	Thinking          string   `json:"thinking"`
+	PageIDs           []string `json:"page_ids"`
+	RelationshipPaths []string `json:"relationship_paths"`
+}
+
+// GraphReasoner sends a graph navigation prompt to an LLM and returns
+// the pages it selects for answering a query.
+type GraphReasoner struct {
+	cfg    ReasonConfig
+	client *http.Client
+}
+
+// NewGraphReasoner creates a new GraphReasoner with the given config.
+func NewGraphReasoner(cfg ReasonConfig) *GraphReasoner {
+	client := cfg.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &GraphReasoner{cfg: cfg, client: client}
+}
+
+// graphNavigationSystemPrompt is the system prompt used for all reasoning calls.
+const graphNavigationSystemPrompt = `You are given a question and the structure of a knowledge graph.
+Each node represents a markdown page with metadata. Edges represent typed relationships between pages.
+
+Your task: identify which pages are most likely to contain or contribute to answering the question.
+Consider relationship chains, entity types, temporal validity, and confidence scores.
+
+Reply ONLY in JSON (no markdown fences):
+{
+  "thinking": "Your reasoning about which pages are relevant and why, considering the graph structure",
+  "page_ids": ["id1", "id2", ...],
+  "relationship_paths": ["id1 --studies--> id2"]
+}`
+
+// Reason takes a query and a compact graph JSON string, sends the navigation
+// prompt to the LLM, and returns the reasoning result.
+func (r *GraphReasoner) Reason(ctx context.Context, query, compactGraphJSON string) (*ReasonResult, error) {
+	userMsg := fmt.Sprintf("Question: %s\n\nKnowledge graph structure:\n%s", query, compactGraphJSON)
+
+	req := chatRequest{
+		Model: r.cfg.Model,
+		Messages: []chatMessage{
+			{Role: "system", Content: graphNavigationSystemPrompt},
+			{Role: "user", Content: userMsg},
+		},
+	}
+
+	content, err := r.sendRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseReasonOutput(content)
+}
+
+// sendRequest sends a chat completion request and returns the first choice's content.
+func (r *GraphReasoner) sendRequest(ctx context.Context, reqBody chatRequest) (string, error) {
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("enrich: marshal reason request: %w", err)
+	}
+
+	endpoint := strings.TrimRight(r.cfg.Endpoint, "/") + "/v1/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", fmt.Errorf("enrich: create reason request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	if r.cfg.APIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+r.cfg.APIKey)
+	}
+
+	resp, err := r.client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("enrich: reason request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("enrich: read reason response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("enrich: model returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var chatResp chatResponse
+	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+		return "", fmt.Errorf("enrich: unmarshal reason response: %w", err)
+	}
+
+	if len(chatResp.Choices) == 0 {
+		return "", fmt.Errorf("enrich: reason model returned no choices")
+	}
+
+	return chatResp.Choices[0].Message.Content, nil
+}
+
+// parseReasonOutput parses the LLM's JSON response into a ReasonResult.
+func parseReasonOutput(content string) (*ReasonResult, error) {
+	content = strings.TrimSpace(content)
+	// Strip markdown code fences if the model wrapped the output.
+	if strings.HasPrefix(content, "```") {
+		lines := strings.Split(content, "\n")
+		if len(lines) >= 3 {
+			content = strings.Join(lines[1:len(lines)-1], "\n")
+		}
+	}
+	content = strings.TrimSpace(content)
+
+	var result ReasonResult
+	if err := json.Unmarshal([]byte(content), &result); err != nil {
+		return nil, fmt.Errorf("parse reason output: %w", err)
+	}
+
+	return &result, nil
+}

--- a/enrich/reason_test.go
+++ b/enrich/reason_test.go
@@ -1,0 +1,114 @@
+package enrich
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGraphReasoner_Reason(t *testing.T) {
+	responsePayload := map[string]interface{}{
+		"thinking":           "Alice is a researcher, relevant to the query",
+		"page_ids":           []string{"alice", "concept-graph"},
+		"relationship_paths": []string{"alice --studies--> concept-graph"},
+	}
+
+	var capturedReq chatRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/chat/completions", r.URL.Path)
+
+		if err := json.NewDecoder(r.Body).Decode(&capturedReq); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		respContent, _ := json.Marshal(responsePayload)
+		resp := chatResponse{
+			Choices: []chatChoice{
+				{Message: chatMessage{Role: "assistant", Content: string(respContent)}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	reasoner := NewGraphReasoner(ReasonConfig{
+		Endpoint:   srv.URL,
+		Model:      "test-model",
+		HTTPClient: srv.Client(),
+	})
+
+	query := "who does Alice work with?"
+	graphJSON := `{"stats":{"pages":2},"pages":[{"id":"alice"},{"id":"concept-graph"}]}`
+
+	result, err := reasoner.Reason(context.Background(), query, graphJSON)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify parsed result.
+	assert.Len(t, result.PageIDs, 2)
+	assert.Contains(t, result.PageIDs, "alice")
+	assert.Contains(t, result.PageIDs, "concept-graph")
+	assert.Len(t, result.RelationshipPaths, 1)
+	assert.Equal(t, "alice --studies--> concept-graph", result.RelationshipPaths[0])
+	assert.NotEmpty(t, result.Thinking)
+
+	// Verify the request sent to the server.
+	require.Len(t, capturedReq.Messages, 2)
+	assert.True(t, strings.HasPrefix(capturedReq.Messages[0].Content, "You are given a question"),
+		"system message should start with the graph navigation prompt preamble")
+	assert.Contains(t, capturedReq.Messages[1].Content, query,
+		"user message should contain the query")
+	assert.Contains(t, capturedReq.Messages[1].Content, graphJSON,
+		"user message should contain the graph JSON")
+}
+
+func TestGraphReasoner_Reason_MalformedOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := chatResponse{
+			Choices: []chatChoice{
+				{Message: chatMessage{Role: "assistant", Content: "not json"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	reasoner := NewGraphReasoner(ReasonConfig{
+		Endpoint:   srv.URL,
+		Model:      "test-model",
+		HTTPClient: srv.Client(),
+	})
+
+	_, err := reasoner.Reason(context.Background(), "test query", "{}")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse reason output",
+		"error should mention parse reason output")
+}
+
+func TestGraphReasoner_Reason_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	reasoner := NewGraphReasoner(ReasonConfig{
+		Endpoint:   srv.URL,
+		Model:      "test-model",
+		HTTPClient: srv.Client(),
+	})
+
+	_, err := reasoner.Reason(context.Background(), "test query", "{}")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 500",
+		"error should mention status 500")
+}

--- a/index/graph_summary.go
+++ b/index/graph_summary.go
@@ -28,6 +28,7 @@ type SummaryNode struct {
 	Title         string                `json:"title"`
 	EntityType    string                `json:"entity_type"`
 	Tags          []string              `json:"tags"`
+	Summary       string                `json:"summary,omitempty"`
 	Confidence    float64               `json:"confidence"`
 	Relationships []SummaryRelationship `json:"relationships,omitempty"`
 
@@ -51,6 +52,7 @@ type summaryConfig struct {
 	includeRels      bool
 	includeTemporal  bool
 	maxPages         int
+	idFilter         map[string]struct{} // if non-nil, only include pages whose IDs are in this set
 }
 
 // SummaryOption configures the behavior of CompactGraphSummary.
@@ -86,6 +88,21 @@ func WithMaxPages(n int) SummaryOption {
 	return func(c *summaryConfig) { c.maxPages = n }
 }
 
+// WithIDFilter restricts the summary to pages whose IDs are in the given set.
+// An empty or nil filter includes all pages (no restriction).
+func WithIDFilter(ids []string) SummaryOption {
+	return func(c *summaryConfig) {
+		if len(ids) == 0 {
+			c.idFilter = nil
+			return
+		}
+		c.idFilter = make(map[string]struct{}, len(ids))
+		for _, id := range ids {
+			c.idFilter[id] = struct{}{}
+		}
+	}
+}
+
 // CompactGraphSummary builds a token-efficient summary of the knowledge
 // graph. It is used by both the MCP markedup_get_structure tool and the
 // CLI export --compact command.
@@ -101,6 +118,11 @@ func (idx *KnowledgeIndex) CompactGraphSummary(opts ...SummaryOption) *GraphSumm
 	var filtered []*schema.Page
 	for _, id := range idx.sortedIDs {
 		p := idx.byID[id]
+		if cfg.idFilter != nil {
+			if _, ok := cfg.idFilter[id]; !ok {
+				continue
+			}
+		}
 		if cfg.entityTypeFilter != "" && p.Frontmatter.EntityType != cfg.entityTypeFilter {
 			continue
 		}
@@ -145,6 +167,7 @@ func (idx *KnowledgeIndex) CompactGraphSummary(opts ...SummaryOption) *GraphSumm
 			Title:      fm.Title,
 			EntityType: fm.EntityType,
 			Tags:       fm.Tags,
+			Summary:    fm.Summary,
 			Confidence: fm.Confidence,
 		}
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/KHAEntertainment/markedup/cache"
 	"github.com/KHAEntertainment/markedup/embed"
+	"github.com/KHAEntertainment/markedup/enrich"
 	"github.com/KHAEntertainment/markedup/index"
 	"github.com/KHAEntertainment/markedup/rerank"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -48,6 +49,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	s.AddTool(srv.getStructureToolDef(), srv.toolGetStructure)
 	s.AddTool(srv.embedStatusToolDef(), srv.toolEmbedStatus)
 	s.AddTool(srv.embedFileToolDef(), srv.toolEmbedFile)
+	s.AddTool(srv.reasonToolDef(), srv.toolReason)
 
 	return server.ServeStdio(s)
 }
@@ -315,6 +317,124 @@ func (s *mcpServer) toolEmbedFile(ctx context.Context, request mcp.CallToolReque
 		"path":       params.Path,
 		"dimensions": dims,
 		"status":     "embedded",
+	}
+	b, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+func (s *mcpServer) reasonToolDef() mcp.Tool {
+	return mcp.NewTool("markedup_reason",
+		mcp.WithDescription("Use LLM reasoning over the knowledge graph structure to answer multi-hop, structural, and dependency queries. Returns reasoning trace and full content of selected pages. Requires MARKEDUP_LLM_ENDPOINT and MARKEDUP_LLM_MODEL to be set."),
+		mcp.WithString("query",
+			mcp.Required(),
+			mcp.Description("The question to reason about using the graph structure"),
+		),
+		mcp.WithNumber("max_pages",
+			mcp.Description("Maximum pages to include in graph context (default 20). Larger values give the LLM more context but use more tokens."),
+		),
+		mcp.WithBoolean("include_relationships",
+			mcp.Description("Include relationship edges in the graph context (default true)"),
+		),
+		mcp.WithBoolean("include_temporal",
+			mcp.Description("Include temporal metadata in the graph context (default false)"),
+		),
+	)
+}
+
+func (s *mcpServer) toolReason(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	var params struct {
+		Query                string  `json:"query"`
+		MaxPages             float64 `json:"max_pages"`
+		IncludeRelationships *bool   `json:"include_relationships"`
+		IncludeTemporal      bool    `json:"include_temporal"`
+	}
+	if err := request.BindArguments(&params); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Invalid arguments: %s", err.Error())), nil
+	}
+
+	llmEndpoint := os.Getenv("MARKEDUP_LLM_ENDPOINT")
+	llmModel := os.Getenv("MARKEDUP_LLM_MODEL")
+	llmAPIKey := os.Getenv("MARKEDUP_LLM_API_KEY")
+	if llmEndpoint == "" || llmModel == "" {
+		return mcp.NewToolResultError("LLM endpoint not configured. Set MARKEDUP_LLM_ENDPOINT and MARKEDUP_LLM_MODEL."), nil
+	}
+
+	maxPages := int(params.MaxPages)
+	if maxPages <= 0 {
+		maxPages = 20
+	}
+
+	// Build summary options. If the graph is larger than maxPages, use keyword
+	// search to pre-filter to the most relevant pages plus their 1-hop neighbors,
+	// then pass those IDs via WithIDFilter. When using an ID filter the set is
+	// already bounded, so we omit WithMaxPages.
+	var opts []index.SummaryOption
+
+	if s.idx.Pages() > maxPages {
+		results := index.Search(s.idx, params.Query, index.WithContext(ctx))
+		ids := make(map[string]struct{})
+		for _, r := range results {
+			ids[r.Page.Frontmatter.ID] = struct{}{}
+			// Add 1-hop relationship targets.
+			for _, rel := range r.Page.Frontmatter.Relationships {
+				ids[rel.Target] = struct{}{}
+			}
+		}
+		idList := make([]string, 0, len(ids))
+		for id := range ids {
+			idList = append(idList, id)
+		}
+		opts = append(opts, index.WithIDFilter(idList))
+	} else {
+		opts = append(opts, index.WithMaxPages(maxPages))
+	}
+
+	// include_relationships defaults to true; only disable if explicitly false.
+	if params.IncludeRelationships != nil && !*params.IncludeRelationships {
+		opts = append(opts, index.WithRelationships(false))
+	}
+	if params.IncludeTemporal {
+		opts = append(opts, index.WithTemporal(true))
+	}
+
+	summary := s.idx.CompactGraphSummary(opts...)
+	graphJSON, err := json.Marshal(summary)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal graph: %s", err.Error())), nil
+	}
+
+	reasoner := enrich.NewGraphReasoner(enrich.ReasonConfig{
+		Endpoint: llmEndpoint,
+		Model:    llmModel,
+		APIKey:   llmAPIKey,
+	})
+
+	reasonResult, err := reasoner.Reason(ctx, params.Query, string(graphJSON))
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Reasoning failed: %s", err.Error())), nil
+	}
+
+	// Fetch full page content for each selected ID.
+	type pageResult struct {
+		ID      string      `json:"id"`
+		Page    interface{} `json:"page,omitempty"`
+		Missing bool        `json:"missing,omitempty"`
+	}
+	pages := make([]pageResult, 0, len(reasonResult.PageIDs))
+	for _, id := range reasonResult.PageIDs {
+		p, ok := s.idx.Get(id)
+		if !ok {
+			pages = append(pages, pageResult{ID: id, Missing: true})
+			continue
+		}
+		pages = append(pages, pageResult{ID: id, Page: p})
+	}
+
+	result := map[string]interface{}{
+		"reasoning":          reasonResult.Thinking,
+		"selected_page_ids":  reasonResult.PageIDs,
+		"relationship_paths": reasonResult.RelationshipPaths,
+		"pages":              pages,
 	}
 	b, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(b)), nil

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -317,3 +317,40 @@ func TestMCP_IndexFromTestdata(t *testing.T) {
 	assert.Equal(t, "Alice Chen", page.Frontmatter.Title)
 	assert.Equal(t, "person", page.Frontmatter.EntityType)
 }
+
+// ---------------------------------------------------------------------------
+// markedup_reason
+// ---------------------------------------------------------------------------
+
+func TestMCP_Reason_NoLLMEndpoint(t *testing.T) {
+	srv := testMCPServer(t)
+	ctx := context.Background()
+
+	// Ensure env vars are not set.
+	t.Setenv("MARKEDUP_LLM_ENDPOINT", "")
+	t.Setenv("MARKEDUP_LLM_MODEL", "")
+
+	result, err := srv.toolReason(ctx, callToolReq(map[string]any{"query": "who works with Alice?"}))
+	require.NoError(t, err, "missing env should return error result, not Go error")
+	require.NotNil(t, result, "result should not be nil")
+	require.True(t, result.IsError, "result should be an error when LLM is not configured")
+
+	text := resultText(t, result)
+	assert.Contains(t, text, "MARKEDUP_LLM_ENDPOINT", "error should mention the missing env var")
+}
+
+func TestMCP_Reason_ToolDef(t *testing.T) {
+	srv := testMCPServer(t)
+
+	def := srv.reasonToolDef()
+	assert.Equal(t, "markedup_reason", def.Name)
+	assert.NotEmpty(t, def.Description)
+
+	// Verify "query" is required.
+	assert.Contains(t, def.InputSchema.Required, "query",
+		"query should be a required parameter")
+
+	// Verify query property exists.
+	_, exists := def.InputSchema.Properties["query"]
+	assert.True(t, exists, "query property must be defined")
+}


### PR DESCRIPTION
## Summary

Implements KHA-278: a new `markedup_reason` MCP tool that uses LLM reasoning over a compact knowledge graph summary to answer multi-hop, structural, and dependency queries.

- **`enrich/reason.go`** — new `GraphReasoner` that sends graph navigation prompts to any OpenAI-compatible LLM endpoint and parses the structured JSON response (`thinking`, `page_ids`, `relationship_paths`)
- **`index/graph_summary.go`** (prereq fix) — adds `Summary` field to `SummaryNode` (populated from `fm.Summary`) and `WithIDFilter` option for pre-filtering the graph to a specific set of page IDs
- **`internal/cli/serve.go`** — registers the `markedup_reason` tool; handler builds a compact graph summary (with keyword pre-filter + 1-hop expansion for large graphs), calls the LLM, then fetches full page content for selected IDs
- **`docs/mcp-tools.md`** — documents `markedup_get_structure` and the new `markedup_reason` tool including parameters, example request/response, and new `MARKEDUP_LLM_*` env vars

## Test output

```
ok  github.com/KHAEntertainment/markedup              4.972s
ok  github.com/KHAEntertainment/markedup/enrich        1.241s  (+3 new tests)
ok  github.com/KHAEntertainment/markedup/index         1.181s
ok  github.com/KHAEntertainment/markedup/internal/cli  1.330s  (+2 new tests)
```

All 5 new tests pass; no regressions in existing tests.

## Notes

- E2E test with a live LLM endpoint is tracked separately (same pattern as KHA-281 E2E tests — use `//go:build e2e` tag)
- `docs/design-graph-reasoning-tool.md` was the spec; fully implemented
- The prereq `Summary` field fix in `SummaryNode` enables richer LLM context when pages have auto-generated summaries (from KHA-276 page summaries pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added knowledge graph structure query tool with optional filtering and metadata options.
  * Added AI-driven structural reasoning tool for multi-hop queries with page content retrieval.

* **Documentation**
  * Updated documentation with new tools and required LLM configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->