### PR TITLE
feat: [Issue #68] config/ model pull helpers — Ollama + HuggingFace

### DIFF
--- a/config/pull.go
+++ b/config/pull.go
@@ -1,0 +1,60 @@
+// Package config provides configuration helpers for the markedup CLI,
+// including model download utilities for Ollama and HuggingFace.
+package config
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+// execCommand is the function used to create exec.Cmd instances.
+// It can be overridden in tests to mock command execution.
+var execCommand = exec.CommandContext
+
+// lookPath is the function used to check if a binary exists in PATH.
+// It can be overridden in tests to mock binary detection.
+var lookPath = exec.LookPath
+
+// OllamaAvailable reports whether the ollama CLI binary is in PATH.
+func OllamaAvailable() bool {
+	_, err := lookPath("ollama")
+	return err == nil
+}
+
+// HFAvailable reports whether the hf CLI binary is in PATH.
+func HFAvailable() bool {
+	_, err := lookPath("hf")
+	return err == nil
+}
+
+// OllamaPull runs "ollama pull <model>" and streams output to w.
+// The process is terminated if ctx is cancelled.
+func OllamaPull(ctx context.Context, model string, w io.Writer) error {
+	if !OllamaAvailable() {
+		return fmt.Errorf("ollama binary not found in PATH: %w", exec.ErrNotFound)
+	}
+	cmd := execCommand(ctx, "ollama", "pull", model)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("ollama pull %s: %w", model, err)
+	}
+	return nil
+}
+
+// HFPull runs "hf download <model>" and streams output to w.
+// The process is terminated if ctx is cancelled.
+func HFPull(ctx context.Context, model string, w io.Writer) error {
+	if !HFAvailable() {
+		return fmt.Errorf("hf binary not found in PATH: %w", exec.ErrNotFound)
+	}
+	cmd := execCommand(ctx, "hf", "download", model)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("hf download %s: %w", model, err)
+	}
+	return nil
+}

--- a/config/pull_test.go
+++ b/config/pull_test.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// restoreGlobals saves and restores the package-level function variables
+// so tests don't leak state.
+func restoreGlobals(t *testing.T) {
+	t.Helper()
+	origExecCommand := execCommand
+	origLookPath := lookPath
+	t.Cleanup(func() {
+		execCommand = origExecCommand
+		lookPath = origLookPath
+	})
+}
+
+// --- OllamaAvailable / HFAvailable ---
+
+func TestOllamaAvailable_True(t *testing.T) {
+	restoreGlobals(t)
+	lookPath = func(file string) (string, error) {
+		if file == "ollama" {
+			return "/usr/local/bin/ollama", nil
+		}
+		return "", exec.ErrNotFound
+	}
+	if !OllamaAvailable() {
+		t.Fatal("expected OllamaAvailable() == true when ollama is in PATH")
+	}
+}
+
+func TestOllamaAvailable_False(t *testing.T) {
+	restoreGlobals(t)
+	lookPath = func(string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+	if OllamaAvailable() {
+		t.Fatal("expected OllamaAvailable() == false when ollama is not in PATH")
+	}
+}
+
+func TestHFAvailable_True(t *testing.T) {
+	restoreGlobals(t)
+	lookPath = func(file string) (string, error) {
+		if file == "hf" {
+			return "/usr/local/bin/hf", nil
+		}
+		return "", exec.ErrNotFound
+	}
+	if !HFAvailable() {
+		t.Fatal("expected HFAvailable() == true when hf is in PATH")
+	}
+}
+
+func TestHFAvailable_False(t *testing.T) {
+	restoreGlobals(t)
+	lookPath = func(string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+	if HFAvailable() {
+		t.Fatal("expected HFAvailable() == false when hf is not in PATH")
+	}
+}
+
+// --- OllamaPull ---
+
+func TestOllamaPull_BinaryNotFound(t *testing.T) {
+	restoreGlobals(t)
+	lookPath = func(string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+	err := OllamaPull(context.Background(), "llama3", &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error when ollama binary is not found")
+	}
+	if !errorContains(err, "ollama binary not found") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestOllamaPull_StreamsOutput(t *testing.T) {
+	restoreGlobals(t)
+	lookPath = func(file string) (string, error) {
+		if file == "ollama" {
+			return "/usr/local/bin/ollama", nil
+		}
+		return "", exec.ErrNotFound
+	}
+	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		// Verify arguments
+		if name != "ollama" || len(args) != 2 || args[0] != "pull" || args[1] != "llama3" {
+			t.Fatalf("unexpected command: %s %v", name, args)
+		}
+		return exec.CommandContext(ctx, "echo", "pulling llama3...")
+	}
+
+	var buf bytes.Buffer
+	if err := OllamaPull(context.Background(), "llama3", &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("expected output to be streamed to writer")
+	}
+}
+
+// --- HFPull ---
+
+func TestHFPull_BinaryNotFound(t *testing.T) {
+	restoreGlobals(t)
+	lookPath = func(string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+	err := HFPull(context.Background(), "some/model", &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error when hf binary is not found")
+	}
+	if !errorContains(err, "hf binary not found") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestHFPull_StreamsOutput(t *testing.T) {
+	restoreGlobals(t)
+	lookPath = func(file string) (string, error) {
+		if file == "hf" {
+			return "/usr/local/bin/hf", nil
+		}
+		return "", exec.ErrNotFound
+	}
+	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if name != "hf" || len(args) != 2 || args[0] != "download" || args[1] != "some/model" {
+			t.Fatalf("unexpected command: %s %v", name, args)
+		}
+		return exec.CommandContext(ctx, "echo", "downloading some/model...")
+	}
+
+	var buf bytes.Buffer
+	if err := HFPull(context.Background(), "some/model", &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("expected output to be streamed to writer")
+	}
+}
+
+// --- Context cancellation ---
+
+func TestOllamaPull_ContextCancellation(t *testing.T) {
+	restoreGlobals(t)
+	lookPath = func(file string) (string, error) {
+		if file == "ollama" {
+			return "/usr/local/bin/ollama", nil
+		}
+		return "", exec.ErrNotFound
+	}
+	execCommand = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		// Use sleep to simulate a long-running process that can be cancelled
+		return exec.CommandContext(ctx, "sleep", "30")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := OllamaPull(ctx, "llama3", &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+func TestHFPull_ContextCancellation(t *testing.T) {
+	restoreGlobals(t)
+	lookPath = func(file string) (string, error) {
+		if file == "hf" {
+			return "/usr/local/bin/hf", nil
+		}
+		return "", exec.ErrNotFound
+	}
+	execCommand = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sleep", "30")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := HFPull(ctx, "some/model", &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+// errorContains checks if an error's message contains a substring.
+func errorContains(err error, substr string) bool {
+	if err == nil {
+		return false
+	}
+	return bytes.Contains([]byte(err.Error()), []byte(substr))
+}


### PR DESCRIPTION
## Summary

- Adds `config/pull.go` with `OllamaAvailable()`, `HFAvailable()`, `OllamaPull()`, and `HFPull()` helpers
- Uses `exec.LookPath` for binary detection and `exec.CommandContext` for cancellation support
- Returns wrapped errors when CLI binaries are not found
- Streams stdout/stderr to the provided `io.Writer`

## Acceptance Criteria Status

- [x] `config.OllamaAvailable() bool` checks if `ollama` binary is in PATH
- [x] `config.HFAvailable() bool` checks if `hf` binary is in PATH
- [x] `config.OllamaPull(ctx, model, w)` runs `ollama pull <model>`, streams output to writer
- [x] `config.HFPull(ctx, model, w)` runs `hf download <model>`, streams output to writer
- [x] Context cancellation terminates the pull process
- [x] Returns wrapped error if CLI binary not found
- [x] Tests use mocked exec (do not actually pull models)
- [x] `go test ./config/...` passes (10/10)
- [x] `go vet ./...` clean

## Test Output

```
=== RUN   TestOllamaAvailable_True       --- PASS
=== RUN   TestOllamaAvailable_False      --- PASS
=== RUN   TestHFAvailable_True           --- PASS
=== RUN   TestHFAvailable_False          --- PASS
=== RUN   TestOllamaPull_BinaryNotFound  --- PASS
=== RUN   TestOllamaPull_StreamsOutput   --- PASS
=== RUN   TestHFPull_BinaryNotFound      --- PASS
=== RUN   TestHFPull_StreamsOutput       --- PASS
=== RUN   TestOllamaPull_ContextCancellation --- PASS
=== RUN   TestHFPull_ContextCancellation --- PASS
PASS  ok  github.com/KHAEntertainment/markedup/config  0.268s
```

## Test plan

- [x] Verify availability checks return correct bool for present/absent binaries
- [x] Verify pull functions return wrapped error when binary missing
- [x] Verify output is streamed to the provided writer
- [x] Verify context cancellation terminates long-running processes

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model download and availability checking for Ollama and HuggingFace platforms, allowing users to fetch pre-trained models from these sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->