### PR TITLE
feat: [Issue #72] first-run detection + TUI wizard hook + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,11 @@ markedup search . "knowledge graph"
 # Traverse the graph from a node
 markedup explore . knowledge-graph --depth 3
 
-# Launch the interactive TUI
+# Launch the interactive TUI (runs setup wizard on first run)
 markedup tui
 ```
+
+On first run, `markedup tui` will launch an interactive setup wizard to configure embedding, LLM, and reranker endpoints. You can also run `markedup setup` directly from the CLI at any time.
 
 ### Quick Start with Existing Markdown
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -677,6 +677,8 @@ provenance:
 
 Launch an interactive terminal UI for searching, exploring, and viewing the knowledge graph. The TUI is built with the BubbleTea framework and provides keyboard-driven navigation.
 
+**First-run behavior:** If no `.markedup.yaml` configuration file is found (neither global `~/.markedup.yaml` nor local in the target directory), the TUI automatically launches the setup wizard before opening the main interface. After the wizard completes (or if the user cancels), the TUI proceeds normally.
+
 ### Usage
 
 ```
@@ -702,3 +704,42 @@ markedup tui --dir ./my-knowledge-base
 ### Output
 
 Opens a full-screen interactive terminal application. The TUI provides views for searching pages, exploring graph relationships, and viewing page content inline.
+
+---
+
+## setup
+
+Interactive configuration wizard for markedup. Walks through text-based prompts to configure embedding, LLM, and reranker endpoints, then saves the result to `~/.markedup.yaml`.
+
+The wizard auto-detects local model servers (Ollama, llama.cpp, etc.) and presents them alongside cloud provider presets (OpenRouter, OpenAI). API keys are stored in the OS keyring when available; otherwise the wizard prints environment variable instructions.
+
+### Usage
+
+```
+markedup setup
+```
+
+### Flags
+
+No command-specific flags.
+
+### Examples
+
+```sh
+# Run the setup wizard
+markedup setup
+```
+
+### Behavior
+
+1. **Auto-detection** -- Scans common local ports for running model servers.
+2. **Provider selection** -- For each service (embed, LLM, reranker), choose a detected local server, a cloud preset, a custom endpoint, or skip.
+3. **Model selection** -- Pick from detected models or type a model name.
+4. **API keys** -- Prompted only for cloud/custom providers that need authentication. Input is masked when running in a terminal.
+5. **Summary & save** -- Review the configuration and confirm. Saved to `~/.markedup.yaml`.
+
+### Notes
+
+- The `tui` command launches this wizard automatically on first run (when no config file exists).
+- Non-TTY contexts (piped input, MCP serve) print a hint suggesting `markedup setup` but do not block execution.
+- Running `setup` again overwrites the existing global config file.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -16,6 +16,8 @@ markedup serve [path]
 - The server loads the knowledge index from the given path, then enters a read-eval-print loop on stdio.
 - One JSON-RPC request per line; responses are written one per line.
 
+**Configuration:** The server reads endpoint and model settings from `.markedup.yaml` (global at `~/.markedup.yaml` or local at `<path>/.markedup.yaml`). Alternatively, set `MARKEDUP_*` environment variables (e.g. `MARKEDUP_LLM_ENDPOINT`, `MARKEDUP_EMBED_MODEL`). Environment variables override config file values. Run `markedup setup` to generate a config file interactively.
+
 ---
 
 ## Protocol Overview

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,6 +2,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/KHAEntertainment/markedup/config"
@@ -25,6 +26,11 @@ func newRootCmd() *cobra.Command {
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			isTTY = isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 			appConfig, _ = config.Load(".")
+
+			if !config.Exists(".") && isTTY {
+				fmt.Println("No configuration found. Run 'markedup setup' to configure, or set MARKEDUP_* env vars.")
+				fmt.Println()
+			}
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/KHAEntertainment/markedup/config"
 	"github.com/KHAEntertainment/markedup/index"
 	"github.com/KHAEntertainment/markedup/internal/tui"
+	"github.com/KHAEntertainment/markedup/internal/tui/setup"
 	"github.com/spf13/cobra"
 )
 
@@ -27,6 +29,20 @@ func newTUICmd() *cobra.Command {
 }
 
 func runTUI(dir string) error {
+	// First-run detection: launch setup wizard if no config exists.
+	if !config.Exists(dir) {
+		cfg, err := setup.Run()
+		if err != nil {
+			return err
+		}
+		if cfg != nil {
+			if err := config.Save(cfg, config.GlobalPath()); err != nil {
+				return fmt.Errorf("saving config: %w", err)
+			}
+			appConfig = cfg
+		}
+	}
+
 	result, err := index.Load(context.Background(), dir, index.WithIgnoreErrors(true))
 	if err != nil {
 		return fmt.Errorf("failed to load %s: %w", dir, err)


### PR DESCRIPTION
## Summary

- **root.go**: Non-blocking first-run hint in `PersistentPreRun` — prints "No configuration found. Run 'markedup setup'..." when `!config.Exists(".") && isTTY`
- **internal/cli/tui.go**: Before loading the index, checks `config.Exists(dir)` — if false, launches `setup.Run()` wizard from `internal/tui/setup`, saves config to global path, and updates `appConfig`
- **Docs**: Updated README.md (Quick Start mentions wizard), cli-reference.md (new `setup` section + first-run note on `tui`), mcp-tools.md (config file note)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` all 15 packages pass
- [ ] Manual: run `markedup tui` with no `~/.markedup.yaml` — wizard should launch
- [ ] Manual: run `markedup search . "test"` with no config on a TTY — hint should print then proceed
- [ ] Manual: pipe output (`markedup search . "test" | cat`) — no hint printed (non-TTY)
- [ ] Manual: after wizard completes, re-run `markedup tui` — wizard should NOT launch again

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)