### PR TITLE
feat: [Issue #67] config/ auto-detect local endpoints

### DIFF
--- a/config/detect.go
+++ b/config/detect.go
@@ -1,0 +1,262 @@
+// Package config provides configuration management for markedup, including
+// auto-detection of local model serving endpoints.
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Endpoint describes a discovered local model-serving endpoint.
+type Endpoint struct {
+	Name    string   // "Ollama", "LM Studio", "TEI", "vLLM", "llama.cpp"
+	URL     string   // e.g. "http://localhost:11434"
+	Type    string   // "embed", "llm", "rerank", "multi"
+	Healthy bool
+	Models  []string // populated when the service exposes a models API
+}
+
+// probeSpec defines how to detect a single local service.
+type probeSpec struct {
+	Name         string
+	Port         int
+	ProbePath    string
+	SuccessCheck func(statusCode int, body []byte) bool
+	Type         string
+	ModelsPath   string
+	ParseModels  func(body []byte) []string
+}
+
+// defaultProbes is the canonical probe table. Tests override the Port field
+// to point at httptest servers.
+var defaultProbes = []probeSpec{
+	{
+		Name:      "Ollama",
+		Port:      11434,
+		ProbePath: "/",
+		SuccessCheck: func(statusCode int, body []byte) bool {
+			return statusCode == http.StatusOK && strings.Contains(string(body), "Ollama is running")
+		},
+		Type:       "multi",
+		ModelsPath: "/api/tags",
+		ParseModels: func(body []byte) []string {
+			var resp struct {
+				Models []struct {
+					Name string `json:"name"`
+				} `json:"models"`
+			}
+			if err := json.Unmarshal(body, &resp); err != nil {
+				return nil
+			}
+			names := make([]string, 0, len(resp.Models))
+			for _, m := range resp.Models {
+				names = append(names, m.Name)
+			}
+			return names
+		},
+	},
+	{
+		Name:      "LM Studio",
+		Port:      1234,
+		ProbePath: "/v1/models",
+		SuccessCheck: func(statusCode int, _ []byte) bool {
+			return statusCode == http.StatusOK
+		},
+		Type:       "multi",
+		ModelsPath: "", // same as probe path
+		ParseModels: func(body []byte) []string {
+			return parseOpenAIModels(body)
+		},
+	},
+	{
+		Name:      "TEI",
+		Port:      8091,
+		ProbePath: "/info",
+		SuccessCheck: func(statusCode int, _ []byte) bool {
+			return statusCode == http.StatusOK
+		},
+		Type:       "embed",
+		ModelsPath: "/info",
+		ParseModels: func(body []byte) []string {
+			var resp struct {
+				ModelID   string `json:"model_id"`
+				ModelType string `json:"model_type"`
+			}
+			if err := json.Unmarshal(body, &resp); err != nil {
+				return nil
+			}
+			if resp.ModelID != "" {
+				return []string{resp.ModelID}
+			}
+			return nil
+		},
+	},
+	{
+		Name:      "vLLM",
+		Port:      8000,
+		ProbePath: "/v1/models",
+		SuccessCheck: func(statusCode int, _ []byte) bool {
+			return statusCode == http.StatusOK
+		},
+		Type:       "llm",
+		ModelsPath: "", // same as probe path
+		ParseModels: func(body []byte) []string {
+			return parseOpenAIModels(body)
+		},
+	},
+	{
+		Name:      "llama.cpp",
+		Port:      8080,
+		ProbePath: "/health",
+		SuccessCheck: func(statusCode int, body []byte) bool {
+			return statusCode == http.StatusOK || strings.Contains(string(body), "ok")
+		},
+		Type:       "llm",
+		ModelsPath: "/v1/models",
+		ParseModels: func(body []byte) []string {
+			return parseOpenAIModels(body)
+		},
+	},
+}
+
+// parseOpenAIModels parses the OpenAI-compatible GET /v1/models response.
+func parseOpenAIModels(body []byte) []string {
+	var resp struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(resp.Data))
+	for _, m := range resp.Data {
+		names = append(names, m.ID)
+	}
+	return names
+}
+
+// probeTimeout is the per-probe deadline.
+const probeTimeout = 2 * time.Second
+
+// DetectLocal probes well-known localhost ports concurrently and returns all
+// discovered endpoints sorted by name. It never returns an error; unreachable
+// services are silently skipped.
+func DetectLocal(ctx context.Context) []Endpoint {
+	return detectLocalWithProbes(ctx, defaultProbes)
+}
+
+// detectLocalWithProbes is the internal implementation that accepts a probe
+// table, enabling tests to override ports.
+func detectLocalWithProbes(ctx context.Context, probes []probeSpec) []Endpoint {
+	var (
+		mu      sync.Mutex
+		results []Endpoint
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	for _, p := range probes {
+		p := p // capture loop variable
+		g.Go(func() error {
+			ep := probeEndpoint(gctx, p)
+			if ep != nil {
+				mu.Lock()
+				results = append(results, *ep)
+				mu.Unlock()
+			}
+			return nil // never propagate errors
+		})
+	}
+
+	_ = g.Wait()
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+
+	return results
+}
+
+// probeEndpoint checks a single service and optionally fetches its model list.
+func probeEndpoint(ctx context.Context, p probeSpec) *Endpoint {
+	pctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+
+	baseURL := fmt.Sprintf("http://localhost:%d", p.Port)
+
+	// Health probe.
+	statusCode, body, err := httpGet(pctx, baseURL+p.ProbePath)
+	if err != nil || !p.SuccessCheck(statusCode, body) {
+		return nil
+	}
+
+	ep := &Endpoint{
+		Name:    p.Name,
+		URL:     baseURL,
+		Type:    p.Type,
+		Healthy: true,
+	}
+
+	// Determine the type for TEI based on model_type in the response.
+	if p.Name == "TEI" {
+		ep.Type = teiType(body)
+	}
+
+	// Fetch models if the service exposes a models API.
+	if p.ParseModels != nil {
+		modelsBody := body // reuse probe response if paths match
+		if p.ModelsPath != "" && p.ModelsPath != p.ProbePath {
+			_, modelsBody, err = httpGet(pctx, baseURL+p.ModelsPath)
+			if err != nil {
+				// Probe succeeded but models fetch failed — still healthy.
+				return ep
+			}
+		}
+		ep.Models = p.ParseModels(modelsBody)
+	}
+
+	return ep
+}
+
+// teiType returns "rerank" or "embed" based on the TEI /info response.
+func teiType(body []byte) string {
+	var info struct {
+		ModelType string `json:"model_type"`
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return "embed" // default
+	}
+	lower := strings.ToLower(info.ModelType)
+	if strings.Contains(lower, "rerank") || strings.Contains(lower, "cross") {
+		return "rerank"
+	}
+	return "embed"
+}
+
+// httpGet performs a GET request and returns the status code and body.
+func httpGet(ctx context.Context, url string) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	return resp.StatusCode, body, nil
+}

--- a/config/detect_test.go
+++ b/config/detect_test.go
@@ -1,0 +1,392 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testServerPort extracts the port from an httptest.Server URL.
+func testServerPort(t *testing.T, s *httptest.Server) int {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(strings.TrimPrefix(s.URL, "http://"))
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+	return port
+}
+
+// newOllamaServer returns a mock Ollama server.
+func newOllamaServer(t *testing.T, models []string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, "Ollama is running")
+	})
+	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, r *http.Request) {
+		type model struct {
+			Name string `json:"name"`
+		}
+		resp := struct {
+			Models []model `json:"models"`
+		}{}
+		for _, m := range models {
+			resp.Models = append(resp.Models, model{Name: m})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	return httptest.NewServer(mux)
+}
+
+// newOpenAIModelsServer returns a mock OpenAI-compatible /v1/models server.
+func newOpenAIModelsServer(t *testing.T, models []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		type model struct {
+			ID string `json:"id"`
+		}
+		resp := struct {
+			Data []model `json:"data"`
+		}{}
+		for _, m := range models {
+			resp.Data = append(resp.Data, model{ID: m})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// newTEIServer returns a mock TEI /info server.
+func newTEIServer(t *testing.T, modelID, modelType string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := struct {
+			ModelID   string `json:"model_id"`
+			ModelType string `json:"model_type"`
+		}{ModelID: modelID, ModelType: modelType}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// newLlamaCppServer returns a mock llama.cpp server with /health and /v1/models.
+func newLlamaCppServer(t *testing.T, models []string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"ok"}`)
+	})
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
+		type model struct {
+			ID string `json:"id"`
+		}
+		resp := struct {
+			Data []model `json:"data"`
+		}{}
+		for _, m := range models {
+			resp.Data = append(resp.Data, model{ID: m})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	return httptest.NewServer(mux)
+}
+
+// overrideProbePort creates a copy of the default probes with the named
+// service's port replaced.
+func overrideProbePort(probes []probeSpec, name string, port int) []probeSpec {
+	out := make([]probeSpec, len(probes))
+	copy(out, probes)
+	for i := range out {
+		if out[i].Name == name {
+			out[i].Port = port
+		}
+	}
+	return out
+}
+
+func TestDetectLocal_AllHealthy(t *testing.T) {
+	ollamaSrv := newOllamaServer(t, []string{"llama3", "mistral"})
+	defer ollamaSrv.Close()
+
+	lmSrv := newOpenAIModelsServer(t, []string{"deepseek-r1"})
+	defer lmSrv.Close()
+
+	teiSrv := newTEIServer(t, "BAAI/bge-small-en-v1.5", "Embedding")
+	defer teiSrv.Close()
+
+	vllmSrv := newOpenAIModelsServer(t, []string{"meta-llama/Llama-3-8b"})
+	defer vllmSrv.Close()
+
+	llamaCppSrv := newLlamaCppServer(t, []string{"ggml-model"})
+	defer llamaCppSrv.Close()
+
+	probes := defaultProbes
+	probes = overrideProbePort(probes, "Ollama", testServerPort(t, ollamaSrv))
+	probes = overrideProbePort(probes, "LM Studio", testServerPort(t, lmSrv))
+	probes = overrideProbePort(probes, "TEI", testServerPort(t, teiSrv))
+	probes = overrideProbePort(probes, "vLLM", testServerPort(t, vllmSrv))
+	probes = overrideProbePort(probes, "llama.cpp", testServerPort(t, llamaCppSrv))
+
+	eps := detectLocalWithProbes(context.Background(), probes)
+
+	require.Len(t, eps, 5)
+
+	// Sorted by name: LM Studio, Ollama, TEI, llama.cpp, vLLM
+	assert.Equal(t, "LM Studio", eps[0].Name)
+	assert.Equal(t, "multi", eps[0].Type)
+	assert.True(t, eps[0].Healthy)
+	assert.Equal(t, []string{"deepseek-r1"}, eps[0].Models)
+
+	assert.Equal(t, "Ollama", eps[1].Name)
+	assert.Equal(t, "multi", eps[1].Type)
+	assert.True(t, eps[1].Healthy)
+	assert.Equal(t, []string{"llama3", "mistral"}, eps[1].Models)
+
+	assert.Equal(t, "TEI", eps[2].Name)
+	assert.Equal(t, "embed", eps[2].Type)
+	assert.True(t, eps[2].Healthy)
+	assert.Equal(t, []string{"BAAI/bge-small-en-v1.5"}, eps[2].Models)
+
+	assert.Equal(t, "llama.cpp", eps[3].Name)
+	assert.Equal(t, "llm", eps[3].Type)
+	assert.True(t, eps[3].Healthy)
+	assert.Equal(t, []string{"ggml-model"}, eps[3].Models)
+
+	assert.Equal(t, "vLLM", eps[4].Name)
+	assert.Equal(t, "llm", eps[4].Type)
+	assert.True(t, eps[4].Healthy)
+	assert.Equal(t, []string{"meta-llama/Llama-3-8b"}, eps[4].Models)
+}
+
+func TestDetectLocal_AllUnreachable(t *testing.T) {
+	// Use ports that are almost certainly not listening.
+	probes := make([]probeSpec, len(defaultProbes))
+	copy(probes, defaultProbes)
+	for i := range probes {
+		probes[i].Port = 59990 + i // unlikely to be in use
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	eps := detectLocalWithProbes(ctx, probes)
+	assert.Empty(t, eps)
+}
+
+func TestDetectLocal_Mixed(t *testing.T) {
+	ollamaSrv := newOllamaServer(t, []string{"phi3"})
+	defer ollamaSrv.Close()
+
+	probes := make([]probeSpec, len(defaultProbes))
+	copy(probes, defaultProbes)
+	for i := range probes {
+		if probes[i].Name == "Ollama" {
+			probes[i].Port = testServerPort(t, ollamaSrv)
+		} else {
+			probes[i].Port = 59990 + i
+		}
+	}
+
+	eps := detectLocalWithProbes(context.Background(), probes)
+	require.Len(t, eps, 1)
+	assert.Equal(t, "Ollama", eps[0].Name)
+	assert.True(t, eps[0].Healthy)
+	assert.Equal(t, []string{"phi3"}, eps[0].Models)
+}
+
+func TestDetectLocal_Timeout(t *testing.T) {
+	// Server that never responds within the probe timeout.
+	slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+		fmt.Fprint(w, "Ollama is running")
+	}))
+	defer slowSrv.Close()
+
+	probes := make([]probeSpec, len(defaultProbes))
+	copy(probes, defaultProbes)
+	for i := range probes {
+		if probes[i].Name == "Ollama" {
+			probes[i].Port = testServerPort(t, slowSrv)
+		} else {
+			probes[i].Port = 59990 + i
+		}
+	}
+
+	start := time.Now()
+	eps := detectLocalWithProbes(context.Background(), probes)
+	elapsed := time.Since(start)
+
+	assert.Empty(t, eps)
+	// Should complete well within 3 seconds (2s timeout + margin).
+	assert.Less(t, elapsed, 4*time.Second)
+}
+
+func TestDetectLocal_TEIReranker(t *testing.T) {
+	teiSrv := newTEIServer(t, "cross-encoder/ms-marco", "CrossEncoder")
+	defer teiSrv.Close()
+
+	probes := make([]probeSpec, len(defaultProbes))
+	copy(probes, defaultProbes)
+	for i := range probes {
+		if probes[i].Name == "TEI" {
+			probes[i].Port = testServerPort(t, teiSrv)
+		} else {
+			probes[i].Port = 59990 + i
+		}
+	}
+
+	eps := detectLocalWithProbes(context.Background(), probes)
+	require.Len(t, eps, 1)
+	assert.Equal(t, "TEI", eps[0].Name)
+	assert.Equal(t, "rerank", eps[0].Type)
+	assert.Equal(t, []string{"cross-encoder/ms-marco"}, eps[0].Models)
+}
+
+func TestDetectLocal_OllamaWrongBody(t *testing.T) {
+	// Server returns 200 but wrong body — should not be detected.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "Not the expected response")
+	}))
+	defer srv.Close()
+
+	probes := make([]probeSpec, len(defaultProbes))
+	copy(probes, defaultProbes)
+	for i := range probes {
+		if probes[i].Name == "Ollama" {
+			probes[i].Port = testServerPort(t, srv)
+		} else {
+			probes[i].Port = 59990 + i
+		}
+	}
+
+	eps := detectLocalWithProbes(context.Background(), probes)
+	assert.Empty(t, eps)
+}
+
+func TestDetectLocal_ModelsParseFailure(t *testing.T) {
+	// Ollama responds correctly for health but returns garbage for models.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, "Ollama is running")
+	})
+	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "not json")
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	probes := make([]probeSpec, len(defaultProbes))
+	copy(probes, defaultProbes)
+	for i := range probes {
+		if probes[i].Name == "Ollama" {
+			probes[i].Port = testServerPort(t, srv)
+		} else {
+			probes[i].Port = 59990 + i
+		}
+	}
+
+	eps := detectLocalWithProbes(context.Background(), probes)
+	require.Len(t, eps, 1)
+	assert.Equal(t, "Ollama", eps[0].Name)
+	assert.True(t, eps[0].Healthy)
+	assert.Nil(t, eps[0].Models) // models parse failed, but endpoint still healthy
+}
+
+func TestDetectLocal_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	probes := make([]probeSpec, len(defaultProbes))
+	copy(probes, defaultProbes)
+	for i := range probes {
+		probes[i].Port = 59990 + i
+	}
+
+	eps := detectLocalWithProbes(ctx, probes)
+	assert.Empty(t, eps)
+}
+
+func TestParseOpenAIModels(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect []string
+	}{
+		{
+			name:   "valid",
+			input:  `{"data":[{"id":"model-a"},{"id":"model-b"}]}`,
+			expect: []string{"model-a", "model-b"},
+		},
+		{
+			name:   "empty",
+			input:  `{"data":[]}`,
+			expect: []string{},
+		},
+		{
+			name:   "invalid json",
+			input:  `not json`,
+			expect: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseOpenAIModels([]byte(tt.input))
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestLlamaCppHealthOkInBody(t *testing.T) {
+	// llama.cpp returns non-200 status but body contains "ok".
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, `{"status":"ok"}`)
+			return
+		}
+		if r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"data":[{"id":"test-model"}]}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	probes := make([]probeSpec, len(defaultProbes))
+	copy(probes, defaultProbes)
+	for i := range probes {
+		if probes[i].Name == "llama.cpp" {
+			probes[i].Port = testServerPort(t, srv)
+		} else {
+			probes[i].Port = 59990 + i
+		}
+	}
+
+	eps := detectLocalWithProbes(context.Background(), probes)
+	require.Len(t, eps, 1)
+	assert.Equal(t, "llama.cpp", eps[0].Name)
+	assert.True(t, eps[0].Healthy)
+	assert.Equal(t, []string{"test-model"}, eps[0].Models)
+}


### PR DESCRIPTION
## Summary

- Adds `config.DetectLocal(ctx)` which probes 5 well-known localhost ports concurrently (Ollama, LM Studio, TEI, vLLM, llama.cpp) using `errgroup` with 2-second per-probe timeouts
- Returns `[]Endpoint` sorted by name with service name, URL, type (embed/llm/rerank/multi), health status, and discovered model names
- TEI auto-detects rerank vs embed based on `model_type` in `/info` response

## Acceptance Criteria Status

- [x] `config.DetectLocal(ctx context.Context) []Endpoint` probes 5 services concurrently
- [x] `Endpoint` struct: `Name`, `URL`, `Type` (embed/llm/rerank/multi), `Healthy`, `Models`
- [x] Ollama probe: `GET /` checks for "Ollama is running"; fetches models from `/api/tags`
- [x] LM Studio probe: `GET /v1/models` parses model list
- [x] TEI probe: `GET /info` with embed/rerank type detection
- [x] vLLM probe: `GET /v1/models`
- [x] llama.cpp probe: `GET /health` (200 or body contains "ok")
- [x] 2-second timeout per probe
- [x] Returns empty slice if nothing detected
- [x] Tests use `httptest.Server` mocks for each probe type
- [x] `go test ./config/...` passes

## Test Output

```
PASS: TestDetectLocal_AllHealthy (0.01s)
PASS: TestDetectLocal_AllUnreachable (0.00s)
PASS: TestDetectLocal_Mixed (0.00s)
PASS: TestDetectLocal_Timeout (5.00s)
PASS: TestDetectLocal_TEIReranker (0.00s)
PASS: TestDetectLocal_OllamaWrongBody (0.00s)
PASS: TestDetectLocal_ModelsParseFailure (0.00s)
PASS: TestDetectLocal_ContextCancelled (0.00s)
PASS: TestParseOpenAIModels (0.00s)
PASS: TestLlamaCppHealthOkInBody (0.00s)
```

## Test plan

- [x] All 5 services detected when healthy
- [x] Empty result when all unreachable
- [x] Mixed: only healthy services returned
- [x] Timeout: slow server correctly skipped within deadline
- [x] TEI reranker type detection (CrossEncoder model_type)
- [x] Ollama wrong body rejected (200 but not "Ollama is running")
- [x] Models parse failure: endpoint still marked healthy with nil models
- [x] Context cancellation handled gracefully
- [x] llama.cpp "ok" in body with non-200 status still detected

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)