### PR TITLE
[#54] KHA-283 Local reranker format config + CLI flag + docs

### DIFF
--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -160,6 +160,66 @@ Triplex can be served from the same LM Studio instance as the main LLM by loadin
 
 ---
 
+## Local Reranker Setup
+
+markedup supports local cross-encoder reranking via any server that exposes a `/v1/rerank` endpoint. The recommended approach is [Text Embeddings Inference (TEI)](https://github.com/huggingface/text-embeddings-inference) with the IBM Granite reranker model.
+
+### TEI with Granite Reranker
+
+1. **Pull and run TEI** with the Granite reranker checkpoint:
+
+   ```sh
+   # CPU (works on macOS / Linux)
+   docker run -p 8091:80 \
+     ghcr.io/huggingface/text-embeddings-inference:cpu-latest \
+     --model-id ibm-granite/granite-embedding-30m-english \
+     --revision refs/pr/2
+
+   # Or with a cross-encoder checkpoint:
+   docker run -p 8091:80 \
+     ghcr.io/huggingface/text-embeddings-inference:cpu-latest \
+     --model-id jinaai/jina-reranker-v2-base-multilingual
+   ```
+
+2. **Export the env vars**:
+
+   ```sh
+   export MARKEDUP_RERANK_ENDPOINT=http://127.0.0.1:8091
+   export MARKEDUP_RERANK_MODEL=jina-reranker-v2-base-multilingual
+   export MARKEDUP_RERANK_API_KEY=           # leave empty for local TEI
+   export MARKEDUP_RERANK_FORMAT=jina        # default; correct for TEI endpoints
+   ```
+
+3. **Verify** with the smoke test:
+
+   ```sh
+   ./scripts/smoke-test.sh
+   ```
+
+### Reranker Format Configuration
+
+The `MARKEDUP_RERANK_FORMAT` env var (for `markedup serve`) and `--rerank-format` CLI flag (for `markedup search`) control which API response format the reranker client uses:
+
+| Value    | Constant            | Use When                                      |
+|----------|---------------------|-----------------------------------------------|
+| `jina`   | `rerank.FormatJina` | TEI, infinity-emb, Jina AI cloud (default)    |
+| `openai` | `rerank.FormatOpenAI` | OpenAI-compatible reranker endpoints          |
+
+- **Default is `jina`** (backward compatible). TEI endpoints use the Jina format natively.
+- The CLI flag overrides the env var for `markedup search`; the env var is used by `markedup serve` (MCP server).
+
+### KHA-281 E2E Reference
+
+The KHA-281 test environment validated this setup:
+
+- **Server**: TEI at `127.0.0.1:8091` with Granite reranker
+- **Format**: `FormatJina` (default)
+- **Result**: alice scored 0.8085 relevance — test passed
+
+See `docs/test-results-20260413.md` for full E2E results.
+
+---
+
 ## Notes on Reranker
 
 The reranker uses the Jina API format (`/v1/rerank` with `{"query": ..., "documents": [...], "model": ...}`). infinity-emb supports this format natively when loaded with a compatible cross-encoder checkpoint (e.g. `cross-encoder/ms-marco-MiniLM-L-6-v2` or `jinaai/jina-reranker-v2-base-multilingual`).

--- a/internal/cli/rerank_format.go
+++ b/internal/cli/rerank_format.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/KHAEntertainment/markedup/rerank"
+)
+
+// parseRerankFormat maps a user-provided string to a rerank.Format constant.
+// Recognised values (case-insensitive): "openai" -> FormatOpenAI.
+// Everything else (including "" and "jina") defaults to FormatJina, which is
+// the correct format for TEI and Jina AI endpoints.
+func parseRerankFormat(s string) rerank.Format {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "openai":
+		return rerank.FormatOpenAI
+	default:
+		return rerank.FormatJina
+	}
+}

--- a/internal/cli/rerank_format_test.go
+++ b/internal/cli/rerank_format_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/KHAEntertainment/markedup/rerank"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRerankFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected rerank.Format
+	}{
+		{name: "empty string defaults to Jina", input: "", expected: rerank.FormatJina},
+		{name: "jina lowercase", input: "jina", expected: rerank.FormatJina},
+		{name: "jina mixed case", input: "Jina", expected: rerank.FormatJina},
+		{name: "openai lowercase", input: "openai", expected: rerank.FormatOpenAI},
+		{name: "openai mixed case", input: "OpenAI", expected: rerank.FormatOpenAI},
+		{name: "openai with whitespace", input: "  openai  ", expected: rerank.FormatOpenAI},
+		{name: "unknown value defaults to Jina", input: "cohere", expected: rerank.FormatJina},
+		{name: "whitespace only defaults to Jina", input: "   ", expected: rerank.FormatJina},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseRerankFormat(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	searchSemantic bool
-	searchRerank   bool
+	searchSemantic    bool
+	searchRerank      bool
+	searchRerankFmt   string
 )
 
 func newSearchCmd() *cobra.Command {
@@ -31,6 +32,8 @@ func newSearchCmd() *cobra.Command {
 		"Enable semantic search using cached embeddings (requires prior embedding)")
 	cmd.Flags().BoolVar(&searchRerank, "rerank", false,
 		"Re-rank results using a cross-encoder model (requires endpoint config)")
+	cmd.Flags().StringVar(&searchRerankFmt, "rerank-format", "jina",
+		`Reranker API format: "jina" (default, also correct for TEI) or "openai"`)
 
 	return cmd
 }
@@ -88,6 +91,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 				Endpoint: rerankEndpoint,
 				Model:    rerankModel,
 				APIKey:   rerankAPIKey,
+				Format:   parseRerankFormat(searchRerankFmt),
 			})
 			searchOpts = append(searchOpts, index.WithReranker(rr))
 		}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -175,12 +175,14 @@ func (s *mcpServer) toolSearch(ctx context.Context, request mcp.CallToolRequest)
 		rerankEndpoint := os.Getenv("MARKEDUP_RERANK_ENDPOINT")
 		rerankModel := os.Getenv("MARKEDUP_RERANK_MODEL")
 		rerankAPIKey := os.Getenv("MARKEDUP_RERANK_API_KEY")
+		rerankFormat := parseRerankFormat(os.Getenv("MARKEDUP_RERANK_FORMAT"))
 
 		if rerankEndpoint != "" && rerankModel != "" {
 			rr := rerank.NewCrossEncoder(rerank.Config{
 				Endpoint: rerankEndpoint,
 				Model:    rerankModel,
 				APIKey:   rerankAPIKey,
+				Format:   rerankFormat,
 			})
 			searchOpts = append(searchOpts, index.WithReranker(rr))
 		}


### PR DESCRIPTION
Closes #54

## Summary

- Added `MARKEDUP_RERANK_FORMAT` env var support in `serve.go` (MCP server) — maps `"openai"` to `FormatOpenAI`, defaults to `FormatJina`
- Added `--rerank-format` CLI flag to `search.go` — values `"jina"` (default) or `"openai"`
- Added shared `parseRerankFormat()` helper in new `rerank_format.go` with unit tests
- Added "Local Reranker Setup" section to `docs/local-testing.md` documenting TEI + Granite setup, format configuration table, and KHA-281 reference

## Files Changed

| File | Change |
|------|--------|
| `internal/cli/rerank_format.go` | New — `parseRerankFormat()` helper |
| `internal/cli/rerank_format_test.go` | New — 8 table-driven test cases |
| `internal/cli/serve.go` | Read `MARKEDUP_RERANK_FORMAT` env var, pass `Format` to `rerank.Config` |
| `internal/cli/search.go` | Add `--rerank-format` string flag, pass to `rerank.Config` |
| `docs/local-testing.md` | Add "Local Reranker Setup" section with TEI setup, format table, KHA-281 reference |

## Self-Check Results

### Acceptance Criteria

- [x] `MARKEDUP_RERANK_FORMAT=openai` in serve.go selects `FormatOpenAI`; unset/empty defaults to `FormatJina`
- [x] `markedup search --rerank --rerank-format=openai "query"` selects `FormatOpenAI`
- [x] `markedup search --rerank --rerank-format=jina "query"` selects `FormatJina`
- [x] Default (no flag, no env var) uses `FormatJina` (backward compatible)
- [x] `markedup serve` respects `MARKEDUP_RERANK_FORMAT` env var for MCP search tool
- [x] `docs/local-testing.md` has new "Local Reranker Setup" section
- [x] Existing `TestRerankLocalModel` E2E test unaffected (no rerank package changes)
- [x] `go test ./internal/cli/...` passes

### Test Output

```
go test ./internal/cli/... → ok (0.153s)
go test ./... → all 12 packages pass
go vet ./... → clean
go build ./... → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--rerank-format` CLI flag to control reranker response formatting
  * Added `MARKEDUP_RERANK_FORMAT` and `MARKEDUP_RERANK_API_KEY` environment variables for reranker configuration

* **Documentation**
  * Added local reranker setup guide with instructions for running cross-encoder reranking via TEI and smoke-test validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->