### PR TITLE
docs: Wave 2 PROJECT_CONTEXT update

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -26,7 +26,7 @@
 - **Cache architecture**: Two-tier `.knowledge/` sidecar — graph tier (gob-encoded index + SHA-256 checksums) + vector tier (binary float32 per file + meta.json for model tracking)
 - **Auth config**: API key immediate, OAuth token field reserved for future OpenRouter browser auth integration
 - **TUI framework**: BubbleTea + Lip Gloss + Bubbles (charmbracelet ecosystem)
-- **New packages**: `embed/`, `rerank/`, `cache/`, `internal/tui/`
+- **New packages**: `embed/`, `rerank/`, `cache/`, `internal/tui/`, `llm/`
 
 ## Code Style Conventions
 - **Naming**: Go standard (PascalCase exports, camelCase internal)
@@ -94,20 +94,25 @@
 - [x] E2E tests + smoke script + docs for local model endpoints (PR #49, merged 2026-04-13, KHA-281)
 - [x] Triplex-native prompt format + entities_and_triples parser (PR #50, merged 2026-04-13, KHA-284)
 
+### Wave 2 — Graph Reasoning + Local Reranker
+- [x] Extract shared `llm/` package from `enrich/model.go` (PR #59, merged 2026-04-14)
+- [x] Add `Summary` field to `SummaryNode` + `WithPageIDs` option (PR #57, merged 2026-04-14)
+- [x] KHA-283: Local reranker format config — `--rerank-format` flag + `MARKEDUP_RERANK_FORMAT` env var + docs (PR #58, merged 2026-04-14)
+- [x] KHA-278: `markedup_reason` MCP tool — LLM graph reasoning (PR #60, merged 2026-04-14)
+- [x] E2E test for `markedup_reason` (PR #61, merged 2026-04-14)
+
 ## Current Status
-- **Last updated**: 2026-04-13
-- **Current iteration goal**: Wave 1.5 complete (KHA-284 resolved), Wave 2 (markedup_reason) next
-- **Known tech debt**: `show` command 1-arg ambiguity (path vs id heuristic); go.mod at go 1.25 (plan said 1.22+); VectorCacheLookup interface in index/search.go to avoid import cycle; `SummaryNode` in graph_summary.go missing `Summary` field (needs connecting KHA-275 + KHA-276 output)
+- **Last updated**: 2026-04-14
+- **Current iteration goal**: Wave 2 complete (KHA-278 + KHA-283 resolved), Wave 3 next
+- **Known tech debt**: `show` command 1-arg ambiguity (path vs id heuristic); go.mod at go 1.25 (plan said 1.22+); VectorCacheLookup interface in index/search.go to avoid import cycle
 - **CRITICAL GAP**: Files without frontmatter are silently skipped by index.Load() — the entire pipeline requires manual frontmatter authoring, making markedup unusable for existing markdown corpora
-- **MCP server**: Now uses `mark3labs/mcp-go` v0.47.1 SDK. 6 tools: `markedup_search`, `markedup_get_page`, `markedup_traverse`, `markedup_get_structure`, `embed_status`, `embed_file`. Integration tests in serve_test.go.
-- **New packages/files**: `index/graph_summary.go` (CompactGraphSummary), `internal/cli/export.go` (export --compact command)
-- **Schema additions**: `Summary string` field in `GraphFrontmatter`; `GenerateSummary()` in enrich Tier 2
-- **Local model E2E**: `e2e_localmodel_test.go` (`//go:build localmodel`), `scripts/smoke-test.sh`, `docs/local-testing.md`. New env vars: `MARKEDUP_LLM_ENDPOINT/MODEL`, `MARKEDUP_TRIPLEX_ENDPOINT/MODEL` (in addition to existing `MARKEDUP_EMBED_*` and `MARKEDUP_RERANK_*`)
+- **MCP server**: Now uses `mark3labs/mcp-go` v0.47.1 SDK. **7 tools**: `markedup_search`, `markedup_get_page`, `markedup_traverse`, `markedup_get_structure`, `embed_status`, `embed_file`, `markedup_reason`. Integration tests in serve_test.go (9 new reason tests).
+- **New packages**: `llm/` (shared OpenAI-compatible chat completion client), `index/graph_summary.go` (CompactGraphSummary with Summary + WithPageIDs), `internal/cli/rerank_format.go`
+- **Schema additions**: `Summary string` field in `GraphFrontmatter` and `SummaryNode`; `GenerateSummary()` in enrich Tier 2
+- **Local model E2E**: `e2e_localmodel_test.go` (`//go:build localmodel`), `scripts/smoke-test.sh`, `docs/local-testing.md`. **6 E2E tests** (embed, summary, extract-llm, extract-triplex, rerank, reason). Env vars: `MARKEDUP_LLM_ENDPOINT/MODEL`, `MARKEDUP_TRIPLEX_ENDPOINT/MODEL`, `MARKEDUP_EMBED_*`, `MARKEDUP_RERANK_*`, `MARKEDUP_RERANK_FORMAT`
 - **Open PRs**: none
 - **PageIndex investigation**: COMPLETE — Full research in `docs/design-pageindex-research.md`.
 - **Queued — Next up** (Linear project: MarkedUp — Knowledge Graph CLI):
-  - KHA-278: `markedup_reason` — LLM graph reasoning MCP tool (Wave 2, High priority; prereq: add `Summary` field to `SummaryNode` in graph_summary.go; design doc: `docs/design-graph-reasoning-tool.md`)
-  - KHA-283: Local reranker support — Granite Rerank via TEI (Wave 2, Medium)
   - KHA-279: Config file (.markedup.yaml) (Wave 3)
   - KHA-280: OpenRouter OAuth browser auth (Future)
   - KHA-282: Remote model E2E testing — OpenRouter + HF Inference Endpoints (Wave 1.5, owner: human)


### PR DESCRIPTION
## Summary

- Updated completed features with Wave 2 items (PRs #57-#61)
- Updated current status: 7 MCP tools, 6 E2E tests, llm/ package
- Removed KHA-278 and KHA-283 from queued items (completed)
- Removed SummaryNode tech debt item (resolved by PR #57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)