### PR TITLE
improve: [Issue #84] Triplex wizard step — dedicated config step in setup wizard

### DIFF
--- a/internal/tui/setup/steps.go
+++ b/internal/tui/setup/steps.go
@@ -449,7 +449,148 @@ func (p providerStep) View(width int) string {
 }
 
 // ---------------------------------------------------------------------------
-// API Keys step (step 4)
+// Triplex step (step 4)
+// ---------------------------------------------------------------------------
+
+// triplexModelName is the fixed model name for the Triplex fine-tune.
+// This matches the model identifier used in enrich/model.go (FormatTriplex).
+const triplexModelName = "Phi-3-mini-128k-instruct/triplex"
+
+// triplexDescription explains what Triplex does and why it is optional.
+const triplexDescription = "Triplex extracts entities and relationships from your notes to build a\nrich knowledge graph. It is optional but highly recommended — without it,\nmarkedup uses your general LLM for extraction (lower quality).\n\nTriplex is a Phi-3-mini-128k-instruct fine-tune and runs locally via Ollama\nor a compatible OpenAI-compatible endpoint. You do not choose the model name\n— it is fixed."
+
+// triplexStep is the wizard sub-model for configuring the Triplex extraction model.
+// Unlike providerStep, there is no model picker — the model name is fixed.
+type triplexStep struct {
+	endpointIn textinput.Model
+	skip       bool
+	done       bool
+	needsKey   bool
+	selected   config.ServiceConfig
+	// skipCursor: 0 = endpoint input focused, 1 = Skip option highlighted
+	skipCursor int
+}
+
+// newTriplexStep creates the Triplex configuration step.
+// If Ollama was among the detected endpoints, the endpoint is pre-filled.
+func newTriplexStep(detected []config.Endpoint) triplexStep {
+	ei := textinput.New()
+	ei.Placeholder = "http://localhost:11434"
+	ei.CharLimit = 256
+	ei.Width = 50
+
+	// Pre-fill Ollama endpoint if detected.
+	for _, ep := range detected {
+		if ep.URL == "http://localhost:11434" || ep.Type == "multi" {
+			ei.SetValue(ep.URL)
+			break
+		}
+	}
+
+	ei.Focus()
+
+	return triplexStep{
+		endpointIn: ei,
+	}
+}
+
+func (t triplexStep) Update(msg tea.Msg) (triplexStep, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "s", "S":
+			// S key skips directly.
+			t.skip = true
+			t.done = true
+			return t, nil
+		case "tab", "down":
+			// Move focus between endpoint input and skip option.
+			if t.skipCursor == 0 {
+				t.endpointIn.Blur()
+				t.skipCursor = 1
+			} else {
+				t.skipCursor = 0
+				t.endpointIn.Focus()
+				return t, textinput.Blink
+			}
+		case "up":
+			if t.skipCursor == 1 {
+				t.skipCursor = 0
+				t.endpointIn.Focus()
+				return t, textinput.Blink
+			}
+		case "enter":
+			if t.skipCursor == 1 {
+				// Skip selected.
+				t.skip = true
+				t.done = true
+				return t, nil
+			}
+			// Confirm endpoint.
+			val := strings.TrimSpace(t.endpointIn.Value())
+			if val == "" {
+				return t, nil
+			}
+			t.selected.Endpoint = val
+			t.selected.Model = triplexModelName
+			// Cloud endpoint needs an API key; localhost does not.
+			t.needsKey = !strings.Contains(val, "localhost") && !strings.Contains(val, "127.0.0.1")
+			t.done = true
+			return t, nil
+		case "esc":
+			// Esc is handled by the wizard orchestrator (goes back to rerank).
+			return t, nil
+		default:
+			if t.skipCursor == 0 {
+				var cmd tea.Cmd
+				t.endpointIn, cmd = t.endpointIn.Update(msg)
+				return t, cmd
+			}
+		}
+	default:
+		if t.skipCursor == 0 {
+			var cmd tea.Cmd
+			t.endpointIn, cmd = t.endpointIn.Update(msg)
+			return t, cmd
+		}
+	}
+	return t, nil
+}
+
+func (t triplexStep) View(width int) string {
+	var b strings.Builder
+
+	b.WriteString(headerStyle.Width(width).Render("Triple Extraction (Triplex)"))
+	b.WriteString("\n\n")
+	b.WriteString(triplexDescription)
+	b.WriteString("\n\n")
+
+	// Fixed model display.
+	b.WriteString(labelStyle.Render("Model: "))
+	b.WriteString(mutedStyle.Render("Phi-3-mini-128k-instruct (Triplex fine-tune)"))
+	b.WriteString("\n\n")
+
+	// Endpoint input.
+	b.WriteString(labelStyle.Render("Endpoint URL:"))
+	b.WriteString("\n")
+	b.WriteString(t.endpointIn.View())
+	b.WriteString("\n\n")
+
+	// Skip option.
+	skipLabel := "  Skip — use LLM for extraction instead (lower quality)"
+	if t.skipCursor == 1 {
+		b.WriteString(selectedStyle.Render("> " + strings.TrimSpace(skipLabel)))
+	} else {
+		b.WriteString(subtitleStyle.Render(skipLabel))
+	}
+	b.WriteString("\n\n")
+
+	b.WriteString(helpStyle.Render("Enter: confirm  |  S: skip  |  Tab/↑↓: navigate  |  Esc: back  |  Ctrl+C: cancel"))
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// API Keys step (step 5)
 // ---------------------------------------------------------------------------
 
 // keyEntry represents one API key to collect.
@@ -477,6 +618,7 @@ func newKeysStep(
 	needEmbed bool, embedLabel, embedEndpoint string,
 	needLLM bool, llmLabel, llmEndpoint string,
 	needRerank bool, rerankLabel, rerankEndpoint string,
+	needTriplex bool, triplexLabel, triplexEndpoint string,
 ) keysStep {
 	type svcInfo struct {
 		service  string
@@ -493,6 +635,9 @@ func newKeysStep(
 	}
 	if needRerank {
 		candidates = append(candidates, svcInfo{"rerank", rerankLabel, rerankEndpoint})
+	}
+	if needTriplex {
+		candidates = append(candidates, svcInfo{"triplex", triplexLabel, triplexEndpoint})
 	}
 
 	// Deduplicate by endpoint. The first service to claim an endpoint becomes
@@ -638,7 +783,7 @@ func (k keysStep) View(width int) string {
 }
 
 // ---------------------------------------------------------------------------
-// Confirm step (step 5)
+// Confirm step (step 6)
 // ---------------------------------------------------------------------------
 
 type confirmStep struct {
@@ -699,6 +844,17 @@ func (c confirmStep) View(width int) string {
 		}
 	} else {
 		b.WriteString(mutedStyle.Render("  (not configured)"))
+		b.WriteString("\n")
+	}
+
+	// Triplex.
+	b.WriteString(labelStyle.Render("Triplex:"))
+	b.WriteString("\n")
+	if c.cfg.Triplex.Endpoint != "" {
+		b.WriteString(fmt.Sprintf("  URL:      %s\n", c.cfg.Triplex.Endpoint))
+		b.WriteString(fmt.Sprintf("  Model:    %s\n", c.cfg.Triplex.Model))
+	} else {
+		b.WriteString(mutedStyle.Render("  not configured (using LLM for extraction)"))
 		b.WriteString("\n")
 	}
 

--- a/internal/tui/setup/wizard.go
+++ b/internal/tui/setup/wizard.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-isatty"
 
@@ -37,9 +38,9 @@ func Run() (*config.Config, error) {
 	return wm.config, nil
 }
 
-// wizardModel is the root BubbleTea model for the 6-step setup wizard.
+// wizardModel is the root BubbleTea model for the 7-step setup wizard.
 type wizardModel struct {
-	step         int   // 0=welcome, 1=embed, 2=llm, 3=rerank, 4=keys, 5=confirm
+	step         int   // 0=welcome, 1=embed, 2=llm, 3=rerank, 4=triplex, 5=keys, 6=confirm
 	stepHistory  []int // stack of previous step indices for Esc back-navigation
 	config       *config.Config
 	detected     []config.Endpoint
@@ -52,23 +53,27 @@ type wizardModel struct {
 	embed    providerStep
 	llm      providerStep
 	rerank   providerStep
+	triplex  triplexStep
 	keys     keysStep
 	confirm  confirmStep
 
 	// Track which services need API keys.
-	needEmbedKey  bool
-	needLLMKey    bool
-	needRerankKey bool
+	needEmbedKey    bool
+	needLLMKey      bool
+	needRerankKey   bool
+	needTriplexKey  bool
 
 	// Track selected provider labels for key step labeling.
 	embedProviderLabel  string
 	llmProviderLabel    string
 	rerankProviderLabel string
+	triplexProviderLabel string
 
 	// Track selected provider endpoints for key deduplication.
-	embedEndpoint  string
-	llmEndpoint    string
-	rerankEndpoint string
+	embedEndpoint   string
+	llmEndpoint     string
+	rerankEndpoint  string
+	triplexEndpoint string
 }
 
 func newWizardModel() wizardModel {
@@ -116,8 +121,10 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case 3:
 		return m.updateRerank(msg)
 	case 4:
-		return m.updateKeys(msg)
+		return m.updateTriplex(msg)
 	case 5:
+		return m.updateKeys(msg)
+	case 6:
 		return m.updateConfirm(msg)
 	}
 
@@ -140,6 +147,7 @@ func (m wizardModel) handleEsc() (tea.Model, tea.Cmd) {
 		if m.rerank.phase > 0 {
 			return m, nil
 		}
+	// case 4 (triplex): no sub-phases, fall through to pop history
 	}
 
 	// Step 0 (welcome): Esc exits cleanly.
@@ -240,11 +248,37 @@ func (m wizardModel) updateRerank(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.rerankProviderLabel = m.rerank.selectedProviderLabel()
 		m.stepHistory = append(m.stepHistory, m.step)
 
+		// Advance to Triplex step (step 4).
+		m.triplex = newTriplexStep(m.detected)
+		m.step = 4
+		return m, textinput.Blink
+	}
+
+	return m, cmd
+}
+
+func (m wizardModel) updateTriplex(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.triplex, cmd = m.triplex.Update(msg)
+
+	if m.triplex.done {
+		if !m.triplex.skip {
+			// Configured: store endpoint + model. Format is auto-set to "triplex"
+			// by the enrich pipeline based on the model name (FormatTriplex).
+			m.config.Triplex = m.triplex.selected
+			m.needTriplexKey = m.triplex.needsKey
+			m.triplexEndpoint = m.triplex.selected.Endpoint
+			m.triplexProviderLabel = "Triplex"
+		}
+		// When skipped: config.Triplex stays zero value, needTriplexKey = false.
+
+		m.stepHistory = append(m.stepHistory, m.step)
+
 		// Skip keys step if no cloud providers selected.
-		if !m.needEmbedKey && !m.needLLMKey && !m.needRerankKey {
+		if !m.needEmbedKey && !m.needLLMKey && !m.needRerankKey && !m.needTriplexKey {
 			m.keys = keysStep{done: true, collectedKeys: map[string]string{}}
 			m.confirm = newConfirmStep(m.config, m.rerank.formatVal, nil)
-			m.step = 5
+			m.step = 6
 			return m, nil
 		}
 
@@ -252,9 +286,10 @@ func (m wizardModel) updateRerank(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.needEmbedKey, m.embedProviderLabel, m.embedEndpoint,
 			m.needLLMKey, m.llmProviderLabel, m.llmEndpoint,
 			m.needRerankKey, m.rerankProviderLabel, m.rerankEndpoint,
+			m.needTriplexKey, m.triplexProviderLabel, m.triplexEndpoint,
 		)
 		m.stepHistory = append(m.stepHistory, m.step)
-		m.step = 4
+		m.step = 5
 		return m, m.keys.Init()
 	}
 
@@ -268,7 +303,7 @@ func (m wizardModel) updateKeys(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.keys.done {
 		m.confirm = newConfirmStep(m.config, m.rerank.formatVal, m.keys.collectedKeys)
 		m.stepHistory = append(m.stepHistory, m.step)
-		m.step = 5
+		m.step = 6
 		return m, nil
 	}
 
@@ -307,6 +342,9 @@ func (m wizardModel) updateConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if k, ok := m.keys.collectedKeys["rerank"]; ok {
 					m.config.Rerank.APIKey = k
 				}
+				if k, ok := m.keys.collectedKeys["triplex"]; ok {
+					m.config.Triplex.APIKey = k
+				}
 
 				m.confirm.saved = true
 				return m, nil
@@ -327,7 +365,7 @@ func (m wizardModel) View() string {
 	}
 
 	// Step indicator.
-	steps := []string{"Welcome", "Embed", "LLM", "Rerank", "Keys", "Confirm"}
+	steps := []string{"Welcome", "Embed", "LLM", "Rerank", "Triplex", "Keys", "Confirm"}
 	stepLine := ""
 	for i, name := range steps {
 		if i == m.step {
@@ -353,8 +391,10 @@ func (m wizardModel) View() string {
 	case 3:
 		view += m.rerank.View(width)
 	case 4:
-		view += m.keys.View(width)
+		view += m.triplex.View(width)
 	case 5:
+		view += m.keys.View(width)
+	case 6:
 		view += m.confirm.View(width)
 	}
 

--- a/internal/tui/setup/wizard_test.go
+++ b/internal/tui/setup/wizard_test.go
@@ -22,7 +22,7 @@ func TestWizardModel_CtrlC_Cancels(t *testing.T) {
 	m := newWizardModel()
 
 	// Ctrl+C at any step should cancel.
-	for step := 0; step < 6; step++ {
+	for step := 0; step < 7; step++ {
 		m.step = step
 		result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 		wm := result.(wizardModel)
@@ -194,13 +194,13 @@ func TestProviderStep_RerankFormat(t *testing.T) {
 }
 
 func TestKeysStep_NoKeys(t *testing.T) {
-	ks := newKeysStep(false, "", "", false, "", "", false, "", "")
+	ks := newKeysStep(false, "", "", false, "", "", false, "", "", false, "", "")
 	ks, _ = ks.Update(nil)
 	assert.True(t, ks.done)
 }
 
 func TestKeysStep_WithKeys(t *testing.T) {
-	ks := newKeysStep(true, "Ollama", "http://localhost:11434", false, "", "", false, "", "")
+	ks := newKeysStep(true, "Ollama", "http://localhost:11434", false, "", "", false, "", "", false, "", "")
 	assert.Len(t, ks.entries, 1)
 	assert.Equal(t, "embed", ks.entries[0].service)
 }
@@ -275,8 +275,13 @@ func TestWizardModel_FullFlow_SkipAll(t *testing.T) {
 	// Skip Rerank (pre-selected on Skip for optional).
 	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = result.(wizardModel)
+	assert.Equal(t, 4, m.step) // Triplex step
+
+	// Skip Triplex by pressing S.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m = result.(wizardModel)
 	// Should jump to confirm since no keys needed.
-	assert.Equal(t, 5, m.step)
+	assert.Equal(t, 6, m.step)
 }
 
 func TestWizardModel_View_AllSteps(t *testing.T) {
@@ -285,7 +290,7 @@ func TestWizardModel_View_AllSteps(t *testing.T) {
 	m.height = 40
 
 	// Each step should render without panicking.
-	for step := 0; step < 6; step++ {
+	for step := 0; step < 7; step++ {
 		m.step = step
 		switch step {
 		case 1:
@@ -295,8 +300,10 @@ func TestWizardModel_View_AllSteps(t *testing.T) {
 		case 3:
 			m.rerank = newProviderStep("Rerank", "", nil, "rerank", true, true)
 		case 4:
-			m.keys = newKeysStep(true, "Ollama", "http://localhost:11434", false, "", "", false, "", "")
+			m.triplex = newTriplexStep(nil)
 		case 5:
+			m.keys = newKeysStep(true, "Ollama", "http://localhost:11434", false, "", "", false, "", "", false, "", "")
+		case 6:
 			m.confirm = newConfirmStep(m.config, "", nil)
 		}
 
@@ -308,6 +315,145 @@ func TestWizardModel_View_AllSteps(t *testing.T) {
 		assert.Contains(t, view, "Confirm")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Triplex step tests
+// ---------------------------------------------------------------------------
+
+func TestTriplexStep_Skip(t *testing.T) {
+	ts := newTriplexStep(nil)
+
+	// Press S to skip.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	assert.True(t, ts.done, "skip should mark done")
+	assert.True(t, ts.skip, "skip should set skip=true")
+	assert.Equal(t, "", ts.selected.Endpoint, "selected endpoint should be zero value")
+	assert.Equal(t, "", ts.selected.Model, "selected model should be zero value")
+	assert.False(t, ts.needsKey, "skipped triplex should not need a key")
+}
+
+func TestTriplexStep_Configure_Localhost(t *testing.T) {
+	ts := newTriplexStep(nil)
+	ts.endpointIn.SetValue("http://localhost:11434")
+
+	// Press Enter to confirm.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, ts.done)
+	assert.False(t, ts.skip)
+	assert.Equal(t, "http://localhost:11434", ts.selected.Endpoint)
+	assert.Equal(t, triplexModelName, ts.selected.Model)
+	assert.False(t, ts.needsKey, "localhost should not need a key")
+}
+
+func TestTriplexStep_Configure_CloudEndpoint(t *testing.T) {
+	ts := newTriplexStep(nil)
+	ts.endpointIn.SetValue("https://api.example.com")
+
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, ts.done)
+	assert.False(t, ts.skip)
+	assert.Equal(t, "https://api.example.com", ts.selected.Endpoint)
+	assert.Equal(t, triplexModelName, ts.selected.Model)
+	assert.True(t, ts.needsKey, "cloud endpoint should need a key")
+}
+
+func TestTriplexStep_Configure_EmptyEndpoint_NoAdvance(t *testing.T) {
+	ts := newTriplexStep(nil)
+	ts.endpointIn.SetValue("")
+
+	// Pressing Enter with empty endpoint should not advance.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.False(t, ts.done, "empty endpoint should not confirm")
+}
+
+func TestTriplexStep_OllamaPreFill(t *testing.T) {
+	detected := []config.Endpoint{
+		{Name: "Ollama", URL: "http://localhost:11434", Type: "multi", Healthy: true},
+	}
+	ts := newTriplexStep(detected)
+	assert.Equal(t, "http://localhost:11434", ts.endpointIn.Value(), "ollama endpoint should be pre-filled")
+}
+
+func TestTriplexStep_CursorNavigation(t *testing.T) {
+	ts := newTriplexStep(nil)
+	assert.Equal(t, 0, ts.skipCursor, "should start with endpoint focused")
+
+	// Tab moves to skip option.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyTab})
+	assert.Equal(t, 1, ts.skipCursor)
+
+	// Up moves back to endpoint.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyUp})
+	assert.Equal(t, 0, ts.skipCursor)
+}
+
+func TestTriplexStep_View(t *testing.T) {
+	ts := newTriplexStep(nil)
+	view := ts.View(80)
+	assert.Contains(t, view, "Triple Extraction (Triplex)")
+	assert.Contains(t, view, "Phi-3-mini-128k-instruct (Triplex fine-tune)")
+	assert.Contains(t, view, "Skip")
+}
+
+func TestWizardModel_TriplexStep(t *testing.T) {
+	m := newWizardModel()
+
+	// Complete detection.
+	result, _ := m.Update(detectDoneMsg{endpoints: nil})
+	m = result.(wizardModel)
+
+	// Advance to embed step.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(wizardModel)
+	assert.Equal(t, 1, m.step)
+
+	// Skip embed (navigate to last item and press Enter).
+	for m.embed.cursor < len(m.embed.choices)-1 {
+		result, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = result.(wizardModel)
+	}
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(wizardModel)
+	assert.Equal(t, 2, m.step)
+
+	// Skip LLM.
+	for m.llm.cursor < len(m.llm.choices)-1 {
+		result, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = result.(wizardModel)
+	}
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(wizardModel)
+	assert.Equal(t, 3, m.step)
+
+	// Skip Rerank (pre-selected on Skip).
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(wizardModel)
+	assert.Equal(t, 4, m.step, "should advance to triplex step")
+
+	// Configure Triplex with localhost endpoint.
+	m.triplex.endpointIn.SetValue("http://localhost:11434")
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(wizardModel)
+
+	// No cloud keys needed — should jump straight to confirm (step 6).
+	assert.Equal(t, 6, m.step, "no cloud keys → jump to confirm")
+	assert.Equal(t, "http://localhost:11434", m.config.Triplex.Endpoint)
+	assert.Equal(t, triplexModelName, m.config.Triplex.Model)
+}
+
+func TestWizardModel_EscFromTriplex_GoesBackToRerank(t *testing.T) {
+	m := newWizardModel()
+	m.step = 4
+	m.triplex = newTriplexStep(nil)
+	// Push rerank (step 3) onto the history stack as the wizard would.
+	m.stepHistory = []int{0, 1, 2, 3}
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	wm := result.(wizardModel)
+	assert.Equal(t, 3, wm.step, "Esc from triplex should go back to rerank")
+}
+
+// ---------------------------------------------------------------------------
 
 func TestProviderStep_CursorBounds(t *testing.T) {
 	ps := newProviderStep("Test", "", nil, "embed", false, false)


### PR DESCRIPTION
Closes #84

## Summary

- Adds a new dedicated `triplexStep` sub-model in `internal/tui/setup/steps.go` — simpler than `providerStep`: no model picker, no format selector, just endpoint input + skip option
- Inserts Triplex as step 4 in the wizard flow (between Reranker and API Keys), renumbering Keys → 5 and Confirm → 6
- Step indicator updated: `[Welcome] > [Embed] > [LLM] > [Rerank] > [Triplex] > [Keys] > [Confirm]`
- Fixed model display: "Phi-3-mini-128k-instruct (Triplex fine-tune)" — user never types the model name
- Endpoint input with Ollama pre-fill when detected; `needsKey=true` for non-localhost endpoints
- Skip option via `S` key or Tab-to-skip-cursor + Enter; when skipped `config.Triplex` stays zero value
- `newKeysStep` extended with a fourth `needTriplex/triplexLabel/triplexEndpoint` parameter (deduplicates by endpoint like other services)
- Confirm screen shows Triplex endpoint+model or "not configured (using LLM for extraction)"
- Esc from Triplex pops `stepHistory` → returns to Reranker (step 3)
- `updateConfirm` applies collected triplex API key to `config.Triplex.APIKey`

## Acceptance Criteria

- [x] New wizard step added after Reranker step (step 4, before API Keys)
- [x] Step heading: "Triple Extraction (Triplex)"
- [x] Step body explains what Triplex does, that it is optional but highly recommended
- [x] Model name displayed as fixed text — user does NOT type the model name
- [x] User only inputs endpoint URL (pre-filled to http://localhost:11434 if Ollama detected)
- [x] Skip option: "Skip — use LLM for extraction instead (lower quality)"
- [x] When configured: `config.Triplex.Endpoint` and `config.Triplex.Model` set
- [x] When skipped: `config.Triplex` remains zero value
- [x] Esc navigates back to Reranker step
- [x] API Keys step detects Triplex cloud endpoint needs a key
- [x] Confirm screen shows Triplex configuration or "not configured"
- [x] `go test ./internal/tui/...` passes
- [x] `go test ./...` passes with no regressions
- [x] `go vet ./...` clean

## Test plan

- [x] `TestTriplexStep_Skip` — S key sets done=true, skip=true, selected is zero value, needsKey=false
- [x] `TestTriplexStep_Configure_Localhost` — localhost endpoint confirms correctly, needsKey=false
- [x] `TestTriplexStep_Configure_CloudEndpoint` — cloud endpoint sets needsKey=true
- [x] `TestTriplexStep_Configure_EmptyEndpoint_NoAdvance` — empty endpoint does not advance
- [x] `TestTriplexStep_OllamaPreFill` — Ollama detected → endpoint pre-filled
- [x] `TestTriplexStep_CursorNavigation` — Tab/Up navigate between endpoint and skip option
- [x] `TestTriplexStep_View` — renders title, model name, skip option
- [x] `TestWizardModel_TriplexStep` — wizard advances through triplex step, stores config, skips keys for localhost
- [x] `TestWizardModel_EscFromTriplex_GoesBackToRerank` — Esc pops history to rerank step
- [x] All 40 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Triplex configuration step to the setup wizard
  * Users can configure a Triplex endpoint during initial setup
  * Support for both local and cloud Triplex endpoints with automatic API key requirement detection
  * Triplex configuration step can be skipped if not needed
  * Setup confirmation summary now displays configured Triplex endpoint information or notes when Triplex is not configured

<!-- end of auto-generated comment: release notes by coderabbit.ai -->