### PR TITLE
refactor: migrate CLI commands to use config package (#71)

### DIFF
--- a/internal/cli/embed.go
+++ b/internal/cli/embed.go
@@ -51,6 +51,17 @@ func runEmbed(cmd *cobra.Command, args []string) error {
 		return runEmbedStatus(cmd)
 	}
 
+	// Fall back to config values when CLI flags are empty.
+	if embedEndpoint == "" {
+		embedEndpoint = appConfig.Embed.Endpoint
+	}
+	if embedModel == "" {
+		embedModel = appConfig.Embed.Model
+	}
+	if embedAPIKey == "" {
+		embedAPIKey = appConfig.Embed.APIKey
+	}
+
 	if embedEndpoint == "" {
 		return fmt.Errorf("no embedding endpoint configured\n\n" +
 			"Configure an endpoint with the --endpoint flag:\n" +

--- a/internal/cli/enrich.go
+++ b/internal/cli/enrich.go
@@ -99,6 +99,30 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Fall back to config values when CLI flags are empty.
+	// Use Triplex config if available, otherwise fall back to LLM config.
+	if enrichEndpoint == "" {
+		if appConfig.Triplex.Endpoint != "" {
+			enrichEndpoint = appConfig.Triplex.Endpoint
+		} else {
+			enrichEndpoint = appConfig.LLM.Endpoint
+		}
+	}
+	if enrichModel == "" {
+		if appConfig.Triplex.Model != "" {
+			enrichModel = appConfig.Triplex.Model
+		} else {
+			enrichModel = appConfig.LLM.Model
+		}
+	}
+	if enrichAPIKey == "" {
+		if appConfig.Triplex.APIKey != "" {
+			enrichAPIKey = appConfig.Triplex.APIKey
+		} else {
+			enrichAPIKey = appConfig.LLM.APIKey
+		}
+	}
+
 	// Set up Tier 2 model extractor if --model is specified.
 	var modelExtractor *enrich.ModelExtractor
 	var entityTypes, predicates []string

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,6 +4,7 @@ package cli
 import (
 	"os"
 
+	"github.com/KHAEntertainment/markedup/config"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,7 @@ var (
 	depthFlag  int
 	isTTY      bool
 	noEnrich   bool
+	appConfig  = &config.Config{} // safe zero-value default; overwritten by PersistentPreRun
 )
 
 func newRootCmd() *cobra.Command {
@@ -22,6 +24,7 @@ func newRootCmd() *cobra.Command {
 		Long:  "markedup builds an in-memory knowledge graph from Obsidian-compatible markdown files with YAML frontmatter.",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			isTTY = isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+			appConfig, _ = config.Load(".")
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/KHAEntertainment/markedup/cache"
 	"github.com/KHAEntertainment/markedup/embed"
@@ -59,17 +58,13 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	searchOpts = append(searchOpts, index.WithContext(ctx))
 
 	if searchSemantic {
-		embedEndpoint := os.Getenv("MARKEDUP_EMBED_ENDPOINT")
-		embedModel := os.Getenv("MARKEDUP_EMBED_MODEL")
-		embedAPIKey := os.Getenv("MARKEDUP_EMBED_API_KEY")
-
-		if embedEndpoint == "" || embedModel == "" {
-			log.Println("search: --semantic requires MARKEDUP_EMBED_ENDPOINT and MARKEDUP_EMBED_MODEL env vars")
+		if appConfig.Embed.Endpoint == "" || appConfig.Embed.Model == "" {
+			log.Println("search: --semantic requires embed endpoint and model (set via config or MARKEDUP_EMBED_* env vars)")
 		} else {
 			emb := embed.NewOpenAICompatible(embed.Config{
-				Endpoint:  embedEndpoint,
-				ModelName: embedModel,
-				APIKey:    embedAPIKey,
+				Endpoint:  appConfig.Embed.Endpoint,
+				ModelName: appConfig.Embed.Model,
+				APIKey:    appConfig.Embed.APIKey,
 			})
 			vc := cache.NewVectorCache(path)
 			searchOpts = append(searchOpts,
@@ -80,17 +75,13 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	}
 
 	if searchRerank {
-		rerankEndpoint := os.Getenv("MARKEDUP_RERANK_ENDPOINT")
-		rerankModel := os.Getenv("MARKEDUP_RERANK_MODEL")
-		rerankAPIKey := os.Getenv("MARKEDUP_RERANK_API_KEY")
-
-		if rerankEndpoint == "" || rerankModel == "" {
-			log.Println("search: --rerank requires MARKEDUP_RERANK_ENDPOINT and MARKEDUP_RERANK_MODEL env vars")
+		if appConfig.Rerank.Endpoint == "" || appConfig.Rerank.Model == "" {
+			log.Println("search: --rerank requires rerank endpoint and model (set via config or MARKEDUP_RERANK_* env vars)")
 		} else {
 			rr := rerank.NewCrossEncoder(rerank.Config{
-				Endpoint: rerankEndpoint,
-				Model:    rerankModel,
-				APIKey:   rerankAPIKey,
+				Endpoint: appConfig.Rerank.Endpoint,
+				Model:    appConfig.Rerank.Model,
+				APIKey:   appConfig.Rerank.APIKey,
 				Format:   parseRerankFormat(searchRerankFmt),
 			})
 			searchOpts = append(searchOpts, index.WithReranker(rr))

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/KHAEntertainment/markedup/cache"
@@ -40,15 +39,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	srv := &mcpServer{idx: result.Index, path: path}
 
-	// Initialize LLM client from environment variables if configured.
-	if ep := os.Getenv("MARKEDUP_LLM_ENDPOINT"); ep != "" {
-		if model := os.Getenv("MARKEDUP_LLM_MODEL"); model != "" {
-			srv.llmClient = llm.NewClient(llm.Config{
-				Endpoint: ep,
-				Model:    model,
-				APIKey:   os.Getenv("MARKEDUP_LLM_API_KEY"),
-			})
-		}
+	// Initialize LLM client from config if configured.
+	if appConfig.LLM.Endpoint != "" && appConfig.LLM.Model != "" {
+		srv.llmClient = llm.NewClient(llm.Config{
+			Endpoint: appConfig.LLM.Endpoint,
+			Model:    appConfig.LLM.Model,
+			APIKey:   appConfig.LLM.APIKey,
+		})
 	}
 
 	s := server.NewMCPServer("markedup", "0.1.0",
@@ -168,15 +165,11 @@ func (s *mcpServer) toolSearch(ctx context.Context, request mcp.CallToolRequest)
 	searchOpts = append(searchOpts, index.WithContext(ctx))
 
 	if params.Semantic {
-		embedEndpoint := os.Getenv("MARKEDUP_EMBED_ENDPOINT")
-		embedModel := os.Getenv("MARKEDUP_EMBED_MODEL")
-		embedAPIKey := os.Getenv("MARKEDUP_EMBED_API_KEY")
-
-		if embedEndpoint != "" && embedModel != "" {
+		if appConfig.Embed.Endpoint != "" && appConfig.Embed.Model != "" {
 			emb := embed.NewOpenAICompatible(embed.Config{
-				Endpoint:  embedEndpoint,
-				ModelName: embedModel,
-				APIKey:    embedAPIKey,
+				Endpoint:  appConfig.Embed.Endpoint,
+				ModelName: appConfig.Embed.Model,
+				APIKey:    appConfig.Embed.APIKey,
 			})
 			vc := cache.NewVectorCache(".")
 			searchOpts = append(searchOpts,
@@ -187,17 +180,12 @@ func (s *mcpServer) toolSearch(ctx context.Context, request mcp.CallToolRequest)
 	}
 
 	if params.Rerank {
-		rerankEndpoint := os.Getenv("MARKEDUP_RERANK_ENDPOINT")
-		rerankModel := os.Getenv("MARKEDUP_RERANK_MODEL")
-		rerankAPIKey := os.Getenv("MARKEDUP_RERANK_API_KEY")
-		rerankFormat := parseRerankFormat(os.Getenv("MARKEDUP_RERANK_FORMAT"))
-
-		if rerankEndpoint != "" && rerankModel != "" {
+		if appConfig.Rerank.Endpoint != "" && appConfig.Rerank.Model != "" {
 			rr := rerank.NewCrossEncoder(rerank.Config{
-				Endpoint: rerankEndpoint,
-				Model:    rerankModel,
-				APIKey:   rerankAPIKey,
-				Format:   rerankFormat,
+				Endpoint: appConfig.Rerank.Endpoint,
+				Model:    appConfig.Rerank.Model,
+				APIKey:   appConfig.Rerank.APIKey,
+				Format:   parseRerankFormat(appConfig.Rerank.Format),
 			})
 			searchOpts = append(searchOpts, index.WithReranker(rr))
 		}


### PR DESCRIPTION
## Summary
- Replaces all `os.Getenv("MARKEDUP_*")` calls in `search.go`, `serve.go`, `embed.go`, and `enrich.go` with `appConfig.*` lookups
- Loads config once in `PersistentPreRun` via `config.Load(".")`, which applies env var overrides internally for full backward compatibility
- CLI flags still override config values in embed.go and enrich.go (flag > config > env var cascade)

## Changes by file
| File | What changed |
|------|-------------|
| `root.go` | Added `appConfig` package var (zero-value default), `config.Load(".")` in `PersistentPreRun` |
| `search.go` | 6 `os.Getenv()` calls → `appConfig.Embed.*`, `appConfig.Rerank.*` |
| `serve.go` | 10 `os.Getenv()` calls → `appConfig.LLM.*`, `appConfig.Embed.*`, `appConfig.Rerank.*` |
| `embed.go` | Falls back to `appConfig.Embed.*` when `--endpoint`/`--model`/`--api-key` flags are empty |
| `enrich.go` | Falls back to `appConfig.Triplex.*` (preferred) or `appConfig.LLM.*` when flags are empty |

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass (including existing embed/enrich/serve tests)
- [ ] E2E localmodel tests pass with env vars (env vars still work via `config.Load()` applying overrides)
- [ ] Verify config file defaults work when no env vars are set

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)