### PR TITLE
[#55] KHA-278 markedup_reason MCP tool — LLM graph reasoning

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/KHAEntertainment/markedup/cache"
 	"github.com/KHAEntertainment/markedup/embed"
 	"github.com/KHAEntertainment/markedup/index"
+	"github.com/KHAEntertainment/markedup/llm"
 	"github.com/KHAEntertainment/markedup/rerank"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -38,6 +40,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	srv := &mcpServer{idx: result.Index, path: path}
 
+	// Initialize LLM client from environment variables if configured.
+	if ep := os.Getenv("MARKEDUP_LLM_ENDPOINT"); ep != "" {
+		if model := os.Getenv("MARKEDUP_LLM_MODEL"); model != "" {
+			srv.llmClient = llm.NewClient(llm.Config{
+				Endpoint: ep,
+				Model:    model,
+				APIKey:   os.Getenv("MARKEDUP_LLM_API_KEY"),
+			})
+		}
+	}
+
 	s := server.NewMCPServer("markedup", "0.1.0",
 		server.WithToolCapabilities(true),
 	)
@@ -48,14 +61,16 @@ func runServe(cmd *cobra.Command, args []string) error {
 	s.AddTool(srv.getStructureToolDef(), srv.toolGetStructure)
 	s.AddTool(srv.embedStatusToolDef(), srv.toolEmbedStatus)
 	s.AddTool(srv.embedFileToolDef(), srv.toolEmbedFile)
+	s.AddTool(srv.reasonToolDef(), srv.toolReason)
 
 	return server.ServeStdio(s)
 }
 
 type mcpServer struct {
-	idx      *index.KnowledgeIndex
-	path     string         // project root directory
-	embedder embed.Embedder // optional; nil if not configured
+	idx       *index.KnowledgeIndex
+	path      string         // project root directory
+	embedder  embed.Embedder // optional; nil if not configured
+	llmClient *llm.Client    // optional; nil if LLM env vars not set
 }
 
 // Tool definitions.
@@ -320,4 +335,211 @@ func (s *mcpServer) toolEmbedFile(ctx context.Context, request mcp.CallToolReque
 	}
 	b, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(b)), nil
+}
+
+func (s *mcpServer) reasonToolDef() mcp.Tool {
+	return mcp.NewTool("markedup_reason",
+		mcp.WithDescription("Use LLM reasoning to answer multi-hop, structural, or dependency questions about the knowledge graph. Call this when keyword search is insufficient — e.g. 'who is connected to Alice through projects?' or 'what are the main topic clusters?'"),
+		mcp.WithString("query",
+			mcp.Required(),
+			mcp.Description("The question to reason about using the knowledge graph structure"),
+		),
+		mcp.WithNumber("max_pages",
+			mcp.Description("Maximum pages to include in graph summary sent to LLM (default 20)"),
+		),
+		mcp.WithBoolean("include_relationships",
+			mcp.Description("Include relationship edges in graph summary (default true)"),
+		),
+		mcp.WithBoolean("include_temporal",
+			mcp.Description("Include temporal metadata (valid-from, valid-until, last-verified) in graph summary (default false)"),
+		),
+	)
+}
+
+// reasoningLLMResponse is the expected JSON structure from the LLM.
+type reasoningLLMResponse struct {
+	Thinking          string   `json:"thinking"`
+	PageIDs           []string `json:"page_ids"`
+	RelationshipPaths []string `json:"relationship_paths"`
+}
+
+// reasoningResult is the final response returned to the MCP caller.
+type reasoningResult struct {
+	Reasoning reasoningReasoning `json:"reasoning"`
+	Pages     []reasoningPage    `json:"pages"`
+}
+
+type reasoningReasoning struct {
+	Thinking          string   `json:"thinking"`
+	RelationshipPaths []string `json:"relationship_paths"`
+}
+
+type reasoningPage struct {
+	ID         string `json:"id"`
+	Title      string `json:"title"`
+	EntityType string `json:"entity_type"`
+	Body       string `json:"body"`
+}
+
+func (s *mcpServer) toolReason(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	var params struct {
+		Query                string  `json:"query"`
+		MaxPages             float64 `json:"max_pages"`
+		IncludeRelationships *bool   `json:"include_relationships"`
+		IncludeTemporal      bool    `json:"include_temporal"`
+	}
+	if err := request.BindArguments(&params); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Invalid arguments: %s", err.Error())), nil
+	}
+
+	if params.Query == "" {
+		return mcp.NewToolResultError("query is required"), nil
+	}
+
+	if s.llmClient == nil {
+		return mcp.NewToolResultError("LLM not configured. Set MARKEDUP_LLM_ENDPOINT and MARKEDUP_LLM_MODEL environment variables."), nil
+	}
+
+	maxPages := int(params.MaxPages)
+	if maxPages <= 0 {
+		maxPages = 20
+	}
+
+	// Build summary options.
+	var summaryOpts []index.SummaryOption
+	if params.IncludeRelationships != nil && !*params.IncludeRelationships {
+		summaryOpts = append(summaryOpts, index.WithRelationships(false))
+	}
+	if params.IncludeTemporal {
+		summaryOpts = append(summaryOpts, index.WithTemporal(true))
+	}
+
+	// Token budget management: pre-filter if graph is too large.
+	allPages := s.idx.All()
+	if len(allPages) > maxPages {
+		// Pre-filter with keyword search, then expand 1-hop neighbors.
+		results := index.Search(s.idx, params.Query)
+		limit := maxPages
+		if len(results) < limit {
+			limit = len(results)
+		}
+
+		idSet := make(map[string]struct{})
+		for _, r := range results[:limit] {
+			idSet[r.Page.Frontmatter.ID] = struct{}{}
+		}
+
+		// Expand 1-hop neighbors.
+		var toExpand []string
+		for id := range idSet {
+			toExpand = append(toExpand, id)
+		}
+		for _, id := range toExpand {
+			for _, rel := range s.idx.ForwardRels(id) {
+				idSet[rel.Target] = struct{}{}
+			}
+			for _, refID := range s.idx.ReverseRefs(id) {
+				idSet[refID] = struct{}{}
+			}
+		}
+
+		ids := make([]string, 0, len(idSet))
+		for id := range idSet {
+			ids = append(ids, id)
+		}
+		summaryOpts = append(summaryOpts, index.WithPageIDs(ids))
+	}
+
+	summary := s.idx.CompactGraphSummary(summaryOpts...)
+
+	graphJSON, err := json.Marshal(summary)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal graph summary: %s", err.Error())), nil
+	}
+
+	// Build graph navigation prompt.
+	userPrompt := fmt.Sprintf(`You are given a question and the structure of a knowledge graph.
+Each node represents a markdown page with metadata. Edges represent typed relationships between pages.
+
+Your task: identify which pages are most likely to contain or contribute to answering the question.
+Consider relationship chains, entity types, temporal validity, and confidence scores.
+
+Question: %s
+
+Knowledge graph structure:
+%s
+
+Reply in JSON:
+{
+  "thinking": "Your reasoning about which pages are relevant and why, considering the graph structure",
+  "page_ids": ["id1", "id2"],
+  "relationship_paths": ["id1 --type--> id2"]
+}`, params.Query, string(graphJSON))
+
+	messages := []llm.Message{
+		{Role: "system", Content: "You are a knowledge graph reasoning assistant."},
+		{Role: "user", Content: userPrompt},
+	}
+
+	llmContent, err := s.llmClient.ChatCompletion(ctx, messages)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("LLM request failed: %s", err.Error())), nil
+	}
+
+	// Parse LLM response with lenient JSON handling.
+	var llmResp reasoningLLMResponse
+	cleaned := stripMarkdownFences(llmContent)
+	if err := json.Unmarshal([]byte(cleaned), &llmResp); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to parse LLM response: %s\nRaw output: %s", err.Error(), truncateStr(llmContent, 500))), nil
+	}
+
+	// Fetch full pages for each page_id.
+	var pages []reasoningPage
+	for _, id := range llmResp.PageIDs {
+		page, ok := s.idx.Get(id)
+		if !ok {
+			continue // skip unknown page IDs from the LLM
+		}
+		pages = append(pages, reasoningPage{
+			ID:         page.Frontmatter.ID,
+			Title:      page.Frontmatter.Title,
+			EntityType: page.Frontmatter.EntityType,
+			Body:       page.Body,
+		})
+	}
+
+	result := reasoningResult{
+		Reasoning: reasoningReasoning{
+			Thinking:          llmResp.Thinking,
+			RelationshipPaths: llmResp.RelationshipPaths,
+		},
+		Pages: pages,
+	}
+
+	b, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal result: %s", err.Error())), nil
+	}
+
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+// stripMarkdownFences removes markdown code fences (```json ... ```) from LLM output.
+func stripMarkdownFences(content string) string {
+	content = strings.TrimSpace(content)
+	if strings.HasPrefix(content, "```") {
+		lines := strings.Split(content, "\n")
+		if len(lines) >= 3 {
+			content = strings.Join(lines[1:len(lines)-1], "\n")
+		}
+	}
+	return strings.TrimSpace(content)
+}
+
+// truncateStr returns the first maxLen characters of s, appending "..." if truncated.
+func truncateStr(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -3,9 +3,14 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/KHAEntertainment/markedup/index"
+	"github.com/KHAEntertainment/markedup/llm"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -316,4 +321,234 @@ func TestMCP_IndexFromTestdata(t *testing.T) {
 	require.True(t, ok, "index should contain alice page")
 	assert.Equal(t, "Alice Chen", page.Frontmatter.Title)
 	assert.Equal(t, "person", page.Frontmatter.EntityType)
+}
+
+// ---------------------------------------------------------------------------
+// markedup_reason
+// ---------------------------------------------------------------------------
+
+// mockLLMServer creates an httptest.Server that returns canned LLM responses.
+// It captures the last request body for assertion.
+func mockLLMServer(t *testing.T, response string) (*httptest.Server, *string) {
+	t.Helper()
+	var lastBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture request body for assertions.
+		bodyBytes, _ := io.ReadAll(r.Body)
+		lastBody = string(bodyBytes)
+
+		resp := fmt.Sprintf(`{"choices":[{"message":{"role":"assistant","content":%s}}]}`, response)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	return ts, &lastBody
+}
+
+func testMCPServerWithLLM(t *testing.T, endpoint, model string) *mcpServer {
+	t.Helper()
+	srv := testMCPServer(t)
+	srv.llmClient = llm.NewClient(llm.Config{
+		Endpoint: endpoint,
+		Model:    model,
+	})
+	return srv
+}
+
+func TestMCP_Reason_ToolDef(t *testing.T) {
+	srv := testMCPServer(t)
+	def := srv.reasonToolDef()
+
+	assert.Equal(t, "markedup_reason", def.Name)
+	assert.NotEmpty(t, def.Description)
+	assert.ElementsMatch(t, []string{"query"}, def.InputSchema.Required)
+
+	_, hasQuery := def.InputSchema.Properties["query"]
+	assert.True(t, hasQuery, "should have query param")
+	_, hasMaxPages := def.InputSchema.Properties["max_pages"]
+	assert.True(t, hasMaxPages, "should have max_pages param")
+	_, hasRels := def.InputSchema.Properties["include_relationships"]
+	assert.True(t, hasRels, "should have include_relationships param")
+	_, hasTemporal := def.InputSchema.Properties["include_temporal"]
+	assert.True(t, hasTemporal, "should have include_temporal param")
+}
+
+func TestMCP_Reason_NoLLMConfigured(t *testing.T) {
+	srv := testMCPServer(t)
+	ctx := context.Background()
+
+	result, err := srv.toolReason(ctx, callToolReq(map[string]any{"query": "who works with alice?"}))
+	require.NoError(t, err, "should not return Go error")
+	require.True(t, result.IsError, "should return MCP error when LLM not configured")
+
+	text := resultText(t, result)
+	assert.Contains(t, text, "LLM not configured")
+	assert.Contains(t, text, "MARKEDUP_LLM_ENDPOINT")
+}
+
+func TestMCP_Reason_EmptyQuery(t *testing.T) {
+	srv := testMCPServer(t)
+	ctx := context.Background()
+
+	result, err := srv.toolReason(ctx, callToolReq(map[string]any{"query": ""}))
+	require.NoError(t, err)
+	require.True(t, result.IsError, "empty query should return error")
+
+	text := resultText(t, result)
+	assert.Contains(t, text, "required")
+}
+
+func TestMCP_Reason_HappyPath(t *testing.T) {
+	// Canned LLM response.
+	cannedJSON := `"{\"thinking\":\"Alice is connected to Bob through project-alpha.\",\"page_ids\":[\"alice\",\"bob\"],\"relationship_paths\":[\"alice --colleague--> bob\"]}"`
+	ts, lastBody := mockLLMServer(t, cannedJSON)
+	defer ts.Close()
+
+	srv := testMCPServerWithLLM(t, ts.URL, "test-model")
+	ctx := context.Background()
+
+	result, err := srv.toolReason(ctx, callToolReq(map[string]any{"query": "who works with alice?"}))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "happy path should not return error")
+
+	text := resultText(t, result)
+
+	// Verify response structure.
+	var parsed reasoningResult
+	require.NoError(t, json.Unmarshal([]byte(text), &parsed), "result should be valid JSON")
+
+	assert.Equal(t, "Alice is connected to Bob through project-alpha.", parsed.Reasoning.Thinking)
+	assert.Contains(t, parsed.Reasoning.RelationshipPaths, "alice --colleague--> bob")
+	assert.Len(t, parsed.Pages, 2, "should have 2 pages (alice, bob)")
+
+	// Verify pages have full content.
+	pageIDs := make([]string, len(parsed.Pages))
+	for i, p := range parsed.Pages {
+		pageIDs[i] = p.ID
+		assert.NotEmpty(t, p.Title, "page should have title")
+		assert.NotEmpty(t, p.Body, "page should have body content")
+	}
+	assert.Contains(t, pageIDs, "alice")
+	assert.Contains(t, pageIDs, "bob")
+
+	// Verify prompt construction: last request body should contain the query and graph JSON.
+	assert.Contains(t, *lastBody, "who works with alice?", "prompt should contain the query")
+	assert.Contains(t, *lastBody, "knowledge graph", "prompt should reference knowledge graph")
+}
+
+func TestMCP_Reason_MarkdownFencesStripped(t *testing.T) {
+	// LLM response wrapped in markdown fences.
+	cannedJSON := "\"```json\\n{\\\"thinking\\\":\\\"test\\\",\\\"page_ids\\\":[\\\"alice\\\"],\\\"relationship_paths\\\":[]}\\n```\""
+	ts, _ := mockLLMServer(t, cannedJSON)
+	defer ts.Close()
+
+	srv := testMCPServerWithLLM(t, ts.URL, "test-model")
+	ctx := context.Background()
+
+	result, err := srv.toolReason(ctx, callToolReq(map[string]any{"query": "test query"}))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "should handle markdown fences gracefully")
+
+	text := resultText(t, result)
+	var parsed reasoningResult
+	require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+	assert.Equal(t, "test", parsed.Reasoning.Thinking)
+	assert.Len(t, parsed.Pages, 1)
+}
+
+func TestMCP_Reason_InvalidLLMResponse(t *testing.T) {
+	// LLM returns garbage.
+	cannedJSON := `"this is not json at all"`
+	ts, _ := mockLLMServer(t, cannedJSON)
+	defer ts.Close()
+
+	srv := testMCPServerWithLLM(t, ts.URL, "test-model")
+	ctx := context.Background()
+
+	result, err := srv.toolReason(ctx, callToolReq(map[string]any{"query": "test query"}))
+	require.NoError(t, err, "should not return Go error")
+	require.True(t, result.IsError, "invalid LLM response should return MCP error")
+
+	text := resultText(t, result)
+	assert.Contains(t, text, "Failed to parse LLM response")
+	assert.Contains(t, text, "this is not json at all", "error should include raw output for debugging")
+}
+
+func TestMCP_Reason_UnknownPageIDs(t *testing.T) {
+	// LLM returns page IDs that don't exist in the index — should be skipped gracefully.
+	cannedJSON := `"{\"thinking\":\"found stuff\",\"page_ids\":[\"alice\",\"nonexistent_xyz\"],\"relationship_paths\":[]}"`
+	ts, _ := mockLLMServer(t, cannedJSON)
+	defer ts.Close()
+
+	srv := testMCPServerWithLLM(t, ts.URL, "test-model")
+	ctx := context.Background()
+
+	result, err := srv.toolReason(ctx, callToolReq(map[string]any{"query": "test"}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	text := resultText(t, result)
+	var parsed reasoningResult
+	require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+	assert.Len(t, parsed.Pages, 1, "should only return alice, skipping nonexistent")
+	assert.Equal(t, "alice", parsed.Pages[0].ID)
+}
+
+func TestMCP_Reason_PreFilterPath(t *testing.T) {
+	// Use max_pages=1 to force pre-filtering (testdata has 6 pages).
+	cannedJSON := `"{\"thinking\":\"filtered\",\"page_ids\":[\"alice\"],\"relationship_paths\":[]}"`
+	ts, lastBody := mockLLMServer(t, cannedJSON)
+	defer ts.Close()
+
+	srv := testMCPServerWithLLM(t, ts.URL, "test-model")
+	ctx := context.Background()
+
+	result, err := srv.toolReason(ctx, callToolReq(map[string]any{
+		"query":     "alice",
+		"max_pages": float64(1),
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	// The prompt should contain a graph summary — verify it was sent.
+	assert.Contains(t, *lastBody, "alice", "pre-filtered prompt should include alice")
+
+	text := resultText(t, result)
+	var parsed reasoningResult
+	require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+	assert.Equal(t, "filtered", parsed.Reasoning.Thinking)
+}
+
+func TestStripMarkdownFences(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no fences",
+			input:    `{"thinking": "test"}`,
+			expected: `{"thinking": "test"}`,
+		},
+		{
+			name:     "json fences",
+			input:    "```json\n{\"thinking\": \"test\"}\n```",
+			expected: `{"thinking": "test"}`,
+		},
+		{
+			name:     "plain fences",
+			input:    "```\n{\"thinking\": \"test\"}\n```",
+			expected: `{"thinking": "test"}`,
+		},
+		{
+			name:     "whitespace around fences",
+			input:    "  \n```json\n{\"thinking\": \"test\"}\n```\n  ",
+			expected: `{"thinking": "test"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, stripMarkdownFences(tt.input))
+		})
+	}
 }


### PR DESCRIPTION
Closes #55

## Summary
- Adds `markedup_reason` as the 7th MCP tool in `serve.go`, enabling LLM-powered graph reasoning for multi-hop, structural, and dependency questions
- Initializes `llmClient` from `MARKEDUP_LLM_ENDPOINT`/`MARKEDUP_LLM_MODEL`/`MARKEDUP_LLM_API_KEY` env vars
- Implements token budget management with pre-filter path (keyword search + 1-hop neighbor expansion) for large graphs
- Lenient JSON parsing strips markdown fences from LLM responses (same pattern as `enrich/model.go`)

## Files Changed
- `internal/cli/serve.go` — `llmClient` field, `reasonToolDef()`, `toolReason()` handler, `stripMarkdownFences()` helper
- `internal/cli/serve_test.go` — 9 new test functions with `httptest.Server` mock LLM

## Self-Check Results

### Acceptance Criteria
- [x] `markedup_reason` registered as 7th MCP tool
- [x] Params: `query` (required), `max_pages` (opt, default 20), `include_relationships` (opt, default true), `include_temporal` (opt, default false)
- [x] No LLM configured → "LLM not configured. Set MARKEDUP_LLM_ENDPOINT and MARKEDUP_LLM_MODEL environment variables."
- [x] With LLM → JSON with `reasoning.thinking`, `reasoning.relationship_paths`, `pages[]` (full content)
- [x] Pre-filter triggers when `len(idx.All()) > max_pages`
- [x] Small graph uses `CompactGraphSummary()` directly
- [x] Graph navigation prompt matches design doc template
- [x] Lenient JSON parsing strips markdown fences
- [x] Unit tests with `httptest.Server` mock
- [x] `go test ./internal/cli/...` passes (all 39 tests)

### Test Output
```
go test ./... — all 13 packages PASS
go vet ./... — clean
go build ./... — clean
```

### New Tests
- `TestMCP_Reason_ToolDef` — tool definition params
- `TestMCP_Reason_NoLLMConfigured` — error path
- `TestMCP_Reason_EmptyQuery` — validation
- `TestMCP_Reason_HappyPath` — full flow with mock LLM
- `TestMCP_Reason_MarkdownFencesStripped` — lenient parsing
- `TestMCP_Reason_InvalidLLMResponse` — malformed LLM output
- `TestMCP_Reason_UnknownPageIDs` — graceful skip of bad IDs
- `TestMCP_Reason_PreFilterPath` — token budget pre-filter
- `TestStripMarkdownFences` — table-driven unit test