### PR TITLE
improve: [Issue #88] TUI home navigation + background Enrich/Embed + status bar + Settings

### DIFF
--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -48,5 +48,5 @@ func runTUI(dir string) error {
 		return fmt.Errorf("failed to load %s: %w", dir, err)
 	}
 
-	return tui.Run(result.Index)
+	return tui.Run(result.Index, dir, appConfig)
 }

--- a/internal/tui/home.go
+++ b/internal/tui/home.go
@@ -14,17 +14,19 @@ type menuItem struct {
 }
 
 var homeMenuItems = []menuItem{
-	{label: "Search", description: "Search the knowledge base"},
-	{label: "Explore", description: "Explore graph connections"},
-	{label: "Graph", description: "Graph overview (coming soon)"},
-	{label: "Settings / Reconfigure", description: "Reconfigure markedup"},
+	{label: "Search", description: "Search by keyword or semantic similarity"},
+	{label: "Explore", description: "Traverse graph connections from an entity"},
+	{label: "Enrich", description: "Auto-generate frontmatter for plain markdown files"},
+	{label: "Embed", description: "Generate vector embeddings for semantic search"},
+	{label: "Settings", description: "View config and reconfigure"},
 }
 
 // homeModel is the home/menu screen shown on TUI launch.
 type homeModel struct {
-	cursor int
-	width  int
-	height int
+	cursor      int
+	width       int
+	height      int
+	taskRunning bool // when true, Enrich and Embed are greyed out
 }
 
 func newHomeModel() homeModel {
@@ -67,17 +69,27 @@ func (m homeModel) View() string {
 	b.WriteString("\n\n")
 
 	for i, item := range homeMenuItems {
+		// Enrich (2) and Embed (3) are disabled while a task is running.
+		disabled := m.taskRunning && (i == homeMenuEnrich || i == homeMenuEmbed)
+
 		prefix := "  "
 		labelSty := lipgloss.NewStyle()
 		descSty := mutedStyle
 
-		if i == m.cursor {
+		switch {
+		case disabled:
+			labelSty = mutedStyle
+			descSty = mutedStyle
+		case i == m.cursor:
 			prefix = "> "
 			labelSty = selectedStyle
 			descSty = lipgloss.NewStyle().Foreground(colorSecondary)
 		}
 
 		line := prefix + item.label
+		if disabled {
+			line = "  " + item.label + " (running...)"
+		}
 		b.WriteString(labelSty.Render(line))
 		b.WriteString("  ")
 		b.WriteString(descSty.Render(item.description))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,8 +1,14 @@
 package tui
 
 import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/KHAEntertainment/markedup/config"
 	"github.com/KHAEntertainment/markedup/index"
 	"github.com/KHAEntertainment/markedup/schema"
 )
@@ -16,26 +22,47 @@ const (
 	viewDocument
 	viewExplore
 	viewOnboarding
+	viewSettings
 )
+
+// homeMenuSearch is the menu index for Search.
+const homeMenuSearch = 0
+
+// homeMenuExplore is the menu index for Explore.
+const homeMenuExplore = 1
+
+// homeMenuEnrich is the menu index for Enrich.
+const homeMenuEnrich = 2
+
+// homeMenuEmbed is the menu index for Embed.
+const homeMenuEmbed = 3
+
+// homeMenuSettings is the menu index for Settings.
+const homeMenuSettings = 4
 
 // Model is the top-level BubbleTea model that composes all views.
 type Model struct {
-	idx        *index.KnowledgeIndex
-	current    view
-	home       homeModel
-	search     searchModel
-	doc        docModel
-	explore    exploreModel
-	onboarding onboardingModel
-	width      int
-	height     int
-	empty      bool // true when index has zero pages
+	idx         *index.KnowledgeIndex
+	kbDir       string
+	cfg         *config.Config
+	current     view
+	home        homeModel
+	search      searchModel
+	doc         docModel
+	explore     exploreModel
+	onboarding  onboardingModel
+	settings    settingsModel
+	status      statusModel
+	taskRunning bool
+	width       int
+	height      int
+	empty       bool // true when index has zero pages
 }
 
 // NewModel creates the root TUI model from a loaded knowledge index.
 // If the index has zero pages, the onboarding screen is shown first.
 // Otherwise, the home/menu screen is shown.
-func NewModel(idx *index.KnowledgeIndex) Model {
+func NewModel(idx *index.KnowledgeIndex, kbDir string, cfg *config.Config) Model {
 	empty := idx.Pages() == 0
 	initial := viewHome
 	if empty {
@@ -43,10 +70,13 @@ func NewModel(idx *index.KnowledgeIndex) Model {
 	}
 	return Model{
 		idx:        idx,
+		kbDir:      kbDir,
+		cfg:        cfg,
 		current:    initial,
 		home:       newHomeModel(),
 		search:     newSearchModel(idx),
 		onboarding: newOnboardingModel(),
+		settings:   newSettingsModel(cfg, 0, 0),
 		empty:      empty,
 	}
 }
@@ -76,6 +106,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.explore.height = msg.Height
 		m.onboarding.width = msg.Width
 		m.onboarding.height = msg.Height
+		m.settings.width = msg.Width
+		m.settings.height = msg.Height
 
 		// Re-init doc viewport on resize if viewing doc.
 		if m.current == viewDocument {
@@ -84,6 +116,60 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.doc.initViewport()
 		}
 		return m, nil
+
+	case statusTickMsg:
+		if m.status.shouldDismiss() {
+			m.status = statusModel{state: taskIdle}
+			m.taskRunning = false
+			m.home.taskRunning = false
+			return m, nil
+		}
+		m.status = m.status.tick()
+		if m.status.state == taskRunning {
+			return m, spinnerTick()
+		}
+		// Done/error: keep ticking for auto-dismiss.
+		return m, dismissTick()
+
+	case taskDoneMsg:
+		m.taskRunning = false
+		m.home.taskRunning = false
+		if msg.err != nil {
+			// Extract last non-empty line from output as error detail.
+			errDetail := msg.err.Error()
+			if msg.output != "" {
+				lines := strings.Split(strings.TrimSpace(msg.output), "\n")
+				for i := len(lines) - 1; i >= 0; i-- {
+					if strings.TrimSpace(lines[i]) != "" {
+						errDetail = strings.TrimSpace(lines[i])
+						break
+					}
+				}
+			}
+			m.status = statusModel{
+				state:     taskError,
+				taskName:  msg.taskName,
+				message:   errDetail,
+				dismissAt: time.Now().Add(5 * time.Second),
+			}
+		} else {
+			m.status = statusModel{
+				state:     taskDone,
+				taskName:  msg.taskName,
+				dismissAt: time.Now().Add(5 * time.Second),
+			}
+			// Reload the index so newly enriched/embedded pages appear.
+			if m.kbDir != "" {
+				result, err := index.Load(context.Background(), m.kbDir, index.WithIgnoreErrors(true))
+				if err == nil {
+					m.idx = result.Index
+					m.search = newSearchModel(m.idx)
+					m.search.width = m.width
+					m.search.height = m.height
+				}
+			}
+		}
+		return m, dismissTick()
 
 	case tea.KeyMsg:
 		// Global quit keys.
@@ -130,19 +216,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateDocument(msg)
 	case viewExplore:
 		return m.updateExplore(msg)
+	case viewSettings:
+		return m.updateSettings(msg)
 	}
 
 	return m, nil
 }
-
-// homeMenuSearch is the menu index for Search.
-const homeMenuSearch = 0
-
-// homeMenuExplore is the menu index for Explore.
-const homeMenuExplore = 1
-
-// homeMenuSettings is the menu index for Settings / Reconfigure.
-const homeMenuSettings = 3
 
 func (m Model) updateHome(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
@@ -151,22 +230,46 @@ func (m Model) updateHome(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch m.home.SelectedIndex() {
 			case homeMenuSearch:
 				m.current = viewSearch
+				m.search.exploreMode = false
 				m.search.input.Focus()
 				return m, nil
 			case homeMenuExplore:
-				// Go to explore. If no page is loaded yet, go to search first
-				// so the user can pick one.
+				// Go to search with explore mode active.
 				m.current = viewSearch
+				m.search.exploreMode = true
 				m.search.input.Focus()
 				return m, nil
+			case homeMenuEnrich:
+				if m.taskRunning {
+					return m, nil
+				}
+				m.taskRunning = true
+				m.home.taskRunning = true
+				m.status = statusModel{
+					state:    taskRunning,
+					taskName: "Enrich",
+				}
+				return m, tea.Batch(
+					runBackgroundTask(m.kbDir, "Enrich", "markedup", "enrich"),
+					spinnerTick(),
+				)
+			case homeMenuEmbed:
+				if m.taskRunning {
+					return m, nil
+				}
+				m.taskRunning = true
+				m.home.taskRunning = true
+				m.status = statusModel{
+					state:    taskRunning,
+					taskName: "Embed",
+				}
+				return m, tea.Batch(
+					runBackgroundTask(m.kbDir, "Embed", "markedup", "embed"),
+					spinnerTick(),
+				)
 			case homeMenuSettings:
-				// Settings: exit and tell user to run `markedup setup`.
-				// We can't re-launch the setup wizard from within the TUI without
-				// a round-trip through the CLI, so we quit with a message.
-				// The message is surfaced via the CLI's exit flow.
-				return m, tea.Quit
-			default:
-				// Graph (placeholder) and any future items: no-op for now.
+				m.settings = newSettingsModel(m.cfg, m.width, m.height)
+				m.current = viewSettings
 				return m, nil
 			}
 		}
@@ -263,6 +366,17 @@ func (m Model) updateExplore(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m Model) updateSettings(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "esc", "h":
+			m.current = viewHome
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
 // navigateToNode follows a link in the explore view.
 func (m *Model) navigateToNode(page *schema.Page) {
 	m.explore = newExploreModel(m.idx, page)
@@ -272,17 +386,55 @@ func (m *Model) navigateToNode(page *schema.Page) {
 
 // View implements tea.Model.
 func (m Model) View() string {
+	var content string
 	switch m.current {
 	case viewHome:
-		return m.home.View()
+		content = m.home.View()
 	case viewOnboarding:
-		return m.onboarding.View()
+		content = m.onboarding.View()
 	case viewSearch:
-		return m.search.View()
+		content = m.search.View()
 	case viewDocument:
-		return m.doc.View()
+		content = m.doc.View()
 	case viewExplore:
-		return m.explore.View()
+		content = m.explore.View()
+	case viewSettings:
+		content = m.settings.View()
 	}
-	return ""
+
+	// Append status bar if there is something to show.
+	statusLine := m.status.View(m.width)
+	if statusLine != "" {
+		return content + "\n" + statusLine
+	}
+	return content
+}
+
+// runBackgroundTask runs a subprocess to completion in a goroutine and returns
+// a taskDoneMsg when it finishes. The kbDir is appended as the last argument.
+func runBackgroundTask(kbDir, taskName, binary string, subArgs ...string) tea.Cmd {
+	return func() tea.Msg {
+		args := append(subArgs, kbDir)
+		cmd := exec.Command(binary, args...)
+		out, err := cmd.CombinedOutput()
+		return taskDoneMsg{
+			taskName: taskName,
+			err:      err,
+			output:   string(out),
+		}
+	}
+}
+
+// spinnerTick returns a Cmd that sends statusTickMsg after 200ms.
+func spinnerTick() tea.Cmd {
+	return tea.Tick(200*time.Millisecond, func(_ time.Time) tea.Msg {
+		return statusTickMsg{}
+	})
+}
+
+// dismissTick returns a Cmd that sends statusTickMsg after 1s (for auto-dismiss polling).
+func dismissTick() tea.Cmd {
+	return tea.Tick(1*time.Second, func(_ time.Time) tea.Msg {
+		return statusTickMsg{}
+	})
 }

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -22,14 +22,15 @@ type debounceMsg struct {
 // searchModel implements the search view: a text input with real-time
 // filtered results.
 type searchModel struct {
-	idx      *index.KnowledgeIndex
-	input    textinput.Model
-	results  []index.Result
-	cursor   int
-	width    int
-	height   int
-	lastQuery string
+	idx           *index.KnowledgeIndex
+	input         textinput.Model
+	results       []index.Result
+	cursor        int
+	width         int
+	height        int
+	lastQuery     string
 	debounceTimer *time.Timer
+	exploreMode   bool // when true, show explore-oriented header/hint
 }
 
 func newSearchModel(idx *index.KnowledgeIndex) searchModel {
@@ -111,9 +112,19 @@ func (m searchModel) View() string {
 	var b strings.Builder
 
 	// Header.
-	header := headerStyle.Width(m.width).Render("Search")
+	headerText := "Search"
+	if m.exploreMode {
+		headerText = "Explore"
+	}
+	header := headerStyle.Width(m.width).Render(headerText)
 	b.WriteString(header)
 	b.WriteString("\n\n")
+
+	// Explore mode subtitle.
+	if m.exploreMode {
+		b.WriteString(subtitleStyle.Render("Explore Mode — search for an entity, then tab to traverse its connections"))
+		b.WriteString("\n\n")
+	}
 
 	// Input.
 	b.WriteString(m.input.View())
@@ -175,7 +186,11 @@ func (m searchModel) View() string {
 
 	// Help.
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("enter: view  |  tab: explore  |  esc/h: home  |  q/ctrl+c: quit"))
+	if m.exploreMode {
+		b.WriteString(helpStyle.Render("tab: traverse connections  |  enter: view doc  |  esc/h: home  |  q/ctrl+c: quit"))
+	} else {
+		b.WriteString(helpStyle.Render("enter: view  |  tab: explore  |  esc/h: home  |  q/ctrl+c: quit"))
+	}
 
 	return b.String()
 }

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -1,0 +1,110 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/KHAEntertainment/markedup/config"
+)
+
+// settingsModel is a read-only view of the current markedup configuration.
+type settingsModel struct {
+	cfg    *config.Config
+	width  int
+	height int
+}
+
+func newSettingsModel(cfg *config.Config, width, height int) settingsModel {
+	return settingsModel{cfg: cfg, width: width, height: height}
+}
+
+func (m settingsModel) View() string {
+	var b strings.Builder
+
+	header := headerStyle.Width(m.width).Render("Settings")
+	b.WriteString(header)
+	b.WriteString("\n\n")
+
+	b.WriteString(subtitleStyle.Render("Current Configuration"))
+	b.WriteString("\n\n")
+
+	cfg := m.cfg
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+
+	// Embed section.
+	b.WriteString(labelStyle.Render("Embed"))
+	b.WriteString("\n")
+	b.WriteString("  ")
+	b.WriteString(mutedStyle.Render("endpoint: "))
+	if cfg.Embed.Endpoint != "" {
+		b.WriteString(cfg.Embed.Endpoint)
+	} else {
+		b.WriteString(mutedStyle.Render("not configured"))
+	}
+	b.WriteString("\n")
+	b.WriteString("  ")
+	b.WriteString(mutedStyle.Render("model:    "))
+	if cfg.Embed.Model != "" {
+		b.WriteString(cfg.Embed.Model)
+	} else {
+		b.WriteString(mutedStyle.Render("not configured"))
+	}
+	b.WriteString("\n\n")
+
+	// LLM section.
+	b.WriteString(labelStyle.Render("LLM"))
+	b.WriteString("\n")
+	b.WriteString("  ")
+	b.WriteString(mutedStyle.Render("endpoint: "))
+	if cfg.LLM.Endpoint != "" {
+		b.WriteString(cfg.LLM.Endpoint)
+	} else {
+		b.WriteString(mutedStyle.Render("not configured"))
+	}
+	b.WriteString("\n")
+	b.WriteString("  ")
+	b.WriteString(mutedStyle.Render("model:    "))
+	if cfg.LLM.Model != "" {
+		b.WriteString(cfg.LLM.Model)
+	} else {
+		b.WriteString(mutedStyle.Render("not configured"))
+	}
+	b.WriteString("\n\n")
+
+	// Rerank section.
+	b.WriteString(labelStyle.Render("Rerank"))
+	b.WriteString("\n")
+	b.WriteString("  ")
+	b.WriteString(mutedStyle.Render("endpoint: "))
+	if cfg.Rerank.Endpoint != "" {
+		b.WriteString(cfg.Rerank.Endpoint)
+	} else {
+		b.WriteString(mutedStyle.Render("not configured"))
+	}
+	b.WriteString("\n")
+	b.WriteString("  ")
+	b.WriteString(mutedStyle.Render("model:    "))
+	if cfg.Rerank.Model != "" {
+		b.WriteString(cfg.Rerank.Model)
+	} else {
+		b.WriteString(mutedStyle.Render("not configured"))
+	}
+	b.WriteString("\n\n")
+
+	// Triplex section.
+	b.WriteString(labelStyle.Render("Triplex"))
+	b.WriteString("\n")
+	b.WriteString("  ")
+	b.WriteString(mutedStyle.Render("endpoint: "))
+	if cfg.Triplex.Endpoint != "" {
+		b.WriteString(cfg.Triplex.Endpoint)
+	} else {
+		b.WriteString(mutedStyle.Render("not configured"))
+	}
+	b.WriteString("\n\n")
+
+	b.WriteString(helpStyle.Render("To reconfigure, exit and run: markedup setup  |  esc/h: back"))
+
+	return b.String()
+}

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -1,0 +1,74 @@
+package tui
+
+import (
+	"fmt"
+	"time"
+)
+
+// taskState represents the current state of a background task.
+type taskState int
+
+const (
+	taskIdle    taskState = iota
+	taskRunning           // subprocess is running
+	taskDone              // completed successfully
+	taskError             // completed with error
+)
+
+// statusModel tracks the state of a background task and renders a status bar.
+type statusModel struct {
+	state      taskState
+	taskName   string    // "Enrich" or "Embed"
+	message    string    // completion/error message
+	dismissAt  time.Time // auto-dismiss after 5s on done/error
+	spinnerPos int       // spinner animation position
+}
+
+// statusTickMsg is sent to advance the spinner animation.
+type statusTickMsg struct{}
+
+// taskDoneMsg is sent when a background subprocess completes.
+type taskDoneMsg struct {
+	taskName string
+	err      error
+	output   string
+}
+
+var spinnerFrames = []string{"⠋", "⠙", "⠸", "⠴", "⠦", "⠇"}
+
+// View renders the status bar line for the given terminal width.
+// - idle: empty string (no bar shown)
+// - running: spinner + task name
+// - done: success message
+// - error: error message
+func (m statusModel) View(width int) string {
+	switch m.state {
+	case taskIdle:
+		return ""
+	case taskRunning:
+		frame := spinnerFrames[m.spinnerPos%len(spinnerFrames)]
+		msg := fmt.Sprintf("%s %sing...", frame, m.taskName)
+		return helpStyle.Render(msg)
+	case taskDone:
+		msg := fmt.Sprintf("✓ %s complete", m.taskName)
+		return selectedStyle.Render(msg)
+	case taskError:
+		msg := fmt.Sprintf("✗ %s failed: %s", m.taskName, m.message)
+		return warningStyle.Render(msg)
+	}
+	return ""
+}
+
+// tick advances the spinner frame and returns a new statusModel.
+func (m statusModel) tick() statusModel {
+	m.spinnerPos++
+	return m
+}
+
+// shouldDismiss returns true when the done/error state has expired.
+func (m statusModel) shouldDismiss() bool {
+	if m.state != taskDone && m.state != taskError {
+		return false
+	}
+	return !m.dismissAt.IsZero() && time.Now().After(m.dismissAt)
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -7,18 +7,20 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-isatty"
 
+	"github.com/KHAEntertainment/markedup/config"
 	"github.com/KHAEntertainment/markedup/index"
 )
 
-// Run launches the TUI with the given knowledge index. It returns an error
-// if stdout is not a terminal or if the TUI encounters a fatal error.
-// The TUI package has no dependency on cobra — it receives only the index.
-func Run(idx *index.KnowledgeIndex) error {
+// Run launches the TUI with the given knowledge index, KB directory, and config.
+// It returns an error if stdout is not a terminal or if the TUI encounters a
+// fatal error. The TUI package has no dependency on cobra — it receives only
+// the index, directory, and config.
+func Run(idx *index.KnowledgeIndex, kbDir string, cfg *config.Config) error {
 	if !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 		return fmt.Errorf("TUI requires a terminal (stdout is not a TTY); use plain CLI commands instead")
 	}
 
-	model := NewModel(idx)
+	model := NewModel(idx, kbDir, cfg)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 
 	_, err := p.Run()

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -4,11 +4,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/KHAEntertainment/markedup/config"
 	"github.com/KHAEntertainment/markedup/index"
 	"github.com/KHAEntertainment/markedup/schema"
 )
@@ -66,7 +68,7 @@ func writeTestFile(dir, name, content string) error {
 
 func TestNewModel_EmptyIndex(t *testing.T) {
 	idx := buildTestIndex(t)
-	m := NewModel(idx)
+	m := NewModel(idx, ".", nil)
 
 	assert.True(t, m.empty)
 	// Empty index should show onboarding screen, not search.
@@ -85,7 +87,7 @@ func TestNewModel_WithPages(t *testing.T) {
 		&schema.Page{Frontmatter: schema.GraphFrontmatter{ID: "test-1", Title: "Test Page", EntityType: "concept", Confidence: 0.9}},
 	)
 
-	m := NewModel(idx)
+	m := NewModel(idx, ".", nil)
 	assert.False(t, m.empty)
 	// With pages, should start at home screen.
 	assert.Equal(t, viewHome, m.current)
@@ -99,7 +101,7 @@ func TestModel_WindowResize(t *testing.T) {
 	idx := buildTestIndex(t,
 		&schema.Page{Frontmatter: schema.GraphFrontmatter{ID: "test-1", Title: "Test Page", Confidence: 0.9}},
 	)
-	m := NewModel(idx)
+	m := NewModel(idx, ".", nil)
 
 	resized, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	rm := resized.(Model)
@@ -113,7 +115,7 @@ func TestModel_QuitOnCtrlC(t *testing.T) {
 	idx := buildTestIndex(t,
 		&schema.Page{Frontmatter: schema.GraphFrontmatter{ID: "test-1", Title: "Test Page", Confidence: 0.9}},
 	)
-	m := NewModel(idx)
+	m := NewModel(idx, ".", nil)
 
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	require.NotNil(t, cmd)
@@ -127,7 +129,7 @@ func TestModel_QuitOnQ_EmptyInput(t *testing.T) {
 	idx := buildTestIndex(t,
 		&schema.Page{Frontmatter: schema.GraphFrontmatter{ID: "test-1", Title: "Test Page", Confidence: 0.9}},
 	)
-	m := NewModel(idx)
+	m := NewModel(idx, ".", nil)
 
 	// q with empty input should quit.
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
@@ -300,7 +302,7 @@ func TestModel_ViewTransitions(t *testing.T) {
 		},
 	)
 
-	m := NewModel(idx)
+	m := NewModel(idx, ".", nil)
 	// With pages, starts at home screen.
 	assert.Equal(t, viewHome, m.current)
 
@@ -361,8 +363,11 @@ func TestHomeModel_Navigation(t *testing.T) {
 	v := m.View()
 	assert.Contains(t, v, "Search")
 	assert.Contains(t, v, "Explore")
-	assert.Contains(t, v, "Graph")
+	assert.Contains(t, v, "Enrich")
+	assert.Contains(t, v, "Embed")
 	assert.Contains(t, v, "Settings")
+	// "Graph" menu item removed; only appears in subtitle "Knowledge Graph Terminal UI"
+	assert.NotContains(t, v, "Graph overview")
 }
 
 func TestOnboardingModel_View(t *testing.T) {
@@ -376,4 +381,177 @@ func TestOnboardingModel_View(t *testing.T) {
 	assert.Contains(t, v, "markedup enrich .")
 	assert.Contains(t, v, "markedup embed .")
 	assert.Contains(t, v, "markedup tui")
+}
+
+// --------------------------------------------------------------------------
+// New tests for Wave 5 features
+// --------------------------------------------------------------------------
+
+func TestHomeModel_Items(t *testing.T) {
+	m := newHomeModel()
+	m.width = 80
+	m.height = 24
+
+	// Exactly 5 menu items.
+	assert.Len(t, homeMenuItems, 5)
+	assert.Equal(t, "Search", homeMenuItems[homeMenuSearch].label)
+	assert.Equal(t, "Explore", homeMenuItems[homeMenuExplore].label)
+	assert.Equal(t, "Enrich", homeMenuItems[homeMenuEnrich].label)
+	assert.Equal(t, "Embed", homeMenuItems[homeMenuEmbed].label)
+	assert.Equal(t, "Settings", homeMenuItems[homeMenuSettings].label)
+
+	// Graph item is gone.
+	for _, item := range homeMenuItems {
+		assert.NotEqual(t, "Graph", item.label)
+	}
+
+	// View renders all items.
+	v := m.View()
+	assert.Contains(t, v, "Search")
+	assert.Contains(t, v, "Explore")
+	assert.Contains(t, v, "Enrich")
+	assert.Contains(t, v, "Embed")
+	assert.Contains(t, v, "Settings")
+}
+
+func TestHomeModel_TaskRunning_DisablesEnrichEmbed(t *testing.T) {
+	m := newHomeModel()
+	m.width = 80
+	m.height = 24
+	m.taskRunning = true
+
+	v := m.View()
+	assert.Contains(t, v, "Enrich (running...)")
+	assert.Contains(t, v, "Embed (running...)")
+}
+
+func TestStatusModel_View_Idle(t *testing.T) {
+	s := statusModel{state: taskIdle}
+	v := s.View(80)
+	assert.Equal(t, "", v)
+}
+
+func TestStatusModel_View_Running(t *testing.T) {
+	s := statusModel{state: taskRunning, taskName: "Enrich"}
+	v := s.View(80)
+	assert.Contains(t, v, "Enrich")
+	assert.Contains(t, v, "ing...")
+}
+
+func TestStatusModel_View_Done(t *testing.T) {
+	s := statusModel{state: taskDone, taskName: "Enrich"}
+	v := s.View(80)
+	assert.Contains(t, v, "✓")
+	assert.Contains(t, v, "Enrich")
+	assert.Contains(t, v, "complete")
+}
+
+func TestStatusModel_View_Error(t *testing.T) {
+	s := statusModel{state: taskError, taskName: "Embed", message: "connection refused"}
+	v := s.View(80)
+	assert.Contains(t, v, "✗")
+	assert.Contains(t, v, "Embed")
+	assert.Contains(t, v, "failed")
+	assert.Contains(t, v, "connection refused")
+}
+
+func TestStatusModel_ShouldDismiss(t *testing.T) {
+	// Not done — should not dismiss.
+	s := statusModel{state: taskRunning}
+	assert.False(t, s.shouldDismiss())
+
+	// Done but dismissAt in the future.
+	s = statusModel{state: taskDone, dismissAt: time.Now().Add(10 * time.Second)}
+	assert.False(t, s.shouldDismiss())
+
+	// Done and dismissAt in the past.
+	s = statusModel{state: taskDone, dismissAt: time.Now().Add(-1 * time.Second)}
+	assert.True(t, s.shouldDismiss())
+
+	// Error and dismissAt in the past.
+	s = statusModel{state: taskError, dismissAt: time.Now().Add(-1 * time.Second)}
+	assert.True(t, s.shouldDismiss())
+}
+
+func TestSettingsModel_View(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Embed.Endpoint = "http://localhost:11434/v1"
+	cfg.Embed.Model = "nomic-embed-text"
+	cfg.LLM.Endpoint = "http://localhost:11434"
+	cfg.LLM.Model = "llama3"
+
+	m := newSettingsModel(cfg, 80, 24)
+	v := m.View()
+
+	assert.Contains(t, v, "Settings")
+	assert.Contains(t, v, "Embed")
+	assert.Contains(t, v, "http://localhost:11434/v1")
+	assert.Contains(t, v, "nomic-embed-text")
+	assert.Contains(t, v, "LLM")
+	assert.Contains(t, v, "llama3")
+	assert.Contains(t, v, "Rerank")
+	assert.Contains(t, v, "Triplex")
+	assert.Contains(t, v, "markedup setup")
+	assert.Contains(t, v, "esc/h: back")
+}
+
+func TestSettingsModel_View_NilConfig(t *testing.T) {
+	m := newSettingsModel(nil, 80, 24)
+	v := m.View()
+	assert.Contains(t, v, "Settings")
+	assert.Contains(t, v, "not configured")
+}
+
+func TestModel_Settings_Navigation(t *testing.T) {
+	idx := buildTestIndex(t,
+		&schema.Page{Frontmatter: schema.GraphFrontmatter{ID: "test-1", Title: "Test Page", Confidence: 0.9}},
+	)
+	m := NewModel(idx, ".", nil)
+	assert.Equal(t, viewHome, m.current)
+
+	// Navigate down to Settings (index 4).
+	for i := 0; i < homeMenuSettings; i++ {
+		m.home.cursor = i + 1
+	}
+	m.home.cursor = homeMenuSettings
+
+	// Press Enter on Settings.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	assert.Equal(t, viewSettings, m.current)
+
+	// Esc returns to home.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	assert.Equal(t, viewHome, m.current)
+}
+
+func TestModel_ExploreMode_Header(t *testing.T) {
+	idx := buildTestIndex(t,
+		&schema.Page{Frontmatter: schema.GraphFrontmatter{ID: "test-1", Title: "Test Page", Confidence: 0.9}},
+	)
+	m := NewModel(idx, ".", nil)
+
+	// Navigate to Explore from home.
+	m.home.cursor = homeMenuExplore
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	assert.Equal(t, viewSearch, m.current)
+	assert.True(t, m.search.exploreMode)
+
+	v := m.View()
+	assert.Contains(t, v, "Explore Mode")
+	assert.Contains(t, v, "tab to traverse")
+}
+
+func TestModel_StatusBar_AppendedToView(t *testing.T) {
+	idx := buildTestIndex(t,
+		&schema.Page{Frontmatter: schema.GraphFrontmatter{ID: "test-1", Title: "Test Page", Confidence: 0.9}},
+	)
+	m := NewModel(idx, ".", nil)
+	m.status = statusModel{state: taskDone, taskName: "Enrich"}
+
+	v := m.View()
+	assert.Contains(t, v, "✓")
+	assert.Contains(t, v, "Enrich")
 }


### PR DESCRIPTION
Closes #88

## Summary

- **Home menu**: Updated to 5 items (Search, Explore, Enrich, Embed, Settings); Graph placeholder removed
- **Explore mode**: Selecting Explore from home sets `exploreMode = true` on the search model, showing a distinct header ("Explore Mode — search for an entity, then tab to traverse its connections") and updated help text
- **Background tasks**: Enrich and Embed launch `markedup enrich <dir>` / `markedup embed <dir>` as goroutine subprocesses; TUI remains fully interactive during execution
- **Status bar**: `statusModel` (statusbar.go) appended to every view — idle (hidden), running (spinner + task name), done (✓ message, 5s auto-dismiss), error (✗ message + detail, 5s auto-dismiss)
- **Index hot-reload**: After Enrich/Embed completes successfully, `index.Load` is called and `m.idx` + `m.search` are replaced so new pages appear immediately
- **Settings screen**: New `settingsModel` (settings.go) shows embed/LLM/rerank/triplex endpoint+model; esc/h returns to home; no longer calls `tea.Quit`
- **Signature updates**: `Run()` and `NewModel()` now accept `kbDir string` and `cfg *config.Config`; `internal/cli/tui.go` passes `dir` and `appConfig`

## Acceptance Criteria

- [x] Menu updated to 5 items (Search/Explore/Enrich/Embed/Settings), Graph removed
- [x] Explore goes to search with explore-mode header/hint
- [x] Enrich starts `markedup enrich .` as background subprocess
- [x] Embed starts `markedup embed .` as background subprocess
- [x] TUI fully interactive during task execution
- [x] Enrich/Embed menu items shown greyed-out while task running
- [x] Status bar on all views: idle/running/done/error states
- [x] Auto-dismiss after 5s on done/error
- [x] Only one background task at a time (taskRunning guard)
- [x] Index reloaded on successful task completion
- [x] Settings screen shows config summary, esc/h returns to home
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass (15 packages, 0 failures)

## Test Output

```
ok  github.com/KHAEntertainment/markedup/internal/tui      1.029s
ok  github.com/KHAEntertainment/markedup/internal/cli      1.419s
ok  github.com/KHAEntertainment/markedup/internal/tui/setup 0.999s
# ... all 15 packages pass
```

New tests added: `TestHomeModel_Items`, `TestHomeModel_TaskRunning_DisablesEnrichEmbed`, `TestStatusModel_View_Idle/Running/Done/Error`, `TestStatusModel_ShouldDismiss`, `TestSettingsModel_View`, `TestSettingsModel_View_NilConfig`, `TestModel_Settings_Navigation`, `TestModel_ExploreMode_Header`, `TestModel_StatusBar_AppendedToView`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Enrich and Embed actions to the home menu
  * Introduced a Settings screen to view current application configuration
  * Added Explore mode for search with enhanced navigation options
  * Added background task status display with spinner animation and completion feedback
  * Menu items are disabled during task execution with "(running...)" indication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->