### PR TITLE
[#52] Extract shared llm/ package from enrich/model.go

### DIFF
--- a/enrich/model.go
+++ b/enrich/model.go
@@ -1,14 +1,13 @@
 package enrich
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
+	"github.com/KHAEntertainment/markedup/llm"
 	"github.com/KHAEntertainment/markedup/schema"
 )
 
@@ -41,17 +40,19 @@ type ModelConfig struct {
 
 // ModelExtractor calls a chat-completion API to extract structured knowledge.
 type ModelExtractor struct {
-	cfg    ModelConfig
-	client *http.Client
+	cfg       ModelConfig
+	llmClient *llm.Client
 }
 
 // NewModelExtractor creates a new model extractor with the given config.
 func NewModelExtractor(cfg ModelConfig) *ModelExtractor {
-	client := cfg.HTTPClient
-	if client == nil {
-		client = http.DefaultClient
-	}
-	return &ModelExtractor{cfg: cfg, client: client}
+	llmClient := llm.NewClient(llm.Config{
+		Endpoint:   cfg.Endpoint,
+		Model:      cfg.Model,
+		APIKey:     cfg.APIKey,
+		HTTPClient: cfg.HTTPClient,
+	})
+	return &ModelExtractor{cfg: cfg, llmClient: llmClient}
 }
 
 // ModelResult holds Tier 2 extraction output.
@@ -79,13 +80,10 @@ func (m *ModelExtractor) Extract(ctx context.Context, body string, entityTypes, 
 		if err != nil {
 			return nil, err
 		}
-		req := chatRequest{
-			Model: m.cfg.Model,
-			Messages: []chatMessage{
-				{Role: "user", Content: userMsg},
-			},
+		messages := []llm.Message{
+			{Role: "user", Content: userMsg},
 		}
-		content, err := m.sendChatRequest(ctx, req)
+		content, err := m.llmClient.ChatCompletion(ctx, messages)
 		if err != nil {
 			return nil, err
 		}
@@ -94,83 +92,16 @@ func (m *ModelExtractor) Extract(ctx context.Context, body string, entityTypes, 
 
 	systemPrompt := buildSystemPrompt(entityTypes, predicates)
 
-	req := chatRequest{
-		Model: m.cfg.Model,
-		Messages: []chatMessage{
-			{Role: "system", Content: systemPrompt},
-			{Role: "user", Content: body},
-		},
+	messages := []llm.Message{
+		{Role: "system", Content: systemPrompt},
+		{Role: "user", Content: body},
 	}
 
-	content, err := m.sendChatRequest(ctx, req)
+	content, err := m.llmClient.ChatCompletion(ctx, messages)
 	if err != nil {
 		return nil, err
 	}
 	return parseModelOutput(content)
-}
-
-// sendChatRequest sends a chat completion request and returns the first choice's content.
-func (m *ModelExtractor) sendChatRequest(ctx context.Context, reqBody chatRequest) (string, error) {
-	jsonBody, err := json.Marshal(reqBody)
-	if err != nil {
-		return "", fmt.Errorf("enrich: marshal request: %w", err)
-	}
-
-	endpoint := strings.TrimRight(m.cfg.Endpoint, "/") + "/v1/chat/completions"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(jsonBody))
-	if err != nil {
-		return "", fmt.Errorf("enrich: create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	if m.cfg.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+m.cfg.APIKey)
-	}
-
-	resp, err := m.client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("enrich: model request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("enrich: read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("enrich: model returned status %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	var chatResp chatResponse
-	if err := json.Unmarshal(respBody, &chatResp); err != nil {
-		return "", fmt.Errorf("enrich: unmarshal response: %w", err)
-	}
-
-	if len(chatResp.Choices) == 0 {
-		return "", fmt.Errorf("enrich: model returned no choices")
-	}
-
-	return chatResp.Choices[0].Message.Content, nil
-}
-
-// chatRequest is the OpenAI-compatible chat completion request.
-type chatRequest struct {
-	Model    string        `json:"model"`
-	Messages []chatMessage `json:"messages"`
-}
-
-type chatMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-}
-
-type chatResponse struct {
-	Choices []chatChoice `json:"choices"`
-}
-
-type chatChoice struct {
-	Message chatMessage `json:"message"`
 }
 
 func buildSystemPrompt(entityTypes, predicates []string) string {
@@ -357,15 +288,12 @@ Body (first 500 tokens): %s
 
 Reply with ONLY the summary sentence, no quotes or formatting.`, title, entityType, tagsStr, bodyPreview)
 
-	reqBody := chatRequest{
-		Model: m.cfg.Model,
-		Messages: []chatMessage{
-			{Role: "system", Content: "You are a concise knowledge graph summarizer. Generate one-sentence entity descriptions."},
-			{Role: "user", Content: prompt},
-		},
+	messages := []llm.Message{
+		{Role: "system", Content: "You are a concise knowledge graph summarizer. Generate one-sentence entity descriptions."},
+		{Role: "user", Content: prompt},
 	}
 
-	content, err := m.sendChatRequest(ctx, reqBody)
+	content, err := m.llmClient.ChatCompletion(ctx, messages)
 	if err != nil {
 		// Wrap with summary-specific context to preserve existing error message patterns.
 		return "", fmt.Errorf("enrich: summary %w", err)

--- a/enrich/model_test.go
+++ b/enrich/model_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/KHAEntertainment/markedup/llm"
 	"github.com/KHAEntertainment/markedup/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,7 @@ func TestModelExtractor_Extract(t *testing.T) {
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
 
-		var req chatRequest
+		var req llm.Request
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 		assert.Equal(t, "triplex", req.Model)
 		assert.Len(t, req.Messages, 2)
@@ -40,9 +41,9 @@ func TestModelExtractor_Extract(t *testing.T) {
 		assert.Equal(t, "user", req.Messages[1].Role)
 
 		resultJSON, _ := json.Marshal(modelResult)
-		resp := chatResponse{
-			Choices: []chatChoice{
-				{Message: chatMessage{Role: "assistant", Content: string(resultJSON)}},
+		resp := llm.Response{
+			Choices: []llm.Choice{
+				{Message: llm.Message{Role: "assistant", Content: string(resultJSON)}},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -78,9 +79,9 @@ func TestModelExtractor_CodeFencedResponse(t *testing.T) {
 		// Wrap in code fences like some models do.
 		fenced := "```json\n" + string(resultJSON) + "\n```"
 
-		resp := chatResponse{
-			Choices: []chatChoice{
-				{Message: chatMessage{Role: "assistant", Content: fenced}},
+		resp := llm.Response{
+			Choices: []llm.Choice{
+				{Message: llm.Message{Role: "assistant", Content: fenced}},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -117,9 +118,9 @@ func TestModelExtractor_APIError(t *testing.T) {
 
 func TestModelExtractor_MalformedJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := chatResponse{
-			Choices: []chatChoice{
-				{Message: chatMessage{Role: "assistant", Content: "not valid json at all"}},
+		resp := llm.Response{
+			Choices: []llm.Choice{
+				{Message: llm.Message{Role: "assistant", Content: "not valid json at all"}},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -139,7 +140,7 @@ func TestModelExtractor_MalformedJSON(t *testing.T) {
 
 func TestModelExtractor_NoChoices(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := chatResponse{Choices: []chatChoice{}}
+		resp := llm.Response{Choices: []llm.Choice{}}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
 	}))
@@ -159,15 +160,15 @@ func TestGenerateSummary(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
 
-		var req chatRequest
+		var req llm.Request
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 		assert.Equal(t, "test-model", req.Model)
 		assert.Len(t, req.Messages, 2)
 		assert.Contains(t, req.Messages[1].Content, "Alice Chen")
 
-		resp := chatResponse{
-			Choices: []chatChoice{
-				{Message: chatMessage{Role: "assistant", Content: "AI researcher specializing in knowledge graphs"}},
+		resp := llm.Response{
+			Choices: []llm.Choice{
+				{Message: llm.Message{Role: "assistant", Content: "AI researcher specializing in knowledge graphs"}},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -193,9 +194,9 @@ func TestGenerateSummary(t *testing.T) {
 
 func TestGenerateSummary_StripsQuotes(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := chatResponse{
-			Choices: []chatChoice{
-				{Message: chatMessage{Role: "assistant", Content: `"AI researcher specializing in knowledge graphs"`}},
+		resp := llm.Response{
+			Choices: []llm.Choice{
+				{Message: llm.Message{Role: "assistant", Content: `"AI researcher specializing in knowledge graphs"`}},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -225,14 +226,14 @@ func TestGenerateSummary_APIError(t *testing.T) {
 func TestModelExtractor_Extract_TriplexFormat(t *testing.T) {
 	triplexPayload := `{"entities_and_triples": ["[1], PERSON:Alice Chen", "[2], ORGANIZATION:LucidityLabs", "[3], CONCEPT:knowledge graphs", "(1, WORKS_FOR, 2)", "(1, RESEARCHES, 3)"]}`
 
-	var capturedReq chatRequest
+	var capturedReq llm.Request
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedReq))
 
-		resp := chatResponse{
-			Choices: []chatChoice{
-				{Message: chatMessage{Role: "assistant", Content: triplexPayload}},
+		resp := llm.Response{
+			Choices: []llm.Choice{
+				{Message: llm.Message{Role: "assistant", Content: triplexPayload}},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -278,9 +279,9 @@ func TestModelExtractor_TriplexEntityOnly(t *testing.T) {
 	triplexPayload := `{"entities_and_triples": ["[1], PERSON:Bob", "[2], CONCEPT:graphs"]}`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := chatResponse{
-			Choices: []chatChoice{
-				{Message: chatMessage{Role: "assistant", Content: triplexPayload}},
+		resp := llm.Response{
+			Choices: []llm.Choice{
+				{Message: llm.Message{Role: "assistant", Content: triplexPayload}},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -302,9 +303,9 @@ func TestModelExtractor_TriplexEntityOnly(t *testing.T) {
 
 func TestModelExtractor_TriplexMalformedOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := chatResponse{
-			Choices: []chatChoice{
-				{Message: chatMessage{Role: "assistant", Content: "not json at all"}},
+		resp := llm.Response{
+			Choices: []llm.Choice{
+				{Message: llm.Message{Role: "assistant", Content: "not json at all"}},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/llm/client.go
+++ b/llm/client.go
@@ -1,0 +1,107 @@
+// Package llm provides a shared OpenAI-compatible chat completion HTTP client.
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Config configures the chat completion client.
+type Config struct {
+	Endpoint   string       // Base URL (e.g. http://localhost:11434)
+	Model      string       // Model name (e.g. "triplex")
+	APIKey     string       // Optional API key for authentication
+	HTTPClient *http.Client // Optional; defaults to http.DefaultClient
+}
+
+// Client is an OpenAI-compatible chat completion HTTP client.
+type Client struct {
+	cfg        Config
+	httpClient *http.Client
+}
+
+// NewClient creates a new chat completion client with the given config.
+func NewClient(cfg Config) *Client {
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	return &Client{cfg: cfg, httpClient: hc}
+}
+
+// Message represents a single chat message.
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// Request is the OpenAI-compatible chat completion request.
+type Request struct {
+	Model    string    `json:"model"`
+	Messages []Message `json:"messages"`
+}
+
+// Response is the OpenAI-compatible chat completion response.
+type Response struct {
+	Choices []Choice `json:"choices"`
+}
+
+// Choice is a single completion choice in a chat response.
+type Choice struct {
+	Message Message `json:"message"`
+}
+
+// ChatCompletion sends a chat completion request and returns the first choice's content.
+func (c *Client) ChatCompletion(ctx context.Context, messages []Message) (string, error) {
+	reqBody := Request{
+		Model:    c.cfg.Model,
+		Messages: messages,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("llm: marshal request: %w", err)
+	}
+
+	endpoint := strings.TrimRight(c.cfg.Endpoint, "/") + "/v1/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", fmt.Errorf("llm: create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if c.cfg.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("llm: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("llm: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("llm: model returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var chatResp Response
+	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+		return "", fmt.Errorf("llm: unmarshal response: %w", err)
+	}
+
+	if len(chatResp.Choices) == 0 {
+		return "", fmt.Errorf("llm: model returned no choices")
+	}
+
+	return chatResp.Choices[0].Message.Content, nil
+}

--- a/llm/client_test.go
+++ b/llm/client_test.go
@@ -1,0 +1,163 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ChatCompletion(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiKey     string
+		messages   []Message
+		handler    http.HandlerFunc
+		wantResult string
+		wantErr    string
+	}{
+		{
+			name:   "successful request with auth",
+			apiKey: "test-key",
+			messages: []Message{
+				{Role: "system", Content: "You are helpful."},
+				{Role: "user", Content: "Hello"},
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+
+				var req Request
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+				assert.Equal(t, "test-model", req.Model)
+				assert.Len(t, req.Messages, 2)
+				assert.Equal(t, "system", req.Messages[0].Role)
+				assert.Equal(t, "user", req.Messages[1].Role)
+
+				resp := Response{
+					Choices: []Choice{
+						{Message: Message{Role: "assistant", Content: "Hi there!"}},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			wantResult: "Hi there!",
+		},
+		{
+			name:     "no auth header when key is empty",
+			messages: []Message{{Role: "user", Content: "test"}},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Empty(t, r.Header.Get("Authorization"))
+
+				resp := Response{
+					Choices: []Choice{
+						{Message: Message{Role: "assistant", Content: "ok"}},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			wantResult: "ok",
+		},
+		{
+			name:     "server returns error status",
+			messages: []Message{{Role: "user", Content: "test"}},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("internal error"))
+			},
+			wantErr: "status 500",
+		},
+		{
+			name:     "server returns no choices",
+			messages: []Message{{Role: "user", Content: "test"}},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				resp := Response{Choices: []Choice{}}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			wantErr: "no choices",
+		},
+		{
+			name:     "server returns invalid json",
+			messages: []Message{{Role: "user", Content: "test"}},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte("not json"))
+			},
+			wantErr: "unmarshal response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := NewClient(Config{
+				Endpoint: server.URL,
+				Model:    "test-model",
+				APIKey:   tt.apiKey,
+			})
+
+			result, err := client.ChatCompletion(context.Background(), tt.messages)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantResult, result)
+		})
+	}
+}
+
+func TestClient_EndpointTrailingSlash(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		resp := Response{
+			Choices: []Choice{
+				{Message: Message{Role: "assistant", Content: "ok"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	// Endpoint with trailing slash should still work.
+	client := NewClient(Config{
+		Endpoint: server.URL + "/",
+		Model:    "test",
+	})
+
+	result, err := client.ChatCompletion(context.Background(), []Message{{Role: "user", Content: "hi"}})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result)
+}
+
+func TestClient_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// This handler will never respond in time.
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{
+		Endpoint: server.URL,
+		Model:    "test",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	_, err := client.ChatCompletion(ctx, []Message{{Role: "user", Content: "hi"}})
+	require.Error(t, err)
+}


### PR DESCRIPTION
Closes #52

## Summary
- Created `llm/client.go` with `Config`, `Client`, `Message`, `Request`, `Response`, `Choice` types and `ChatCompletion()` method
- Refactored `enrich/model.go` to import `llm.Client` instead of inline chat types; `ModelExtractor` now holds `*llm.Client`
- Added `llm/client_test.go` with table-driven httptest.Server tests covering success, auth, error status, no choices, invalid JSON, trailing slash, and context cancellation

## Self-Check Results

### AC Verification
- [x] `llm/client.go` exists with `Config`, `Client`, `Message` types and `ChatCompletion()` method
- [x] `enrich/model.go` imports `llm.Client`; `ModelExtractor` holds `*llm.Client`
- [x] `go test ./enrich/...` passes — all 19 tests pass (no regression)
- [x] `go test ./llm/...` passes — 7 test cases with httptest.Server mock
- [x] `go vet ./...` clean, no import cycles
- [x] Public API of `enrich` package unchanged (`NewModelExtractor`, `Extract`, `GenerateSummary` signatures identical)

### Test Output
```
ok  github.com/KHAEntertainment/markedup/llm      0.179s
ok  github.com/KHAEntertainment/markedup/enrich    0.169s
```
Full suite (`go test ./...`): all 13 packages pass.

## Test plan
- [x] `go test ./llm/...` — new package tests pass
- [x] `go test ./enrich/...` — existing tests pass with no regressions
- [x] `go test ./...` — full suite passes
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable chat completion client library for integrating with OpenAI-compatible language models

* **Refactor**
  * Updated model extraction to use the new shared client library for improved maintainability

* **Tests**
  * Added comprehensive test coverage for the chat completion client, including error handling and configuration validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->