### PR TITLE
feat: [Issue #69] markedup setup CLI command

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -41,6 +41,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newEmbedCmd())
 	root.AddCommand(newEnrichCmd())
 	root.AddCommand(newExportCmd())
+	root.AddCommand(newSetupCmd())
 
 	return root
 }

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1,0 +1,331 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/KHAEntertainment/markedup/config"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// cloudPreset describes a cloud provider option shown in the setup menu.
+type cloudPreset struct {
+	Name     string
+	Endpoint string
+	NeedsKey bool
+}
+
+var cloudPresets = []cloudPreset{
+	{Name: "OpenRouter", Endpoint: "https://openrouter.ai/api", NeedsKey: true},
+	{Name: "OpenAI", Endpoint: "https://api.openai.com", NeedsKey: true},
+	{Name: "Ollama Cloud", Endpoint: "https://api.ollama.com", NeedsKey: true},
+	{Name: "Custom", Endpoint: "", NeedsKey: false},
+}
+
+// setupDeps holds injectable dependencies for testing.
+type setupDeps struct {
+	Stdin          io.Reader
+	Stdout         io.Writer
+	DetectLocal    func(ctx context.Context) []config.Endpoint
+	Save           func(cfg *config.Config, path string) error
+	StoreKey       func(name, value string) error
+	KeyringAvail   func() bool
+	GlobalPath     func() string
+	ReadPassword   func(fd int) ([]byte, error)
+	StdinFd        func() int
+	IsTerminal     func(fd int) bool
+}
+
+func defaultDeps() *setupDeps {
+	return &setupDeps{
+		Stdin:        os.Stdin,
+		Stdout:       os.Stdout,
+		DetectLocal:  config.DetectLocal,
+		Save:         config.Save,
+		StoreKey:     config.StoreKey,
+		KeyringAvail: config.KeyringAvailable,
+		GlobalPath:   config.GlobalPath,
+		ReadPassword: term.ReadPassword,
+		StdinFd:      func() int { return int(os.Stdin.Fd()) },
+		IsTerminal:   func(fd int) bool { return term.IsTerminal(fd) },
+	}
+}
+
+func newSetupCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "setup",
+		Short: "Interactive configuration wizard",
+		Long:  "Walk through text-based prompts to configure embedding, LLM, and reranker endpoints.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSetup(cmd.Context(), defaultDeps())
+		},
+	}
+}
+
+func runSetup(ctx context.Context, d *setupDeps) error {
+	w := d.Stdout
+	scanner := bufio.NewScanner(d.Stdin)
+
+	fmt.Fprintln(w, "=== markedup setup ===")
+	fmt.Fprintln(w)
+
+	// Step 1: Auto-detect
+	fmt.Fprintln(w, "Scanning for local model servers...")
+	endpoints := d.DetectLocal(ctx)
+	if len(endpoints) == 0 {
+		fmt.Fprintln(w, "  No local servers detected.")
+	} else {
+		for _, ep := range endpoints {
+			models := ""
+			if len(ep.Models) > 0 {
+				models = " [" + strings.Join(ep.Models, ", ") + "]"
+			}
+			fmt.Fprintf(w, "  ✓ %s (%s) — %s%s\n", ep.Name, ep.URL, ep.Type, models)
+		}
+	}
+	fmt.Fprintln(w)
+
+	cfg := &config.Config{}
+
+	// Step 2: Configure each service
+	embedSvc, embedKey, err := promptService(w, scanner, d, "Embedding", "embed", endpoints)
+	if err != nil {
+		return err
+	}
+	cfg.Embed = embedSvc
+
+	llmSvc, llmKey, err := promptService(w, scanner, d, "LLM", "llm", endpoints)
+	if err != nil {
+		return err
+	}
+	cfg.LLM = llmSvc
+
+	rerankSvc, rerankKey, err := promptService(w, scanner, d, "Reranker (optional)", "rerank", endpoints)
+	if err != nil {
+		return err
+	}
+	cfg.Rerank = config.RerankConfig{ServiceConfig: rerankSvc}
+
+	// Step 3: Summary
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "=== Configuration Summary ===")
+	printServiceSummary(w, "Embed", cfg.Embed)
+	printServiceSummary(w, "LLM", cfg.LLM)
+	printServiceSummary(w, "Rerank", cfg.Rerank.ServiceConfig)
+	fmt.Fprintln(w)
+
+	fmt.Fprint(w, "Save configuration? (y/n): ")
+	if !scanner.Scan() {
+		return scanner.Err()
+	}
+	answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+	if answer != "y" && answer != "yes" {
+		fmt.Fprintln(w, "Setup cancelled.")
+		return nil
+	}
+
+	// Step 4: Save config
+	path := d.GlobalPath()
+	if err := d.Save(cfg, path); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+	fmt.Fprintf(w, "Configuration saved to %s\n", path)
+
+	// Step 5: Store API keys
+	keys := map[string]string{
+		"embed-api-key":  embedKey,
+		"llm-api-key":    llmKey,
+		"rerank-api-key": rerankKey,
+	}
+
+	if d.KeyringAvail() {
+		for name, value := range keys {
+			if value != "" {
+				if err := d.StoreKey(name, value); err != nil {
+					fmt.Fprintf(w, "Warning: failed to store %s in keyring: %v\n", name, err)
+				}
+			}
+		}
+		fmt.Fprintln(w, "API keys stored in OS keyring.")
+	} else {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Keyring not available. Set API keys as environment variables in your shell profile:")
+		if embedKey != "" {
+			fmt.Fprintln(w, "  export MARKEDUP_EMBED_API_KEY=<your-key>")
+		}
+		if llmKey != "" {
+			fmt.Fprintln(w, "  export MARKEDUP_LLM_API_KEY=<your-key>")
+		}
+		if rerankKey != "" {
+			fmt.Fprintln(w, "  export MARKEDUP_RERANK_API_KEY=<your-key>")
+		}
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Setup complete!")
+	return nil
+}
+
+// promptService presents a numbered menu for choosing a provider for the given
+// service type and returns the ServiceConfig and any API key entered.
+func promptService(w io.Writer, scanner *bufio.Scanner, d *setupDeps, label, serviceType string, detected []config.Endpoint) (config.ServiceConfig, string, error) {
+	fmt.Fprintf(w, "--- %s provider ---\n", label)
+
+	// Build options list
+	type option struct {
+		label    string
+		endpoint string
+		models   []string
+		needsKey bool
+		isCustom bool
+		isSkip   bool
+	}
+
+	var opts []option
+
+	// Add detected local endpoints matching this service type
+	for _, ep := range detected {
+		if ep.Type == serviceType || ep.Type == "multi" {
+			opts = append(opts, option{
+				label:    fmt.Sprintf("%s (local — %s)", ep.Name, ep.URL),
+				endpoint: ep.URL,
+				models:   ep.Models,
+			})
+		}
+	}
+
+	// Add cloud presets
+	for _, cp := range cloudPresets {
+		if cp.Name == "Custom" {
+			opts = append(opts, option{
+				label:    "Custom endpoint",
+				isCustom: true,
+			})
+		} else {
+			opts = append(opts, option{
+				label:    cp.Name,
+				endpoint: cp.Endpoint,
+				needsKey: cp.NeedsKey,
+			})
+		}
+	}
+
+	// Add skip
+	opts = append(opts, option{label: "Skip", isSkip: true})
+
+	// Display
+	for i, o := range opts {
+		fmt.Fprintf(w, "  %d) %s\n", i+1, o.label)
+	}
+
+	choice, err := promptInt(w, scanner, "Choose", 1, len(opts))
+	if err != nil {
+		return config.ServiceConfig{}, "", err
+	}
+
+	selected := opts[choice-1]
+	if selected.isSkip {
+		fmt.Fprintln(w)
+		return config.ServiceConfig{}, "", nil
+	}
+
+	svc := config.ServiceConfig{
+		Endpoint: selected.endpoint,
+	}
+
+	// Custom endpoint
+	if selected.isCustom {
+		fmt.Fprint(w, "  Endpoint URL: ")
+		if !scanner.Scan() {
+			return config.ServiceConfig{}, "", scanner.Err()
+		}
+		svc.Endpoint = strings.TrimSpace(scanner.Text())
+	}
+
+	// Model name — show detected models or prompt freely
+	if len(selected.models) > 0 {
+		fmt.Fprintln(w, "  Available models:")
+		for i, m := range selected.models {
+			fmt.Fprintf(w, "    %d) %s\n", i+1, m)
+		}
+		fmt.Fprint(w, "  Model (number or name): ")
+		if !scanner.Scan() {
+			return config.ServiceConfig{}, "", scanner.Err()
+		}
+		input := strings.TrimSpace(scanner.Text())
+		if n, err := strconv.Atoi(input); err == nil && n >= 1 && n <= len(selected.models) {
+			svc.Model = selected.models[n-1]
+		} else {
+			svc.Model = input
+		}
+	} else {
+		fmt.Fprint(w, "  Model name: ")
+		if !scanner.Scan() {
+			return config.ServiceConfig{}, "", scanner.Err()
+		}
+		svc.Model = strings.TrimSpace(scanner.Text())
+	}
+
+	// API key
+	var apiKey string
+	if selected.needsKey || selected.isCustom {
+		fmt.Fprint(w, "  API key (leave empty if none): ")
+		apiKey, err = readMasked(w, scanner, d)
+		if err != nil {
+			return config.ServiceConfig{}, "", err
+		}
+	}
+
+	fmt.Fprintln(w)
+	return svc, apiKey, nil
+}
+
+// readMasked attempts to read a password with terminal echo disabled.
+// Falls back to plain-text input when stdin is not a terminal (e.g. piped).
+func readMasked(w io.Writer, scanner *bufio.Scanner, d *setupDeps) (string, error) {
+	fd := d.StdinFd()
+	if d.IsTerminal(fd) {
+		pw, err := d.ReadPassword(fd)
+		fmt.Fprintln(w) // newline after hidden input
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(pw)), nil
+	}
+
+	// Non-terminal fallback (agent / piped input)
+	if !scanner.Scan() {
+		return "", scanner.Err()
+	}
+	return strings.TrimSpace(scanner.Text()), nil
+}
+
+// promptInt asks the user to enter a number between min and max (inclusive).
+func promptInt(w io.Writer, scanner *bufio.Scanner, prompt string, min, max int) (int, error) {
+	for {
+		fmt.Fprintf(w, "  %s [%d-%d]: ", prompt, min, max)
+		if !scanner.Scan() {
+			return 0, scanner.Err()
+		}
+		text := strings.TrimSpace(scanner.Text())
+		n, err := strconv.Atoi(text)
+		if err == nil && n >= min && n <= max {
+			return n, nil
+		}
+		fmt.Fprintf(w, "  Please enter a number between %d and %d.\n", min, max)
+	}
+}
+
+func printServiceSummary(w io.Writer, label string, svc config.ServiceConfig) {
+	if svc.Endpoint == "" && svc.Model == "" {
+		fmt.Fprintf(w, "  %s: (skipped)\n", label)
+		return
+	}
+	fmt.Fprintf(w, "  %s: %s — %s\n", label, svc.Endpoint, svc.Model)
+}

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -1,0 +1,227 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/KHAEntertainment/markedup/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDeps builds a setupDeps with sensible defaults for testing.
+// stdin is the newline-separated user input to feed.
+func fakeDeps(stdin string) (*setupDeps, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	var savedCfg *config.Config
+	var savedPath string
+	storedKeys := map[string]string{}
+
+	d := &setupDeps{
+		Stdin:  strings.NewReader(stdin),
+		Stdout: out,
+		DetectLocal: func(_ context.Context) []config.Endpoint {
+			return nil // no local servers by default
+		},
+		Save: func(cfg *config.Config, path string) error {
+			savedCfg = cfg
+			savedPath = path
+			_ = savedCfg
+			_ = savedPath
+			return nil
+		},
+		StoreKey: func(name, value string) error {
+			storedKeys[name] = value
+			return nil
+		},
+		KeyringAvail: func() bool { return true },
+		GlobalPath:   func() string { return "/tmp/test-markedup.yaml" },
+		ReadPassword: func(fd int) ([]byte, error) { return nil, nil },
+		StdinFd:      func() int { return 0 },
+		IsTerminal:   func(fd int) bool { return false }, // force scanner fallback
+	}
+	return d, out
+}
+
+func TestSetup_SkipAll(t *testing.T) {
+	// User picks "Skip" for all three services, then declines save.
+	// With 0 detected + 4 cloud + 1 skip = 5 options, skip = 5.
+	input := "5\n5\n5\nn\n"
+	d, out := fakeDeps(input)
+
+	err := runSetup(context.Background(), d)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Scanning for local model servers...")
+	assert.Contains(t, output, "No local servers detected.")
+	assert.Contains(t, output, "Setup cancelled.")
+}
+
+func TestSetup_CloudProvider_SavesConfig(t *testing.T) {
+	// User picks OpenRouter (1) for embed with model "text-embedding-3",
+	// skips LLM and reranker, confirms save.
+	input := strings.Join([]string{
+		"1",                    // Embed: OpenRouter
+		"text-embedding-3",    // model name
+		"sk-test-embed-key",   // API key
+		"5",                    // LLM: Skip
+		"5",                    // Rerank: Skip
+		"y",                    // Save
+	}, "\n") + "\n"
+
+	var savedCfg *config.Config
+	var savedPath string
+	storedKeys := map[string]string{}
+
+	d, out := fakeDeps(input)
+	d.Save = func(cfg *config.Config, path string) error {
+		savedCfg = cfg
+		savedPath = path
+		return nil
+	}
+	d.StoreKey = func(name, value string) error {
+		storedKeys[name] = value
+		return nil
+	}
+
+	err := runSetup(context.Background(), d)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Configuration saved to /tmp/test-markedup.yaml")
+	assert.Contains(t, output, "Setup complete!")
+
+	require.NotNil(t, savedCfg)
+	assert.Equal(t, "https://openrouter.ai/api", savedCfg.Embed.Endpoint)
+	assert.Equal(t, "text-embedding-3", savedCfg.Embed.Model)
+	assert.Equal(t, "/tmp/test-markedup.yaml", savedPath)
+	assert.Equal(t, "sk-test-embed-key", storedKeys["embed-api-key"])
+}
+
+func TestSetup_DetectedLocal(t *testing.T) {
+	// Simulate a detected Ollama instance. User picks it for embed,
+	// selects model by number, skips rest, saves.
+	input := strings.Join([]string{
+		"1",    // Embed: Ollama (local)
+		"1",    // model by number: nomic-embed-text
+		"6",    // LLM: Skip (1 detected + 4 cloud + 1 skip = 6)
+		"6",    // Rerank: Skip
+		"y",    // Save
+	}, "\n") + "\n"
+
+	var savedCfg *config.Config
+
+	d, out := fakeDeps(input)
+	d.DetectLocal = func(_ context.Context) []config.Endpoint {
+		return []config.Endpoint{
+			{
+				Name:    "Ollama",
+				URL:     "http://localhost:11434",
+				Type:    "multi",
+				Healthy: true,
+				Models:  []string{"nomic-embed-text", "llama3"},
+			},
+		}
+	}
+	d.Save = func(cfg *config.Config, path string) error {
+		savedCfg = cfg
+		return nil
+	}
+
+	err := runSetup(context.Background(), d)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Ollama")
+	assert.Contains(t, output, "http://localhost:11434")
+
+	require.NotNil(t, savedCfg)
+	assert.Equal(t, "http://localhost:11434", savedCfg.Embed.Endpoint)
+	assert.Equal(t, "nomic-embed-text", savedCfg.Embed.Model)
+}
+
+func TestSetup_CustomEndpoint(t *testing.T) {
+	// User picks Custom for embed, provides endpoint, model, and key.
+	// Custom is option 4 (no detected servers).
+	input := strings.Join([]string{
+		"4",                        // Embed: Custom
+		"http://my-server:9000",    // endpoint
+		"my-embed-model",           // model
+		"my-secret-key",            // API key
+		"5",                        // LLM: Skip
+		"5",                        // Rerank: Skip
+		"y",                        // Save
+	}, "\n") + "\n"
+
+	var savedCfg *config.Config
+
+	d, _ := fakeDeps(input)
+	d.Save = func(cfg *config.Config, path string) error {
+		savedCfg = cfg
+		return nil
+	}
+
+	err := runSetup(context.Background(), d)
+	require.NoError(t, err)
+
+	require.NotNil(t, savedCfg)
+	assert.Equal(t, "http://my-server:9000", savedCfg.Embed.Endpoint)
+	assert.Equal(t, "my-embed-model", savedCfg.Embed.Model)
+}
+
+func TestSetup_KeyringUnavailable(t *testing.T) {
+	// When keyring is not available, should print env var instructions.
+	input := strings.Join([]string{
+		"1",                   // Embed: OpenRouter
+		"text-embedding-3",
+		"sk-key",
+		"5",                   // LLM: Skip
+		"5",                   // Rerank: Skip
+		"y",                   // Save
+	}, "\n") + "\n"
+
+	d, out := fakeDeps(input)
+	d.KeyringAvail = func() bool { return false }
+
+	err := runSetup(context.Background(), d)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Keyring not available")
+	assert.Contains(t, output, "MARKEDUP_EMBED_API_KEY")
+}
+
+func TestSetup_CommandRegistered(t *testing.T) {
+	root := newRootCmd()
+	found := false
+	for _, cmd := range root.Commands() {
+		if cmd.Use == "setup" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "setup command should be registered in root")
+}
+
+func TestSetup_InvalidInput_Reprompts(t *testing.T) {
+	// Send invalid input first, then valid.
+	input := strings.Join([]string{
+		"abc",  // invalid
+		"99",   // out of range
+		"5",    // valid: Skip
+		"5",    // LLM: Skip
+		"5",    // Rerank: Skip
+		"n",    // Don't save
+	}, "\n") + "\n"
+
+	d, out := fakeDeps(input)
+
+	err := runSetup(context.Background(), d)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Please enter a number between")
+}


### PR DESCRIPTION
## Summary
- Add `markedup setup` text-based interactive configuration wizard
- Auto-detects local model servers (Ollama, LM Studio, TEI, vLLM, llama.cpp) and displays them
- Prompts for embed, LLM, and reranker providers with numbered menus (detected local, OpenRouter, OpenAI, Ollama Cloud, Custom, Skip)
- Masked API key input via `golang.org/x/term.ReadPassword()` with plain-text fallback for piped/agent input
- Saves config to `~/.markedup.yaml` via `config.Save()`, stores keys via `config.StoreKey()`, prints env var instructions if keyring unavailable
- Fully dependency-injected for testability; 7 tests covering skip-all, cloud provider, local detection, custom endpoint, keyring unavailable, command registration, and invalid input reprompting

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/cli/... -run TestSetup` — all 7 tests pass
- [x] `go test ./...` — full suite passes, no regressions
- [ ] Manual: `go run ./cmd/markedup setup` with local Ollama running
- [ ] Manual: piped input (`echo "5\n5\n5\nn" | go run ./cmd/markedup setup`)

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)