### PR TITLE
[#53] Add Summary field to SummaryNode + WithPageIDs option

### DIFF
--- a/index/graph_summary.go
+++ b/index/graph_summary.go
@@ -26,6 +26,7 @@ type SummaryStats struct {
 type SummaryNode struct {
 	ID            string                `json:"id"`
 	Title         string                `json:"title"`
+	Summary       string                `json:"summary,omitempty"`
 	EntityType    string                `json:"entity_type"`
 	Tags          []string              `json:"tags"`
 	Confidence    float64               `json:"confidence"`
@@ -48,6 +49,7 @@ type SummaryRelationship struct {
 type summaryConfig struct {
 	entityTypeFilter string
 	tagFilter        string
+	pageIDFilter     []string
 	includeRels      bool
 	includeTemporal  bool
 	maxPages         int
@@ -86,6 +88,12 @@ func WithMaxPages(n int) SummaryOption {
 	return func(c *summaryConfig) { c.maxPages = n }
 }
 
+// WithPageIDs restricts the summary to pages whose ID is in the given slice.
+// An empty or nil slice means no restriction. Uses a map for O(1) lookup.
+func WithPageIDs(ids []string) SummaryOption {
+	return func(c *summaryConfig) { c.pageIDFilter = ids }
+}
+
 // CompactGraphSummary builds a token-efficient summary of the knowledge
 // graph. It is used by both the MCP markedup_get_structure tool and the
 // CLI export --compact command.
@@ -97,10 +105,24 @@ func (idx *KnowledgeIndex) CompactGraphSummary(opts ...SummaryOption) *GraphSumm
 		o(&cfg)
 	}
 
+	// Build page-ID filter set for O(1) lookup.
+	var pageIDSet map[string]struct{}
+	if len(cfg.pageIDFilter) > 0 {
+		pageIDSet = make(map[string]struct{}, len(cfg.pageIDFilter))
+		for _, id := range cfg.pageIDFilter {
+			pageIDSet[id] = struct{}{}
+		}
+	}
+
 	// Collect matching pages (deterministic order via sortedIDs).
 	var filtered []*schema.Page
 	for _, id := range idx.sortedIDs {
 		p := idx.byID[id]
+		if pageIDSet != nil {
+			if _, ok := pageIDSet[id]; !ok {
+				continue
+			}
+		}
 		if cfg.entityTypeFilter != "" && p.Frontmatter.EntityType != cfg.entityTypeFilter {
 			continue
 		}
@@ -143,6 +165,7 @@ func (idx *KnowledgeIndex) CompactGraphSummary(opts ...SummaryOption) *GraphSumm
 		node := SummaryNode{
 			ID:         fm.ID,
 			Title:      fm.Title,
+			Summary:    fm.Summary,
 			EntityType: fm.EntityType,
 			Tags:       fm.Tags,
 			Confidence: fm.Confidence,

--- a/index/graph_summary_test.go
+++ b/index/graph_summary_test.go
@@ -157,6 +157,60 @@ func TestCompactGraphSummary_NoMatchFilter(t *testing.T) {
 	assert.Empty(t, summary.Pages)
 }
 
+func TestCompactGraphSummary_SummaryField(t *testing.T) {
+	idx := loadTestIndex(t)
+	summary := idx.CompactGraphSummary()
+
+	// alice has a summary populated by the enrich pipeline.
+	for _, n := range summary.Pages {
+		if n.ID == "alice" {
+			assert.NotEmpty(t, n.Summary, "alice should have a summary")
+			assert.Contains(t, n.Summary, "AI researcher")
+			return
+		}
+	}
+	t.Fatal("alice not found in summary pages")
+}
+
+func TestCompactGraphSummary_WithPageIDs(t *testing.T) {
+	idx := loadTestIndex(t)
+
+	// Filter to only alice.
+	summary := idx.CompactGraphSummary(WithPageIDs([]string{"alice"}))
+	assert.Equal(t, 1, summary.Stats.Pages)
+	assert.Len(t, summary.Pages, 1)
+	assert.Equal(t, "alice", summary.Pages[0].ID)
+}
+
+func TestCompactGraphSummary_WithPageIDs_Multiple(t *testing.T) {
+	idx := loadTestIndex(t)
+
+	summary := idx.CompactGraphSummary(WithPageIDs([]string{"alice", "bob"}))
+	assert.Equal(t, 2, summary.Stats.Pages)
+	ids := make([]string, 0, len(summary.Pages))
+	for _, n := range summary.Pages {
+		ids = append(ids, n.ID)
+	}
+	assert.Contains(t, ids, "alice")
+	assert.Contains(t, ids, "bob")
+}
+
+func TestCompactGraphSummary_WithPageIDs_Empty(t *testing.T) {
+	idx := loadTestIndex(t)
+
+	// Empty slice means no restriction — all pages returned.
+	summary := idx.CompactGraphSummary(WithPageIDs([]string{}))
+	assert.Equal(t, idx.Pages(), summary.Stats.Pages)
+}
+
+func TestCompactGraphSummary_WithPageIDs_NonExistent(t *testing.T) {
+	idx := loadTestIndex(t)
+
+	summary := idx.CompactGraphSummary(WithPageIDs([]string{"nonexistent"}))
+	assert.Equal(t, 0, summary.Stats.Pages)
+	assert.Empty(t, summary.Pages)
+}
+
 func TestCompactGraphSummary_StatsEntityTypes(t *testing.T) {
 	idx := loadTestIndex(t)
 	summary := idx.CompactGraphSummary()


### PR DESCRIPTION
Closes #53

## Summary
- Added `Summary string` field to `SummaryNode` struct with `json:"summary,omitempty"` tag
- `CompactGraphSummary()` now copies `fm.Summary` into the summary node
- Added `WithPageIDs(ids []string) SummaryOption` that filters to specified page IDs using O(1) map lookup
- Added `pageIDFilter []string` to `summaryConfig`, checked in the filtering loop before other filters
- Preserves existing deterministic ordering via `sortedIDs`

## Self-Check Results

### Acceptance Criteria
- [x] `SummaryNode` includes `Summary string` with `json:"summary,omitempty"` tag
- [x] `CompactGraphSummary()` copies `fm.Summary` into `SummaryNode.Summary`
- [x] MCP tool JSON output includes `"summary"` field (automatic via struct serialization)
- [x] `WithPageIDs(ids []string) SummaryOption` exists and filters pages
- [x] `summaryConfig` has `pageIDFilter []string` field, checked in filtering loop
- [x] All existing graph summary tests pass
- [x] New test: alice's summary is propagated through `CompactGraphSummary()`
- [x] New test: `WithPageIDs(["alice"])` returns only alice

### Test Output
```
go test ./...          — all packages PASS
go vet ./...           — clean
go build ./...         — clean
```

### New Tests Added
- `TestCompactGraphSummary_SummaryField` — verifies alice's summary propagates
- `TestCompactGraphSummary_WithPageIDs` — single ID filter
- `TestCompactGraphSummary_WithPageIDs_Multiple` — multi-ID filter
- `TestCompactGraphSummary_WithPageIDs_Empty` — empty slice = no restriction
- `TestCompactGraphSummary_WithPageIDs_NonExistent` — non-existent ID returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Summary information now displays in graph summaries
  * Added ability to filter graph summaries by specific page IDs

* **Tests**
  * Added comprehensive test coverage for new summary field display and page ID filtering functionality, including edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->