### PR TITLE
feat: [Issue #70] TUI setup wizard — BubbleTea interactive config

### DIFF
--- a/internal/tui/setup/steps.go
+++ b/internal/tui/setup/steps.go
@@ -1,0 +1,606 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/KHAEntertainment/markedup/config"
+)
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+// detectDoneMsg is sent when DetectLocal finishes.
+type detectDoneMsg struct {
+	endpoints []config.Endpoint
+}
+
+// detectCmd runs config.DetectLocal as a tea.Cmd.
+func detectCmd() tea.Msg {
+	eps := config.DetectLocal(context.Background())
+	return detectDoneMsg{endpoints: eps}
+}
+
+// ---------------------------------------------------------------------------
+// Provider choice
+// ---------------------------------------------------------------------------
+
+// providerChoice is one option in a provider-selection list.
+type providerChoice struct {
+	label    string
+	endpoint string // preset URL, or "" for detected / custom / skip
+	kind     string // "detected", "cloud", "custom", "skip"
+	models   []string
+}
+
+// Cloud provider presets.
+var cloudProviders = []providerChoice{
+	{label: "OpenRouter", endpoint: "https://openrouter.ai/api", kind: "cloud"},
+	{label: "OpenAI", endpoint: "https://api.openai.com", kind: "cloud"},
+	{label: "Ollama Cloud", endpoint: "https://api.ollama.com", kind: "cloud"},
+}
+
+// rerankFormats are the supported reranker request formats.
+var rerankFormats = []string{"jina", "openai"}
+
+// ---------------------------------------------------------------------------
+// Welcome + Detect step (step 0)
+// ---------------------------------------------------------------------------
+
+type welcomeStep struct {
+	spinner   spinner.Model
+	detecting bool
+	detected  []config.Endpoint
+	done      bool
+}
+
+func newWelcomeStep() welcomeStep {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	return welcomeStep{
+		spinner:   s,
+		detecting: true,
+	}
+}
+
+func (w welcomeStep) Init() tea.Cmd {
+	return tea.Batch(w.spinner.Tick, detectCmd)
+}
+
+func (w welcomeStep) Update(msg tea.Msg) (welcomeStep, tea.Cmd) {
+	switch msg := msg.(type) {
+	case detectDoneMsg:
+		w.detected = msg.endpoints
+		w.detecting = false
+		w.done = false
+		return w, nil
+	case spinner.TickMsg:
+		if w.detecting {
+			var cmd tea.Cmd
+			w.spinner, cmd = w.spinner.Update(msg)
+			return w, cmd
+		}
+	}
+	return w, nil
+}
+
+func (w welcomeStep) View(width int) string {
+	var b strings.Builder
+
+	b.WriteString(headerStyle.Width(width).Render("Welcome to markedup setup!"))
+	b.WriteString("\n\n")
+	b.WriteString("This wizard will configure your embedding, LLM, and reranker services.\n\n")
+
+	if w.detecting {
+		b.WriteString(w.spinner.View())
+		b.WriteString(" Detecting local model servers...")
+	} else {
+		if len(w.detected) == 0 {
+			b.WriteString(mutedStyle.Render("No local model servers detected."))
+		} else {
+			b.WriteString(successStyle.Render(fmt.Sprintf("Found %d local service(s):", len(w.detected))))
+			b.WriteString("\n")
+			for _, ep := range w.detected {
+				models := ""
+				if len(ep.Models) > 0 {
+					models = " — models: " + strings.Join(ep.Models, ", ")
+				}
+				b.WriteString(fmt.Sprintf("  %s  %s (%s)%s\n",
+					successStyle.Render("*"),
+					ep.Name, ep.URL, models))
+			}
+		}
+		b.WriteString("\n")
+		b.WriteString(helpStyle.Render("Press Enter to continue, Ctrl+C to cancel"))
+	}
+
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Provider selection step (steps 1, 2, 3)
+// ---------------------------------------------------------------------------
+
+type providerStep struct {
+	title       string
+	description string
+	optional    bool // if true, shows "skip" first and is pre-selected
+	choices     []providerChoice
+	cursor      int
+	phase       int // 0=choosing provider, 1=entering endpoint, 2=entering model, 3=choosing format (rerank only)
+	endpointIn  textinput.Model
+	modelIn     textinput.Model
+	needsKey    bool   // true if a cloud provider was selected
+	formatIdx   int    // rerank format selector index
+	showFormat  bool   // whether to show format selection
+	selected    config.ServiceConfig
+	formatVal   string
+	done        bool
+}
+
+func newProviderStep(title, desc string, detected []config.Endpoint, filterType string, optional bool, showFormat bool) providerStep {
+	choices := make([]providerChoice, 0, len(detected)+5)
+
+	// Add detected endpoints matching the filter type.
+	for _, ep := range detected {
+		if ep.Type == filterType || ep.Type == "multi" {
+			choices = append(choices, providerChoice{
+				label:    fmt.Sprintf("%s (local — %s)", ep.Name, ep.URL),
+				endpoint: ep.URL,
+				kind:     "detected",
+				models:   ep.Models,
+			})
+		}
+	}
+
+	// Add cloud presets.
+	choices = append(choices, cloudProviders...)
+
+	// Add custom + skip.
+	choices = append(choices, providerChoice{label: "Custom endpoint", kind: "custom"})
+	choices = append(choices, providerChoice{label: "Skip", kind: "skip"})
+
+	// Endpoint text input.
+	ei := textinput.New()
+	ei.Placeholder = "https://..."
+	ei.CharLimit = 256
+	ei.Width = 50
+
+	// Model text input.
+	mi := textinput.New()
+	mi.Placeholder = "model-name"
+	mi.CharLimit = 128
+	mi.Width = 50
+
+	startCursor := 0
+	if optional {
+		// Pre-select "Skip" for optional steps.
+		startCursor = len(choices) - 1
+	}
+
+	return providerStep{
+		title:       title,
+		description: desc,
+		optional:    optional,
+		choices:     choices,
+		cursor:      startCursor,
+		endpointIn:  ei,
+		modelIn:     mi,
+		showFormat:  showFormat,
+	}
+}
+
+func (p providerStep) Update(msg tea.Msg) (providerStep, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch p.phase {
+		case 0: // choosing provider
+			switch msg.String() {
+			case "up":
+				if p.cursor > 0 {
+					p.cursor--
+				}
+			case "down":
+				if p.cursor < len(p.choices)-1 {
+					p.cursor++
+				}
+			case "enter":
+				choice := p.choices[p.cursor]
+				switch choice.kind {
+				case "skip":
+					p.done = true
+					return p, nil
+				case "detected":
+					p.selected.Endpoint = choice.endpoint
+					if len(choice.models) > 0 {
+						p.selected.Model = choice.models[0]
+					}
+					// Go to model entry to let user confirm/override.
+					p.phase = 2
+					p.modelIn.SetValue(p.selected.Model)
+					p.modelIn.Focus()
+					return p, textinput.Blink
+				case "cloud":
+					p.selected.Endpoint = choice.endpoint
+					p.needsKey = true
+					p.phase = 2
+					p.modelIn.Focus()
+					return p, textinput.Blink
+				case "custom":
+					p.phase = 1
+					p.endpointIn.Focus()
+					return p, textinput.Blink
+				}
+			}
+		case 1: // entering custom endpoint
+			switch msg.String() {
+			case "enter":
+				val := strings.TrimSpace(p.endpointIn.Value())
+				if val == "" {
+					return p, nil
+				}
+				p.selected.Endpoint = val
+				p.needsKey = true // assume custom needs a key
+				p.phase = 2
+				p.modelIn.Focus()
+				return p, textinput.Blink
+			case "esc":
+				p.phase = 0
+				return p, nil
+			default:
+				var cmd tea.Cmd
+				p.endpointIn, cmd = p.endpointIn.Update(msg)
+				return p, cmd
+			}
+		case 2: // entering model name
+			switch msg.String() {
+			case "enter":
+				val := strings.TrimSpace(p.modelIn.Value())
+				if val == "" {
+					return p, nil
+				}
+				p.selected.Model = val
+				if p.showFormat {
+					p.phase = 3
+					return p, nil
+				}
+				p.done = true
+				return p, nil
+			case "esc":
+				p.phase = 0
+				return p, nil
+			default:
+				var cmd tea.Cmd
+				p.modelIn, cmd = p.modelIn.Update(msg)
+				return p, cmd
+			}
+		case 3: // choosing rerank format
+			switch msg.String() {
+			case "up", "left":
+				if p.formatIdx > 0 {
+					p.formatIdx--
+				}
+			case "down", "right":
+				if p.formatIdx < len(rerankFormats)-1 {
+					p.formatIdx++
+				}
+			case "enter":
+				p.formatVal = rerankFormats[p.formatIdx]
+				p.done = true
+				return p, nil
+			case "esc":
+				p.phase = 2
+				return p, nil
+			}
+		}
+	default:
+		// Forward non-key messages to active text inputs.
+		switch p.phase {
+		case 1:
+			var cmd tea.Cmd
+			p.endpointIn, cmd = p.endpointIn.Update(msg)
+			return p, cmd
+		case 2:
+			var cmd tea.Cmd
+			p.modelIn, cmd = p.modelIn.Update(msg)
+			return p, cmd
+		}
+	}
+	return p, nil
+}
+
+func (p providerStep) View(width int) string {
+	var b strings.Builder
+
+	b.WriteString(headerStyle.Width(width).Render(p.title))
+	b.WriteString("\n\n")
+	if p.description != "" {
+		b.WriteString(p.description)
+		b.WriteString("\n\n")
+	}
+
+	switch p.phase {
+	case 0:
+		for i, c := range p.choices {
+			prefix := "  "
+			style := subtitleStyle
+			if i == p.cursor {
+				prefix = "> "
+				style = selectedStyle
+			}
+			b.WriteString(style.Render(prefix + c.label))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+		b.WriteString(helpStyle.Render("up/down: navigate  |  Enter: select  |  Esc: back  |  Ctrl+C: cancel"))
+
+	case 1:
+		b.WriteString(labelStyle.Render("Endpoint URL: "))
+		b.WriteString("\n")
+		b.WriteString(p.endpointIn.View())
+		b.WriteString("\n\n")
+		b.WriteString(helpStyle.Render("Enter: confirm  |  Esc: back  |  Ctrl+C: cancel"))
+
+	case 2:
+		b.WriteString(mutedStyle.Render(fmt.Sprintf("Endpoint: %s", p.selected.Endpoint)))
+		b.WriteString("\n\n")
+		b.WriteString(labelStyle.Render("Model name: "))
+		b.WriteString("\n")
+		b.WriteString(p.modelIn.View())
+		b.WriteString("\n\n")
+		b.WriteString(helpStyle.Render("Enter: confirm  |  Esc: back  |  Ctrl+C: cancel"))
+
+	case 3:
+		b.WriteString(mutedStyle.Render(fmt.Sprintf("Endpoint: %s  |  Model: %s", p.selected.Endpoint, p.selected.Model)))
+		b.WriteString("\n\n")
+		b.WriteString(labelStyle.Render("Reranker format:"))
+		b.WriteString("\n")
+		for i, f := range rerankFormats {
+			prefix := "  "
+			style := subtitleStyle
+			if i == p.formatIdx {
+				prefix = "> "
+				style = selectedStyle
+			}
+			b.WriteString(style.Render(prefix + f))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+		b.WriteString(helpStyle.Render("up/down: navigate  |  Enter: select  |  Esc: back  |  Ctrl+C: cancel"))
+	}
+
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// API Keys step (step 4)
+// ---------------------------------------------------------------------------
+
+// keyEntry represents one API key to collect.
+type keyEntry struct {
+	service string // "embed", "llm", "rerank"
+	label   string // display label
+}
+
+type keysStep struct {
+	entries        []keyEntry
+	inputs         []textinput.Model
+	cursor         int
+	keyringOK      bool
+	done           bool
+	collectedKeys  map[string]string // service -> key value
+}
+
+func newKeysStep(needEmbed, needLLM, needRerank bool) keysStep {
+	var entries []keyEntry
+	if needEmbed {
+		entries = append(entries, keyEntry{service: "embed", label: "Embedding API Key"})
+	}
+	if needLLM {
+		entries = append(entries, keyEntry{service: "llm", label: "LLM API Key"})
+	}
+	if needRerank {
+		entries = append(entries, keyEntry{service: "rerank", label: "Reranker API Key"})
+	}
+
+	inputs := make([]textinput.Model, len(entries))
+	for i := range entries {
+		ti := textinput.New()
+		ti.Placeholder = "sk-..."
+		ti.CharLimit = 256
+		ti.Width = 50
+		ti.EchoMode = textinput.EchoPassword
+		inputs[i] = ti
+	}
+	if len(inputs) > 0 {
+		inputs[0].Focus()
+	}
+
+	return keysStep{
+		entries:       entries,
+		inputs:        inputs,
+		keyringOK:     config.KeyringAvailable(),
+		collectedKeys: make(map[string]string),
+	}
+}
+
+func (k keysStep) Init() tea.Cmd {
+	if len(k.inputs) > 0 {
+		return textinput.Blink
+	}
+	return nil
+}
+
+func (k keysStep) Update(msg tea.Msg) (keysStep, tea.Cmd) {
+	if len(k.entries) == 0 {
+		k.done = true
+		return k, nil
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			val := strings.TrimSpace(k.inputs[k.cursor].Value())
+			if val != "" {
+				k.collectedKeys[k.entries[k.cursor].service] = val
+			}
+			if k.cursor < len(k.entries)-1 {
+				k.inputs[k.cursor].Blur()
+				k.cursor++
+				k.inputs[k.cursor].Focus()
+				return k, textinput.Blink
+			}
+			k.done = true
+			return k, nil
+		case "tab":
+			if k.cursor < len(k.entries)-1 {
+				val := strings.TrimSpace(k.inputs[k.cursor].Value())
+				if val != "" {
+					k.collectedKeys[k.entries[k.cursor].service] = val
+				}
+				k.inputs[k.cursor].Blur()
+				k.cursor++
+				k.inputs[k.cursor].Focus()
+				return k, textinput.Blink
+			}
+		default:
+			var cmd tea.Cmd
+			k.inputs[k.cursor], cmd = k.inputs[k.cursor].Update(msg)
+			return k, cmd
+		}
+	default:
+		if k.cursor < len(k.inputs) {
+			var cmd tea.Cmd
+			k.inputs[k.cursor], cmd = k.inputs[k.cursor].Update(msg)
+			return k, cmd
+		}
+	}
+	return k, nil
+}
+
+func (k keysStep) View(width int) string {
+	var b strings.Builder
+
+	b.WriteString(headerStyle.Width(width).Render("API Keys"))
+	b.WriteString("\n\n")
+
+	if k.keyringOK {
+		b.WriteString(successStyle.Render("Keys will be stored in your OS keychain."))
+	} else {
+		b.WriteString(warningStyle.Render("OS keychain not available. Set keys via environment variables instead."))
+		b.WriteString("\n")
+		b.WriteString(mutedStyle.Render("(MARKEDUP_EMBED_API_KEY, MARKEDUP_LLM_API_KEY, MARKEDUP_RERANK_API_KEY)"))
+	}
+	b.WriteString("\n\n")
+
+	for i, entry := range k.entries {
+		if i == k.cursor {
+			b.WriteString(selectedStyle.Render(entry.label + ":"))
+		} else {
+			b.WriteString(labelStyle.Render(entry.label + ":"))
+		}
+		b.WriteString("\n")
+		b.WriteString(k.inputs[i].View())
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString(helpStyle.Render("Enter/Tab: next  |  Ctrl+C: cancel"))
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Confirm step (step 5)
+// ---------------------------------------------------------------------------
+
+type confirmStep struct {
+	cfg       *config.Config
+	format    string
+	keys      map[string]string
+	keyringOK bool
+	saved     bool
+	err       error
+}
+
+func newConfirmStep(cfg *config.Config, format string, keys map[string]string) confirmStep {
+	return confirmStep{
+		cfg:       cfg,
+		format:    format,
+		keys:      keys,
+		keyringOK: config.KeyringAvailable(),
+	}
+}
+
+func (c confirmStep) View(width int) string {
+	var b strings.Builder
+
+	b.WriteString(headerStyle.Width(width).Render("Configuration Summary"))
+	b.WriteString("\n\n")
+
+	// Embedding.
+	b.WriteString(labelStyle.Render("Embedding:"))
+	b.WriteString("\n")
+	if c.cfg.Embed.Endpoint != "" {
+		b.WriteString(fmt.Sprintf("  Endpoint: %s\n", c.cfg.Embed.Endpoint))
+		b.WriteString(fmt.Sprintf("  Model:    %s\n", c.cfg.Embed.Model))
+	} else {
+		b.WriteString(mutedStyle.Render("  (not configured)"))
+		b.WriteString("\n")
+	}
+
+	// LLM.
+	b.WriteString(labelStyle.Render("LLM:"))
+	b.WriteString("\n")
+	if c.cfg.LLM.Endpoint != "" {
+		b.WriteString(fmt.Sprintf("  Endpoint: %s\n", c.cfg.LLM.Endpoint))
+		b.WriteString(fmt.Sprintf("  Model:    %s\n", c.cfg.LLM.Model))
+	} else {
+		b.WriteString(mutedStyle.Render("  (not configured)"))
+		b.WriteString("\n")
+	}
+
+	// Reranker.
+	b.WriteString(labelStyle.Render("Reranker:"))
+	b.WriteString("\n")
+	if c.cfg.Rerank.Endpoint != "" {
+		b.WriteString(fmt.Sprintf("  Endpoint: %s\n", c.cfg.Rerank.Endpoint))
+		b.WriteString(fmt.Sprintf("  Model:    %s\n", c.cfg.Rerank.Model))
+		if c.format != "" {
+			b.WriteString(fmt.Sprintf("  Format:   %s\n", c.format))
+		}
+	} else {
+		b.WriteString(mutedStyle.Render("  (not configured)"))
+		b.WriteString("\n")
+	}
+
+	// Keys.
+	if len(c.keys) > 0 {
+		b.WriteString("\n")
+		b.WriteString(labelStyle.Render("API Keys:"))
+		b.WriteString("\n")
+		for svc := range c.keys {
+			b.WriteString(fmt.Sprintf("  %s: %s\n", svc, successStyle.Render("provided")))
+		}
+	}
+
+	b.WriteString("\n")
+
+	if c.saved {
+		b.WriteString(successStyle.Render("Configuration saved to " + config.GlobalPath()))
+		b.WriteString("\n")
+	} else if c.err != nil {
+		b.WriteString(warningStyle.Render("Error: " + c.err.Error()))
+		b.WriteString("\n")
+	} else {
+		b.WriteString(fmt.Sprintf("Save to %s?\n\n", config.GlobalPath()))
+		b.WriteString(helpStyle.Render("Enter: save  |  Esc: cancel  |  Ctrl+C: cancel"))
+	}
+
+	return b.String()
+}

--- a/internal/tui/setup/styles.go
+++ b/internal/tui/setup/styles.go
@@ -1,0 +1,53 @@
+// Package setup provides a BubbleTea-based setup wizard for markedup
+// configuration. It walks through provider selection, endpoint configuration,
+// model choice, API key entry, and saves the result.
+package setup
+
+import "github.com/charmbracelet/lipgloss"
+
+// Colors — reuse the same palette as the main TUI (internal/tui/styles.go).
+var (
+	colorPrimary   = lipgloss.Color("12")  // bright blue
+	colorSecondary = lipgloss.Color("243") // gray
+	colorAccent    = lipgloss.Color("10")  // green
+	colorMuted     = lipgloss.Color("240") // dark gray
+	colorWarning   = lipgloss.Color("11")  // yellow
+)
+
+// Shared styles.
+var (
+	titleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(colorPrimary)
+
+	subtitleStyle = lipgloss.NewStyle().
+			Foreground(colorSecondary)
+
+	selectedStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(colorAccent)
+
+	mutedStyle = lipgloss.NewStyle().
+			Foreground(colorMuted)
+
+	labelStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(colorSecondary)
+
+	headerStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(colorPrimary).
+			BorderStyle(lipgloss.NormalBorder()).
+			BorderBottom(true).
+			BorderForeground(colorMuted)
+
+	helpStyle = lipgloss.NewStyle().
+			Foreground(colorMuted)
+
+	warningStyle = lipgloss.NewStyle().
+			Foreground(colorWarning)
+
+	successStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(colorAccent)
+)

--- a/internal/tui/setup/wizard.go
+++ b/internal/tui/setup/wizard.go
@@ -1,0 +1,330 @@
+package setup
+
+import (
+	"fmt"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-isatty"
+
+	"github.com/KHAEntertainment/markedup/config"
+)
+
+// Run launches the setup wizard and returns the completed config.
+// Returns nil config if the user cancels (Ctrl+C / Esc at confirm).
+func Run() (*config.Config, error) {
+	if !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+		return nil, fmt.Errorf("setup wizard requires a terminal (stdout is not a TTY)")
+	}
+
+	m := newWizardModel()
+	p := tea.NewProgram(m, tea.WithAltScreen())
+
+	result, err := p.Run()
+	if err != nil {
+		return nil, fmt.Errorf("setup wizard error: %w", err)
+	}
+
+	wm, ok := result.(wizardModel)
+	if !ok {
+		return nil, nil
+	}
+
+	if wm.cancelled {
+		return nil, nil
+	}
+
+	return wm.config, nil
+}
+
+// wizardModel is the root BubbleTea model for the 6-step setup wizard.
+type wizardModel struct {
+	step      int // 0=welcome, 1=embed, 2=llm, 3=rerank, 4=keys, 5=confirm
+	config    *config.Config
+	detected  []config.Endpoint
+	cancelled bool
+	width     int
+	height    int
+
+	// Sub-models for each step.
+	welcome  welcomeStep
+	embed    providerStep
+	llm      providerStep
+	rerank   providerStep
+	keys     keysStep
+	confirm  confirmStep
+
+	// Track which services need API keys.
+	needEmbedKey  bool
+	needLLMKey    bool
+	needRerankKey bool
+}
+
+func newWizardModel() wizardModel {
+	return wizardModel{
+		step:    0,
+		config:  &config.Config{},
+		welcome: newWelcomeStep(),
+	}
+}
+
+// Init implements tea.Model.
+func (m wizardModel) Init() tea.Cmd {
+	return m.welcome.Init()
+}
+
+// Update implements tea.Model.
+func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		// Global quit at any step.
+		if msg.String() == "ctrl+c" {
+			m.cancelled = true
+			return m, tea.Quit
+		}
+
+		// Esc goes back one step (or cancels at step 0).
+		if msg.String() == "esc" {
+			return m.handleEsc()
+		}
+	}
+
+	// Delegate to current step.
+	switch m.step {
+	case 0:
+		return m.updateWelcome(msg)
+	case 1:
+		return m.updateEmbed(msg)
+	case 2:
+		return m.updateLLM(msg)
+	case 3:
+		return m.updateRerank(msg)
+	case 4:
+		return m.updateKeys(msg)
+	case 5:
+		return m.updateConfirm(msg)
+	}
+
+	return m, nil
+}
+
+func (m wizardModel) handleEsc() (tea.Model, tea.Cmd) {
+	switch m.step {
+	case 0:
+		m.cancelled = true
+		return m, tea.Quit
+	case 1:
+		// Check if the embed step is in a sub-phase. If so, let it handle esc.
+		if m.embed.phase > 0 {
+			return m, nil // will be handled by step update
+		}
+		m.step = 0
+	case 2:
+		if m.llm.phase > 0 {
+			return m, nil
+		}
+		m.step = 1
+	case 3:
+		if m.rerank.phase > 0 {
+			return m, nil
+		}
+		m.step = 2
+	case 4:
+		m.step = 3
+	case 5:
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+// ---------------------------------------------------------------------------
+// Step update helpers
+// ---------------------------------------------------------------------------
+
+func (m wizardModel) updateWelcome(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Handle Enter to advance when detection is done.
+	if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "enter" && !m.welcome.detecting {
+		m.detected = m.welcome.detected
+		m.embed = newProviderStep(
+			"Embedding Provider",
+			"Choose an embedding endpoint for semantic search.",
+			m.detected, "embed", false, false,
+		)
+		m.step = 1
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	m.welcome, cmd = m.welcome.Update(msg)
+	return m, cmd
+}
+
+func (m wizardModel) updateEmbed(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.embed, cmd = m.embed.Update(msg)
+
+	if m.embed.done {
+		m.config.Embed = m.embed.selected
+		m.needEmbedKey = m.embed.needsKey
+		m.llm = newProviderStep(
+			"LLM Provider",
+			"Choose an LLM endpoint for enrichment and reasoning.",
+			m.detected, "llm", false, false,
+		)
+		m.step = 2
+		return m, nil
+	}
+
+	return m, cmd
+}
+
+func (m wizardModel) updateLLM(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.llm, cmd = m.llm.Update(msg)
+
+	if m.llm.done {
+		m.config.LLM = m.llm.selected
+		m.needLLMKey = m.llm.needsKey
+		m.rerank = newProviderStep(
+			"Reranker (optional)",
+			"Configure a reranker? Improves search quality by re-scoring results.",
+			m.detected, "rerank", true, true,
+		)
+		m.step = 3
+		return m, nil
+	}
+
+	return m, cmd
+}
+
+func (m wizardModel) updateRerank(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.rerank, cmd = m.rerank.Update(msg)
+
+	if m.rerank.done {
+		m.config.Rerank = config.RerankConfig{
+			ServiceConfig: m.rerank.selected,
+			Format:        m.rerank.formatVal,
+		}
+		m.needRerankKey = m.rerank.needsKey
+
+		// Skip keys step if no cloud providers selected.
+		if !m.needEmbedKey && !m.needLLMKey && !m.needRerankKey {
+			m.keys = keysStep{done: true, collectedKeys: map[string]string{}}
+			m.confirm = newConfirmStep(m.config, m.rerank.formatVal, nil)
+			m.step = 5
+			return m, nil
+		}
+
+		m.keys = newKeysStep(m.needEmbedKey, m.needLLMKey, m.needRerankKey)
+		m.step = 4
+		return m, m.keys.Init()
+	}
+
+	return m, cmd
+}
+
+func (m wizardModel) updateKeys(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.keys, cmd = m.keys.Update(msg)
+
+	if m.keys.done {
+		m.confirm = newConfirmStep(m.config, m.rerank.formatVal, m.keys.collectedKeys)
+		m.step = 5
+		return m, nil
+	}
+
+	return m, cmd
+}
+
+func (m wizardModel) updateConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "enter":
+			if !m.confirm.saved {
+				// Save config file.
+				if err := config.Save(m.config, config.GlobalPath()); err != nil {
+					m.confirm.err = err
+					return m, nil
+				}
+
+				// Store API keys in keyring.
+				if config.KeyringAvailable() {
+					for svc, key := range m.keys.collectedKeys {
+						keyName := svc + "-api-key"
+						if err := config.StoreKey(keyName, key); err != nil {
+							m.confirm.err = fmt.Errorf("failed to store %s key: %w", svc, err)
+							return m, nil
+						}
+					}
+				}
+
+				// Set API keys on the config for the returned value.
+				if k, ok := m.keys.collectedKeys["embed"]; ok {
+					m.config.Embed.APIKey = k
+				}
+				if k, ok := m.keys.collectedKeys["llm"]; ok {
+					m.config.LLM.APIKey = k
+				}
+				if k, ok := m.keys.collectedKeys["rerank"]; ok {
+					m.config.Rerank.APIKey = k
+				}
+
+				m.confirm.saved = true
+				return m, nil
+			}
+			// Already saved — quit.
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+// View implements tea.Model.
+func (m wizardModel) View() string {
+	width := m.width
+	if width == 0 {
+		width = 80
+	}
+
+	// Step indicator.
+	steps := []string{"Welcome", "Embed", "LLM", "Rerank", "Keys", "Confirm"}
+	stepLine := ""
+	for i, name := range steps {
+		if i == m.step {
+			stepLine += selectedStyle.Render(fmt.Sprintf("[%s]", name))
+		} else if i < m.step {
+			stepLine += successStyle.Render(fmt.Sprintf("[%s]", name))
+		} else {
+			stepLine += mutedStyle.Render(fmt.Sprintf("[%s]", name))
+		}
+		if i < len(steps)-1 {
+			stepLine += mutedStyle.Render(" > ")
+		}
+	}
+	view := stepLine + "\n\n"
+
+	switch m.step {
+	case 0:
+		view += m.welcome.View(width)
+	case 1:
+		view += m.embed.View(width)
+	case 2:
+		view += m.llm.View(width)
+	case 3:
+		view += m.rerank.View(width)
+	case 4:
+		view += m.keys.View(width)
+	case 5:
+		view += m.confirm.View(width)
+	}
+
+	return view
+}

--- a/internal/tui/setup/wizard_test.go
+++ b/internal/tui/setup/wizard_test.go
@@ -1,0 +1,324 @@
+package setup
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KHAEntertainment/markedup/config"
+)
+
+func TestNewWizardModel_InitialState(t *testing.T) {
+	m := newWizardModel()
+	assert.Equal(t, 0, m.step)
+	assert.NotNil(t, m.config)
+	assert.False(t, m.cancelled)
+	assert.True(t, m.welcome.detecting)
+}
+
+func TestWizardModel_CtrlC_Cancels(t *testing.T) {
+	m := newWizardModel()
+
+	// Ctrl+C at any step should cancel.
+	for step := 0; step < 6; step++ {
+		m.step = step
+		result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+		wm := result.(wizardModel)
+		assert.True(t, wm.cancelled, "step %d should cancel on Ctrl+C", step)
+		require.NotNil(t, cmd)
+		msg := cmd()
+		_, isQuit := msg.(tea.QuitMsg)
+		assert.True(t, isQuit, "step %d should quit on Ctrl+C", step)
+	}
+}
+
+func TestWizardModel_WindowResize(t *testing.T) {
+	m := newWizardModel()
+
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	wm := result.(wizardModel)
+	assert.Equal(t, 120, wm.width)
+	assert.Equal(t, 40, wm.height)
+}
+
+func TestWizardModel_WelcomeStep_DetectDone(t *testing.T) {
+	m := newWizardModel()
+
+	// Simulate detection completing.
+	endpoints := []config.Endpoint{
+		{Name: "Ollama", URL: "http://localhost:11434", Type: "multi", Healthy: true, Models: []string{"llama3"}},
+	}
+	result, _ := m.Update(detectDoneMsg{endpoints: endpoints})
+	wm := result.(wizardModel)
+	assert.False(t, wm.welcome.detecting)
+	assert.Len(t, wm.welcome.detected, 1)
+}
+
+func TestWizardModel_WelcomeStep_EnterAdvances(t *testing.T) {
+	m := newWizardModel()
+
+	// Simulate detection completing.
+	result, _ := m.Update(detectDoneMsg{endpoints: nil})
+	m = result.(wizardModel)
+
+	// Press Enter to advance.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	wm := result.(wizardModel)
+	assert.Equal(t, 1, wm.step)
+}
+
+func TestWizardModel_WelcomeStep_EnterDuringDetectDoesNotAdvance(t *testing.T) {
+	m := newWizardModel()
+	// Still detecting, press Enter.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	wm := result.(wizardModel)
+	assert.Equal(t, 0, wm.step, "should not advance while detecting")
+}
+
+func TestWizardModel_EscAtStep0_Cancels(t *testing.T) {
+	m := newWizardModel()
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	wm := result.(wizardModel)
+	assert.True(t, wm.cancelled)
+	require.NotNil(t, cmd)
+}
+
+func TestWizardModel_EscAtStep1_GoesBack(t *testing.T) {
+	m := newWizardModel()
+	// Fast-forward to step 1.
+	m.step = 1
+	m.embed = newProviderStep("Embed", "", nil, "embed", false, false)
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	wm := result.(wizardModel)
+	assert.Equal(t, 0, wm.step)
+}
+
+func TestProviderStep_SkipSelection(t *testing.T) {
+	ps := newProviderStep("Test", "desc", nil, "embed", true, false)
+
+	// Cursor should start at "Skip" (last item).
+	assert.Equal(t, len(ps.choices)-1, ps.cursor)
+	assert.Equal(t, "skip", ps.choices[ps.cursor].kind)
+
+	// Press Enter to select Skip.
+	ps, _ = ps.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, ps.done)
+}
+
+func TestProviderStep_CloudSelection(t *testing.T) {
+	ps := newProviderStep("Test", "", nil, "embed", false, false)
+
+	// First items are cloud providers. Find OpenRouter.
+	found := false
+	for i, c := range ps.choices {
+		if c.label == "OpenRouter" {
+			ps.cursor = i
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+
+	// Select it.
+	ps, _ = ps.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, 2, ps.phase) // should be in model entry phase
+	assert.Equal(t, "https://openrouter.ai/api", ps.selected.Endpoint)
+	assert.True(t, ps.needsKey)
+}
+
+func TestProviderStep_DetectedEndpoint(t *testing.T) {
+	detected := []config.Endpoint{
+		{Name: "Ollama", URL: "http://localhost:11434", Type: "multi", Healthy: true, Models: []string{"nomic-embed-text"}},
+	}
+	ps := newProviderStep("Test", "", detected, "embed", false, false)
+
+	// First choice should be the detected endpoint.
+	assert.Equal(t, "detected", ps.choices[0].kind)
+	assert.Contains(t, ps.choices[0].label, "Ollama")
+
+	// Select it.
+	ps.cursor = 0
+	ps, _ = ps.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, 2, ps.phase)
+	assert.Equal(t, "http://localhost:11434", ps.selected.Endpoint)
+	assert.Equal(t, "nomic-embed-text", ps.selected.Model)
+	assert.False(t, ps.needsKey)
+}
+
+func TestProviderStep_CustomEndpoint(t *testing.T) {
+	ps := newProviderStep("Test", "", nil, "embed", false, false)
+
+	// Find "Custom endpoint".
+	for i, c := range ps.choices {
+		if c.kind == "custom" {
+			ps.cursor = i
+			break
+		}
+	}
+
+	// Select custom.
+	ps, _ = ps.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, 1, ps.phase) // endpoint input phase
+
+	// Esc should go back.
+	ps, _ = ps.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	assert.Equal(t, 0, ps.phase)
+}
+
+func TestProviderStep_RerankFormat(t *testing.T) {
+	ps := newProviderStep("Rerank", "", nil, "rerank", true, true)
+
+	// Select a cloud provider for reranking.
+	for i, c := range ps.choices {
+		if c.label == "OpenRouter" {
+			ps.cursor = i
+			break
+		}
+	}
+	ps, _ = ps.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, 2, ps.phase) // model input
+
+	// Type a model name.
+	ps.modelIn.SetValue("reranker-v1")
+	ps, _ = ps.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, 3, ps.phase) // format selection
+	assert.False(t, ps.done)
+
+	// Select jina format.
+	ps, _ = ps.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, ps.done)
+	assert.Equal(t, "jina", ps.formatVal)
+}
+
+func TestKeysStep_NoKeys(t *testing.T) {
+	ks := newKeysStep(false, false, false)
+	ks, _ = ks.Update(nil)
+	assert.True(t, ks.done)
+}
+
+func TestKeysStep_WithKeys(t *testing.T) {
+	ks := newKeysStep(true, false, false)
+	assert.Len(t, ks.entries, 1)
+	assert.Equal(t, "embed", ks.entries[0].service)
+}
+
+func TestConfirmStep_View(t *testing.T) {
+	cfg := &config.Config{
+		Embed: config.ServiceConfig{Endpoint: "http://localhost:11434", Model: "nomic"},
+		LLM:   config.ServiceConfig{Endpoint: "https://openrouter.ai/api", Model: "llama3"},
+	}
+	cs := newConfirmStep(cfg, "", map[string]string{"llm": "sk-test"})
+	view := cs.View(80)
+	assert.Contains(t, view, "http://localhost:11434")
+	assert.Contains(t, view, "nomic")
+	assert.Contains(t, view, "https://openrouter.ai/api")
+	assert.Contains(t, view, "llama3")
+	assert.Contains(t, view, "provided")
+}
+
+func TestWelcomeStep_View(t *testing.T) {
+	ws := newWelcomeStep()
+	// While detecting.
+	view := ws.View(80)
+	assert.Contains(t, view, "Welcome to markedup setup!")
+	assert.Contains(t, view, "Detecting local model servers")
+
+	// After detection with results.
+	ws.detecting = false
+	ws.detected = []config.Endpoint{
+		{Name: "Ollama", URL: "http://localhost:11434", Type: "multi", Healthy: true},
+	}
+	view = ws.View(80)
+	assert.Contains(t, view, "Ollama")
+	assert.Contains(t, view, "Enter to continue")
+
+	// After detection with no results.
+	ws.detected = nil
+	view = ws.View(80)
+	assert.Contains(t, view, "No local model servers detected")
+}
+
+func TestWizardModel_FullFlow_SkipAll(t *testing.T) {
+	m := newWizardModel()
+
+	// Complete detection.
+	result, _ := m.Update(detectDoneMsg{endpoints: nil})
+	m = result.(wizardModel)
+
+	// Advance to embed step.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(wizardModel)
+	assert.Equal(t, 1, m.step)
+
+	// Skip embed.
+	// Navigate to "Skip" (last item).
+	for m.embed.cursor < len(m.embed.choices)-1 {
+		result, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = result.(wizardModel)
+	}
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(wizardModel)
+	assert.Equal(t, 2, m.step) // LLM step
+
+	// Skip LLM.
+	for m.llm.cursor < len(m.llm.choices)-1 {
+		result, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = result.(wizardModel)
+	}
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(wizardModel)
+	assert.Equal(t, 3, m.step) // Rerank step
+
+	// Skip Rerank (pre-selected on Skip for optional).
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(wizardModel)
+	// Should jump to confirm since no keys needed.
+	assert.Equal(t, 5, m.step)
+}
+
+func TestWizardModel_View_AllSteps(t *testing.T) {
+	m := newWizardModel()
+	m.width = 80
+	m.height = 40
+
+	// Each step should render without panicking.
+	for step := 0; step < 6; step++ {
+		m.step = step
+		switch step {
+		case 1:
+			m.embed = newProviderStep("Embed", "", nil, "embed", false, false)
+		case 2:
+			m.llm = newProviderStep("LLM", "", nil, "llm", false, false)
+		case 3:
+			m.rerank = newProviderStep("Rerank", "", nil, "rerank", true, true)
+		case 4:
+			m.keys = newKeysStep(true, false, false)
+		case 5:
+			m.confirm = newConfirmStep(m.config, "", nil)
+		}
+
+		view := m.View()
+		assert.NotEmpty(t, view, "step %d view should not be empty", step)
+		// Step indicator should be present.
+		assert.Contains(t, view, "Welcome")
+		assert.Contains(t, view, "Embed")
+		assert.Contains(t, view, "Confirm")
+	}
+}
+
+func TestProviderStep_CursorBounds(t *testing.T) {
+	ps := newProviderStep("Test", "", nil, "embed", false, false)
+
+	// Move up when already at 0.
+	ps, _ = ps.Update(tea.KeyMsg{Type: tea.KeyUp})
+	assert.Equal(t, 0, ps.cursor)
+
+	// Move down to end.
+	for i := 0; i < len(ps.choices)+5; i++ {
+		ps, _ = ps.Update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	assert.Equal(t, len(ps.choices)-1, ps.cursor)
+}


### PR DESCRIPTION
## Summary
- Adds `internal/tui/setup/` package with a 6-step BubbleTea setup wizard (Welcome+Detect, Embedding, LLM, Reranker, API Keys, Confirm)
- `setup.Run()` entry point launches the wizard in alt-screen mode and returns `*config.Config` (nil on cancel)
- Auto-detects local model servers via `config.DetectLocal()` with spinner, offers cloud presets (OpenRouter/OpenAI/Ollama Cloud), custom endpoints, and skip options
- Masked API key input with OS keychain storage; saves config to `~/.markedup.yaml`
- 20 tests covering all steps, navigation, cancel, skip-all flow, cursor bounds, and view rendering

Closes #70

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/tui/setup/` — 20/20 pass
- [x] `go test ./...` — all packages pass, no regressions
- [ ] Manual: run wizard in terminal, walk through each step
- [ ] Manual: Ctrl+C exits cleanly at every step
- [ ] Manual: Esc navigates back through steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)