### PR TITLE
improve: [Issue #82] setup wizard UX polish + functional bug fixes

### DIFF
--- a/config/detect.go
+++ b/config/detect.go
@@ -170,6 +170,14 @@ func detectLocalWithProbes(ctx context.Context, probes []probeSpec) []Endpoint {
 		g.Go(func() error {
 			ep := probeEndpoint(gctx, p)
 			if ep != nil {
+				// Skip services that expose a models API and returned an explicitly
+				// empty list ([]string{}) — e.g. LM Studio or Ollama with nothing
+				// loaded. Surfacing an endpoint with no available models is confusing.
+				// Note: nil models (parse failure) are not filtered so the endpoint
+				// is still surfaced as healthy.
+				if p.ParseModels != nil && ep.Models != nil && len(ep.Models) == 0 {
+					return nil
+				}
 				mu.Lock()
 				results = append(results, *ep)
 				mu.Unlock()

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -20,9 +20,10 @@ var (
 
 func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
-		Use:   "markedup",
-		Short: "Knowledge graph toolkit for markdown files",
-		Long:  "markedup builds an in-memory knowledge graph from Obsidian-compatible markdown files with YAML frontmatter.",
+		Use:     "markedup",
+		Short:   "Knowledge graph toolkit for markdown files",
+		Long:    "markedup builds an in-memory knowledge graph from Obsidian-compatible markdown files with YAML frontmatter.",
+		Version: "0.1.0",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			isTTY = isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 			appConfig, _ = config.Load(".")

--- a/internal/tui/setup/steps.go
+++ b/internal/tui/setup/steps.go
@@ -46,8 +46,21 @@ var cloudProviders = []providerChoice{
 	{label: "Ollama Cloud", endpoint: "https://api.ollama.com", kind: "cloud"},
 }
 
-// rerankFormats are the supported reranker request formats.
+// rerankFormats are the internal config values for reranker request formats.
+// These must NOT be changed — they are stored in config YAML.
 var rerankFormats = []string{"jina", "openai"}
+
+// rerankFormatLabels are the display labels for rerankFormats, parallel by index.
+var rerankFormatLabels = []string{
+	"Standard (/v1/rerank)",
+	"Score API (/v1/score)",
+}
+
+// rerankFormatHelper is shown below the format selector.
+const rerankFormatHelper = "Most cloud providers (Jina, Cohere via OpenRouter) use Standard."
+
+// embedModelNote is shown when auto-detected model list contains no known embedding models.
+const embedModelNote = "Note: select an embedding model (e.g. nomic-embed-text, all-minilm, bge-*). LLM models will not work here."
 
 // ---------------------------------------------------------------------------
 // Welcome + Detect step (step 0)
@@ -128,20 +141,38 @@ func (w welcomeStep) View(width int) string {
 // ---------------------------------------------------------------------------
 
 type providerStep struct {
-	title       string
-	description string
-	optional    bool // if true, shows "skip" first and is pre-selected
-	choices     []providerChoice
-	cursor      int
-	phase       int // 0=choosing provider, 1=entering endpoint, 2=entering model, 3=choosing format (rerank only)
-	endpointIn  textinput.Model
-	modelIn     textinput.Model
-	needsKey    bool   // true if a cloud provider was selected
-	formatIdx   int    // rerank format selector index
-	showFormat  bool   // whether to show format selection
-	selected    config.ServiceConfig
-	formatVal   string
-	done        bool
+	title         string
+	description   string
+	optional      bool // if true, shows "skip" first and is pre-selected
+	choices       []providerChoice
+	cursor        int
+	phase         int // 0=choosing provider, 1=entering endpoint, 2=entering model, 3=choosing format (rerank only)
+	endpointIn    textinput.Model
+	modelIn       textinput.Model
+	needsKey      bool   // true if a cloud provider was selected
+	formatIdx     int    // rerank format selector index
+	showFormat    bool   // whether to show format selection
+	selected      config.ServiceConfig
+	formatVal     string
+	done          bool
+	embedWarning  bool   // true if detected models look like LLM models, not embedding models
+}
+
+// selectedProviderLabel returns a human-readable label for the chosen provider,
+// used to label API key inputs.
+func (p providerStep) selectedProviderLabel() string {
+	if p.cursor < len(p.choices) {
+		c := p.choices[p.cursor]
+		switch c.kind {
+		case "detected":
+			return c.label
+		case "cloud":
+			return c.label
+		case "custom":
+			return "Custom"
+		}
+	}
+	return "API"
 }
 
 func newProviderStep(title, desc string, detected []config.Endpoint, filterType string, optional bool, showFormat bool) providerStep {
@@ -184,16 +215,47 @@ func newProviderStep(title, desc string, detected []config.Endpoint, filterType 
 		startCursor = len(choices) - 1
 	}
 
-	return providerStep{
-		title:       title,
-		description: desc,
-		optional:    optional,
-		choices:     choices,
-		cursor:      startCursor,
-		endpointIn:  ei,
-		modelIn:     mi,
-		showFormat:  showFormat,
+	// For the embed step, check whether the detected model lists appear to be
+	// LLM-named models rather than embedding models. If so, surface a warning.
+	embedWarning := false
+	if filterType == "embed" {
+		for _, c := range choices {
+			if c.kind == "detected" {
+				for _, m := range c.models {
+					if !looksLikeEmbedModel(m) {
+						embedWarning = true
+						break
+					}
+				}
+				if embedWarning {
+					break
+				}
+			}
+		}
 	}
+
+	return providerStep{
+		title:        title,
+		description:  desc,
+		optional:     optional,
+		choices:      choices,
+		cursor:       startCursor,
+		endpointIn:   ei,
+		modelIn:      mi,
+		showFormat:   showFormat,
+		embedWarning: embedWarning,
+	}
+}
+
+// looksLikeEmbedModel returns true if the model name contains patterns that
+// indicate it is an embedding model (rather than a generative LLM).
+func looksLikeEmbedModel(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.Contains(lower, "embed") ||
+		strings.Contains(lower, "minilm") ||
+		strings.Contains(lower, "bge") ||
+		strings.Contains(lower, "e5") ||
+		strings.Contains(lower, "nomic")
 }
 
 func (p providerStep) Update(msg tea.Msg) (providerStep, tea.Cmd) {
@@ -327,6 +389,11 @@ func (p providerStep) View(width int) string {
 
 	switch p.phase {
 	case 0:
+		// UX-01: Show a note when detected models appear to be LLM models.
+		if p.embedWarning {
+			b.WriteString(warningStyle.Render(embedModelNote))
+			b.WriteString("\n\n")
+		}
 		for i, c := range p.choices {
 			prefix := "  "
 			style := subtitleStyle
@@ -361,16 +428,19 @@ func (p providerStep) View(width int) string {
 		b.WriteString("\n\n")
 		b.WriteString(labelStyle.Render("Reranker format:"))
 		b.WriteString("\n")
-		for i, f := range rerankFormats {
+		// UX-11: Use display labels; internal values (rerankFormats) are unchanged.
+		for i, label := range rerankFormatLabels {
 			prefix := "  "
 			style := subtitleStyle
 			if i == p.formatIdx {
 				prefix = "> "
 				style = selectedStyle
 			}
-			b.WriteString(style.Render(prefix + f))
+			b.WriteString(style.Render(prefix + label))
 			b.WriteString("\n")
 		}
+		b.WriteString("\n")
+		b.WriteString(mutedStyle.Render(rerankFormatHelper))
 		b.WriteString("\n")
 		b.WriteString(helpStyle.Render("up/down: navigate  |  Enter: select  |  Esc: back  |  Ctrl+C: cancel"))
 	}
@@ -384,8 +454,10 @@ func (p providerStep) View(width int) string {
 
 // keyEntry represents one API key to collect.
 type keyEntry struct {
-	service string // "embed", "llm", "rerank"
-	label   string // display label
+	service   string   // "embed", "llm", "rerank"
+	label     string   // display label
+	endpoint  string   // provider endpoint, used for deduplication
+	services  []string // additional services sharing this key (for deduplication)
 }
 
 type keysStep struct {
@@ -397,16 +469,57 @@ type keysStep struct {
 	collectedKeys  map[string]string // service -> key value
 }
 
-func newKeysStep(needEmbed, needLLM, needRerank bool) keysStep {
-	var entries []keyEntry
+// newKeysStep builds the API key collection step. For each service that needs
+// a key, provide needX=true, providerLabelX (shown in the input label), and
+// endpointX (used to deduplicate — if two services share the same endpoint,
+// only one key input is shown and the key is applied to both services).
+func newKeysStep(
+	needEmbed bool, embedLabel, embedEndpoint string,
+	needLLM bool, llmLabel, llmEndpoint string,
+	needRerank bool, rerankLabel, rerankEndpoint string,
+) keysStep {
+	type svcInfo struct {
+		service  string
+		label    string
+		endpoint string
+	}
+
+	var candidates []svcInfo
 	if needEmbed {
-		entries = append(entries, keyEntry{service: "embed", label: "Embedding API Key"})
+		candidates = append(candidates, svcInfo{"embed", embedLabel, embedEndpoint})
 	}
 	if needLLM {
-		entries = append(entries, keyEntry{service: "llm", label: "LLM API Key"})
+		candidates = append(candidates, svcInfo{"llm", llmLabel, llmEndpoint})
 	}
 	if needRerank {
-		entries = append(entries, keyEntry{service: "rerank", label: "Reranker API Key"})
+		candidates = append(candidates, svcInfo{"rerank", rerankLabel, rerankEndpoint})
+	}
+
+	// Deduplicate by endpoint. The first service to claim an endpoint becomes
+	// the "primary" entry; subsequent services sharing that endpoint are added
+	// to its services list so the collected key is applied to all of them.
+	seen := map[string]int{} // endpoint -> entries index
+	var entries []keyEntry
+	for _, c := range candidates {
+		if idx, ok := seen[c.endpoint]; ok && c.endpoint != "" {
+			// Same endpoint already has an entry — add this service to it.
+			entries[idx].services = append(entries[idx].services, c.service)
+		} else {
+			// Build a label like "OpenRouter API Key".
+			displayLabel := c.label
+			if displayLabel == "" {
+				displayLabel = "API"
+			}
+			e := keyEntry{
+				service:  c.service,
+				label:    displayLabel + " API Key",
+				endpoint: c.endpoint,
+			}
+			if c.endpoint != "" {
+				seen[c.endpoint] = len(entries)
+			}
+			entries = append(entries, e)
+		}
 	}
 
 	inputs := make([]textinput.Model, len(entries))
@@ -449,7 +562,12 @@ func (k keysStep) Update(msg tea.Msg) (keysStep, tea.Cmd) {
 		case "enter":
 			val := strings.TrimSpace(k.inputs[k.cursor].Value())
 			if val != "" {
-				k.collectedKeys[k.entries[k.cursor].service] = val
+				entry := k.entries[k.cursor]
+				k.collectedKeys[entry.service] = val
+				// UX-12b: Apply the same key to all services sharing this endpoint.
+				for _, svc := range entry.services {
+					k.collectedKeys[svc] = val
+				}
 			}
 			if k.cursor < len(k.entries)-1 {
 				k.inputs[k.cursor].Blur()
@@ -463,7 +581,11 @@ func (k keysStep) Update(msg tea.Msg) (keysStep, tea.Cmd) {
 			if k.cursor < len(k.entries)-1 {
 				val := strings.TrimSpace(k.inputs[k.cursor].Value())
 				if val != "" {
-					k.collectedKeys[k.entries[k.cursor].service] = val
+					entry := k.entries[k.cursor]
+					k.collectedKeys[entry.service] = val
+					for _, svc := range entry.services {
+						k.collectedKeys[svc] = val
+					}
 				}
 				k.inputs[k.cursor].Blur()
 				k.cursor++
@@ -547,7 +669,8 @@ func (c confirmStep) View(width int) string {
 	b.WriteString(labelStyle.Render("Embedding:"))
 	b.WriteString("\n")
 	if c.cfg.Embed.Endpoint != "" {
-		b.WriteString(fmt.Sprintf("  Endpoint: %s\n", c.cfg.Embed.Endpoint))
+		// UX-10: show effective URL with known path suffix for display only.
+		b.WriteString(fmt.Sprintf("  URL:      %s\n", c.cfg.Embed.Endpoint+"/v1/embeddings"))
 		b.WriteString(fmt.Sprintf("  Model:    %s\n", c.cfg.Embed.Model))
 	} else {
 		b.WriteString(mutedStyle.Render("  (not configured)"))
@@ -558,7 +681,7 @@ func (c confirmStep) View(width int) string {
 	b.WriteString(labelStyle.Render("LLM:"))
 	b.WriteString("\n")
 	if c.cfg.LLM.Endpoint != "" {
-		b.WriteString(fmt.Sprintf("  Endpoint: %s\n", c.cfg.LLM.Endpoint))
+		b.WriteString(fmt.Sprintf("  URL:      %s\n", c.cfg.LLM.Endpoint+"/v1/chat/completions"))
 		b.WriteString(fmt.Sprintf("  Model:    %s\n", c.cfg.LLM.Model))
 	} else {
 		b.WriteString(mutedStyle.Render("  (not configured)"))
@@ -569,7 +692,7 @@ func (c confirmStep) View(width int) string {
 	b.WriteString(labelStyle.Render("Reranker:"))
 	b.WriteString("\n")
 	if c.cfg.Rerank.Endpoint != "" {
-		b.WriteString(fmt.Sprintf("  Endpoint: %s\n", c.cfg.Rerank.Endpoint))
+		b.WriteString(fmt.Sprintf("  URL:      %s\n", c.cfg.Rerank.Endpoint+"/v1/rerank"))
 		b.WriteString(fmt.Sprintf("  Model:    %s\n", c.cfg.Rerank.Model))
 		if c.format != "" {
 			b.WriteString(fmt.Sprintf("  Format:   %s\n", c.format))
@@ -599,7 +722,8 @@ func (c confirmStep) View(width int) string {
 		b.WriteString("\n")
 	} else {
 		b.WriteString(fmt.Sprintf("Save to %s?\n\n", config.GlobalPath()))
-		b.WriteString(helpStyle.Render("Enter: save  |  Esc: cancel  |  Ctrl+C: cancel"))
+		// UX-13: Show "Press Enter to save and continue" hint.
+		b.WriteString(helpStyle.Render("Press Enter to save and continue  |  Esc: cancel  |  Ctrl+C: cancel"))
 	}
 
 	return b.String()

--- a/internal/tui/setup/wizard.go
+++ b/internal/tui/setup/wizard.go
@@ -39,12 +39,13 @@ func Run() (*config.Config, error) {
 
 // wizardModel is the root BubbleTea model for the 6-step setup wizard.
 type wizardModel struct {
-	step      int // 0=welcome, 1=embed, 2=llm, 3=rerank, 4=keys, 5=confirm
-	config    *config.Config
-	detected  []config.Endpoint
-	cancelled bool
-	width     int
-	height    int
+	step         int   // 0=welcome, 1=embed, 2=llm, 3=rerank, 4=keys, 5=confirm
+	stepHistory  []int // stack of previous step indices for Esc back-navigation
+	config       *config.Config
+	detected     []config.Endpoint
+	cancelled    bool
+	width        int
+	height       int
 
 	// Sub-models for each step.
 	welcome  welcomeStep
@@ -58,6 +59,16 @@ type wizardModel struct {
 	needEmbedKey  bool
 	needLLMKey    bool
 	needRerankKey bool
+
+	// Track selected provider labels for key step labeling.
+	embedProviderLabel  string
+	llmProviderLabel    string
+	rerankProviderLabel string
+
+	// Track selected provider endpoints for key deduplication.
+	embedEndpoint  string
+	llmEndpoint    string
+	rerankEndpoint string
 }
 
 func newWizardModel() wizardModel {
@@ -114,31 +125,36 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m wizardModel) handleEsc() (tea.Model, tea.Cmd) {
+	// If the current step sub-model has an active sub-phase, let it handle Esc
+	// internally (e.g. going from model-entry back to provider list).
 	switch m.step {
-	case 0:
-		m.cancelled = true
-		return m, tea.Quit
 	case 1:
-		// Check if the embed step is in a sub-phase. If so, let it handle esc.
 		if m.embed.phase > 0 {
 			return m, nil // will be handled by step update
 		}
-		m.step = 0
 	case 2:
 		if m.llm.phase > 0 {
 			return m, nil
 		}
-		m.step = 1
 	case 3:
 		if m.rerank.phase > 0 {
 			return m, nil
 		}
-		m.step = 2
-	case 4:
-		m.step = 3
-	case 5:
+	}
+
+	// Step 0 (welcome): Esc exits cleanly.
+	if m.step == 0 {
 		m.cancelled = true
 		return m, tea.Quit
+	}
+
+	// Pop the step history stack to go back to the previous step.
+	if len(m.stepHistory) > 0 {
+		m.step = m.stepHistory[len(m.stepHistory)-1]
+		m.stepHistory = m.stepHistory[:len(m.stepHistory)-1]
+	} else {
+		// Fallback: go back one step.
+		m.step--
 	}
 	return m, nil
 }
@@ -152,10 +168,11 @@ func (m wizardModel) updateWelcome(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "enter" && !m.welcome.detecting {
 		m.detected = m.welcome.detected
 		m.embed = newProviderStep(
-			"Embedding Provider",
-			"Choose an embedding endpoint for semantic search.",
+			"Choose a text embedding model",
+			"Converts text to vectors for similarity search\ne.g. nomic-embed-text (local), text-embedding-3-small (OpenAI)",
 			m.detected, "embed", false, false,
 		)
+		m.stepHistory = append(m.stepHistory, m.step)
 		m.step = 1
 		return m, nil
 	}
@@ -172,11 +189,14 @@ func (m wizardModel) updateEmbed(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.embed.done {
 		m.config.Embed = m.embed.selected
 		m.needEmbedKey = m.embed.needsKey
+		m.embedEndpoint = m.embed.selected.Endpoint
+		m.embedProviderLabel = m.embed.selectedProviderLabel()
 		m.llm = newProviderStep(
 			"LLM Provider",
-			"Choose an LLM endpoint for enrichment and reasoning.",
+			"Choose an LLM endpoint for enrichment and reasoning.\ne.g. granite-3.1-dense:2b (local), gpt-4o-mini (cloud)",
 			m.detected, "llm", false, false,
 		)
+		m.stepHistory = append(m.stepHistory, m.step)
 		m.step = 2
 		return m, nil
 	}
@@ -191,11 +211,14 @@ func (m wizardModel) updateLLM(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.llm.done {
 		m.config.LLM = m.llm.selected
 		m.needLLMKey = m.llm.needsKey
+		m.llmEndpoint = m.llm.selected.Endpoint
+		m.llmProviderLabel = m.llm.selectedProviderLabel()
 		m.rerank = newProviderStep(
 			"Reranker (optional)",
-			"Configure a reranker? Improves search quality by re-scoring results.",
+			"Configure a reranker model to improve search quality by re-scoring results.\ne.g. bge-reranker-v2-m3 (local TEI), jina-reranker-v2-base-multilingual (cloud)",
 			m.detected, "rerank", true, true,
 		)
+		m.stepHistory = append(m.stepHistory, m.step)
 		m.step = 3
 		return m, nil
 	}
@@ -213,6 +236,9 @@ func (m wizardModel) updateRerank(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Format:        m.rerank.formatVal,
 		}
 		m.needRerankKey = m.rerank.needsKey
+		m.rerankEndpoint = m.rerank.selected.Endpoint
+		m.rerankProviderLabel = m.rerank.selectedProviderLabel()
+		m.stepHistory = append(m.stepHistory, m.step)
 
 		// Skip keys step if no cloud providers selected.
 		if !m.needEmbedKey && !m.needLLMKey && !m.needRerankKey {
@@ -222,7 +248,12 @@ func (m wizardModel) updateRerank(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		m.keys = newKeysStep(m.needEmbedKey, m.needLLMKey, m.needRerankKey)
+		m.keys = newKeysStep(
+			m.needEmbedKey, m.embedProviderLabel, m.embedEndpoint,
+			m.needLLMKey, m.llmProviderLabel, m.llmEndpoint,
+			m.needRerankKey, m.rerankProviderLabel, m.rerankEndpoint,
+		)
+		m.stepHistory = append(m.stepHistory, m.step)
 		m.step = 4
 		return m, m.keys.Init()
 	}
@@ -236,6 +267,7 @@ func (m wizardModel) updateKeys(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if m.keys.done {
 		m.confirm = newConfirmStep(m.config, m.rerank.formatVal, m.keys.collectedKeys)
+		m.stepHistory = append(m.stepHistory, m.step)
 		m.step = 5
 		return m, nil
 	}

--- a/internal/tui/setup/wizard_test.go
+++ b/internal/tui/setup/wizard_test.go
@@ -194,13 +194,13 @@ func TestProviderStep_RerankFormat(t *testing.T) {
 }
 
 func TestKeysStep_NoKeys(t *testing.T) {
-	ks := newKeysStep(false, false, false)
+	ks := newKeysStep(false, "", "", false, "", "", false, "", "")
 	ks, _ = ks.Update(nil)
 	assert.True(t, ks.done)
 }
 
 func TestKeysStep_WithKeys(t *testing.T) {
-	ks := newKeysStep(true, false, false)
+	ks := newKeysStep(true, "Ollama", "http://localhost:11434", false, "", "", false, "", "")
 	assert.Len(t, ks.entries, 1)
 	assert.Equal(t, "embed", ks.entries[0].service)
 }
@@ -295,7 +295,7 @@ func TestWizardModel_View_AllSteps(t *testing.T) {
 		case 3:
 			m.rerank = newProviderStep("Rerank", "", nil, "rerank", true, true)
 		case 4:
-			m.keys = newKeysStep(true, false, false)
+			m.keys = newKeysStep(true, "Ollama", "http://localhost:11434", false, "", "", false, "", "")
 		case 5:
 			m.confirm = newConfirmStep(m.config, "", nil)
 		}


### PR DESCRIPTION
Closes #82

## Summary

IRL testing revealed 11 issues in the setup wizard — a mix of copy/display polish and functional bugs. This PR fixes all of them.

## Root Cause

The wizard was built with placeholder copy, missing version metadata, no step-history stack (Esc was advertised but unimplemented), and API key inputs that used generic service names instead of provider names. Auto-detect also surfaced services with empty model lists.

## Acceptance Criteria Checklist

### Copy / Display fixes
- [x] **UX-02**: Embedding step heading → "Choose a text embedding model" with subtext "Converts text to vectors for similarity search"
- [x] **UX-03**: `markedup --version` returns "0.1.0" — `Version: "0.1.0"` set on cobra root command
- [x] **UX-06**: Role-specific model hints in each provider step description (embed, LLM, reranker)
- [x] **UX-08**: Reranker step copy → "Configure a reranker model to improve search quality by re-scoring results."
- [x] **UX-10**: Confirm screen shows full effective URL per service (`endpoint + /v1/embeddings`, `/v1/chat/completions`, `/v1/rerank`); stored config values unchanged
- [x] **UX-11**: Reranker format labels → "Standard (/v1/rerank)" / "Score API (/v1/score)"; helper text added; internal "jina"/"openai" values unchanged
- [x] **UX-13**: Confirm screen shows "Press Enter to save and continue" hint

### Functional bug fixes
- [x] **UX-01**: `embedWarning` flag shows note when detected model list has no known embedding-name patterns (embed/minilm/bge/e5/nomic)
- [x] **UX-05**: `detectLocalWithProbes` skips endpoints where `ParseModels` returns a non-nil empty slice; nil (parse failure) still surfaces endpoint as healthy
- [x] **UX-09**: `stepHistory []int` stack added to `wizardModel`; Esc pops stack to go back; Esc on step 0 exits cleanly; sub-phase Esc still handled by step sub-model
- [x] **UX-12a**: `providerStep.selectedProviderLabel()` passes provider name into `newKeysStep` — shows e.g. "OpenRouter API Key" not "Reranker API Key"
- [x] **UX-12b**: `newKeysStep` deduplicates inputs by endpoint URL — one key input per unique provider endpoint, key applied to all matching services

## Test Output

```
ok  github.com/KHAEntertainment/markedup                 21.730s
ok  github.com/KHAEntertainment/markedup/cache           1.843s
ok  github.com/KHAEntertainment/markedup/config          8.258s
ok  github.com/KHAEntertainment/markedup/embed           1.188s
ok  github.com/KHAEntertainment/markedup/enrich          1.984s
ok  github.com/KHAEntertainment/markedup/index           0.740s
ok  github.com/KHAEntertainment/markedup/internal/cli    0.385s
ok  github.com/KHAEntertainment/markedup/internal/tui    1.422s
ok  github.com/KHAEntertainment/markedup/internal/tui/setup  0.302s
ok  github.com/KHAEntertainment/markedup/llm             0.304s
ok  github.com/KHAEntertainment/markedup/markdown        0.138s
ok  github.com/KHAEntertainment/markedup/rerank          0.158s
ok  github.com/KHAEntertainment/markedup/schema          0.119s
ok  github.com/KHAEntertainment/markedup/temporal        0.115s
```

`go vet ./...` clean.

## Files Modified

- `config/detect.go` — UX-05: skip empty-model-list endpoints
- `internal/cli/root.go` — UX-03: Version field
- `internal/tui/setup/steps.go` — UX-01, 02, 06, 08, 10, 11, 12a, 12b, 13
- `internal/tui/setup/wizard.go` — UX-09 step history stack, provider label tracking, updated step construction calls
- `internal/tui/setup/wizard_test.go` — Updated tests for new `newKeysStep` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Esc key now navigates back through setup wizard steps.
  * API key deduplication by provider endpoint to simplify multi-service configuration.

* **Improvements**
  * Enhanced setup wizard UI with improved reranker format labels and embedding model detection warnings.
  * Configuration summary now displays provider URLs with full paths for clarity.
  * Updated confirmation step hint text.

* **Updates**
  * CLI root command now displays version 0.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->