### PR TITLE
improve: [Issue #94] Triplex model editable + keyring pre-fill

### DIFF
--- a/internal/tui/setup/steps.go
+++ b/internal/tui/setup/steps.go
@@ -457,22 +457,24 @@ func (p providerStep) View(width int) string {
 const triplexModelName = "Phi-3-mini-128k-instruct/triplex"
 
 // triplexDescription explains what Triplex does and why it is optional.
-const triplexDescription = "Triplex extracts entities and relationships from your notes to build a\nrich knowledge graph. It is optional but highly recommended — without it,\nmarkedup uses your general LLM for extraction (lower quality).\n\nTriplex is a Phi-3-mini-128k-instruct fine-tune and runs locally via Ollama\nor a compatible OpenAI-compatible endpoint. You do not choose the model name\n— it is fixed."
+const triplexDescription = "Triplex extracts entities and relationships from your notes to build a\nrich knowledge graph. It is optional but highly recommended — without it,\nmarkedup uses your general LLM for extraction (lower quality).\n\nTriplex is a Phi-3-mini-128k-instruct fine-tune and runs locally via Ollama\nor a compatible OpenAI-compatible endpoint. The default model name is\npre-filled but can be edited if your host uses a different identifier."
 
 // triplexStep is the wizard sub-model for configuring the Triplex extraction model.
-// Unlike providerStep, there is no model picker — the model name is fixed.
+// The model name defaults to triplexModelName but can be edited by the user.
 type triplexStep struct {
 	endpointIn textinput.Model
+	modelIn    textinput.Model
 	skip       bool
 	done       bool
 	needsKey   bool
 	selected   config.ServiceConfig
-	// skipCursor: 0 = endpoint input focused, 1 = Skip option highlighted
+	// skipCursor: 0 = endpoint input focused, 1 = model input focused, 2 = Skip option highlighted
 	skipCursor int
 }
 
 // newTriplexStep creates the Triplex configuration step.
 // If Ollama was among the detected endpoints, the endpoint is pre-filled.
+// The model name defaults to triplexModelName but is editable.
 func newTriplexStep(detected []config.Endpoint) triplexStep {
 	ei := textinput.New()
 	ei.Placeholder = "http://localhost:11434"
@@ -489,8 +491,16 @@ func newTriplexStep(detected []config.Endpoint) triplexStep {
 
 	ei.Focus()
 
+	// Model input pre-filled with default Triplex model name.
+	mi := textinput.New()
+	mi.Placeholder = triplexModelName
+	mi.CharLimit = 128
+	mi.Width = 50
+	mi.SetValue(triplexModelName)
+
 	return triplexStep{
 		endpointIn: ei,
+		modelIn:    mi,
 	}
 }
 
@@ -499,42 +509,71 @@ func (t triplexStep) Update(msg tea.Msg) (triplexStep, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "s", "S":
-			// S key skips directly.
-			t.skip = true
-			t.done = true
-			return t, nil
-		case "tab", "down":
-			// Move focus between endpoint input and skip option.
+			// S key skips directly (only when not typing in an input).
+			if t.skipCursor == 2 {
+				t.skip = true
+				t.done = true
+				return t, nil
+			}
+			// When focused on endpoint or model input, let the character through.
 			if t.skipCursor == 0 {
+				var cmd tea.Cmd
+				t.endpointIn, cmd = t.endpointIn.Update(msg)
+				return t, cmd
+			}
+			if t.skipCursor == 1 {
+				var cmd tea.Cmd
+				t.modelIn, cmd = t.modelIn.Update(msg)
+				return t, cmd
+			}
+		case "tab", "down":
+			// Cycle: endpoint(0) → model(1) → skip(2) → endpoint(0).
+			switch t.skipCursor {
+			case 0:
 				t.endpointIn.Blur()
 				t.skipCursor = 1
-			} else {
+				t.modelIn.Focus()
+				return t, textinput.Blink
+			case 1:
+				t.modelIn.Blur()
+				t.skipCursor = 2
+			case 2:
 				t.skipCursor = 0
 				t.endpointIn.Focus()
 				return t, textinput.Blink
 			}
 		case "up":
-			if t.skipCursor == 1 {
+			switch t.skipCursor {
+			case 2:
+				t.skipCursor = 1
+				t.modelIn.Focus()
+				return t, textinput.Blink
+			case 1:
+				t.modelIn.Blur()
 				t.skipCursor = 0
 				t.endpointIn.Focus()
 				return t, textinput.Blink
 			}
 		case "enter":
-			if t.skipCursor == 1 {
+			if t.skipCursor == 2 {
 				// Skip selected.
 				t.skip = true
 				t.done = true
 				return t, nil
 			}
-			// Confirm endpoint.
-			val := strings.TrimSpace(t.endpointIn.Value())
-			if val == "" {
+			// Confirm endpoint + model.
+			epVal := strings.TrimSpace(t.endpointIn.Value())
+			if epVal == "" {
 				return t, nil
 			}
-			t.selected.Endpoint = val
-			t.selected.Model = triplexModelName
+			modelVal := strings.TrimSpace(t.modelIn.Value())
+			if modelVal == "" {
+				modelVal = triplexModelName
+			}
+			t.selected.Endpoint = epVal
+			t.selected.Model = modelVal
 			// Cloud endpoint needs an API key; localhost does not.
-			t.needsKey = !strings.Contains(val, "localhost") && !strings.Contains(val, "127.0.0.1")
+			t.needsKey = !strings.Contains(epVal, "localhost") && !strings.Contains(epVal, "127.0.0.1")
 			t.done = true
 			return t, nil
 		case "esc":
@@ -546,11 +585,21 @@ func (t triplexStep) Update(msg tea.Msg) (triplexStep, tea.Cmd) {
 				t.endpointIn, cmd = t.endpointIn.Update(msg)
 				return t, cmd
 			}
+			if t.skipCursor == 1 {
+				var cmd tea.Cmd
+				t.modelIn, cmd = t.modelIn.Update(msg)
+				return t, cmd
+			}
 		}
 	default:
 		if t.skipCursor == 0 {
 			var cmd tea.Cmd
 			t.endpointIn, cmd = t.endpointIn.Update(msg)
+			return t, cmd
+		}
+		if t.skipCursor == 1 {
+			var cmd tea.Cmd
+			t.modelIn, cmd = t.modelIn.Update(msg)
 			return t, cmd
 		}
 	}
@@ -565,27 +614,28 @@ func (t triplexStep) View(width int) string {
 	b.WriteString(triplexDescription)
 	b.WriteString("\n\n")
 
-	// Fixed model display.
-	b.WriteString(labelStyle.Render("Model: "))
-	b.WriteString(mutedStyle.Render("Phi-3-mini-128k-instruct (Triplex fine-tune)"))
-	b.WriteString("\n\n")
-
 	// Endpoint input.
 	b.WriteString(labelStyle.Render("Endpoint URL:"))
 	b.WriteString("\n")
 	b.WriteString(t.endpointIn.View())
 	b.WriteString("\n\n")
 
+	// Model input (editable, pre-filled with default).
+	b.WriteString(labelStyle.Render("Model:"))
+	b.WriteString("\n")
+	b.WriteString(t.modelIn.View())
+	b.WriteString("\n\n")
+
 	// Skip option.
 	skipLabel := "  Skip — use LLM for extraction instead (lower quality)"
-	if t.skipCursor == 1 {
+	if t.skipCursor == 2 {
 		b.WriteString(selectedStyle.Render("> " + strings.TrimSpace(skipLabel)))
 	} else {
 		b.WriteString(subtitleStyle.Render(skipLabel))
 	}
 	b.WriteString("\n\n")
 
-	b.WriteString(helpStyle.Render("Enter: confirm  |  S: skip  |  Tab/↑↓: navigate  |  Esc: back  |  Ctrl+C: cancel"))
+	b.WriteString(helpStyle.Render("Enter: confirm  |  Tab/↑↓: navigate  |  Esc: back  |  Ctrl+C: cancel"))
 	return b.String()
 }
 
@@ -595,10 +645,11 @@ func (t triplexStep) View(width int) string {
 
 // keyEntry represents one API key to collect.
 type keyEntry struct {
-	service   string   // "embed", "llm", "rerank"
-	label     string   // display label
-	endpoint  string   // provider endpoint, used for deduplication
-	services  []string // additional services sharing this key (for deduplication)
+	service    string   // "embed", "llm", "rerank"
+	label      string   // display label
+	endpoint   string   // provider endpoint, used for deduplication
+	services   []string // additional services sharing this key (for deduplication)
+	prefilled  bool     // true if an existing key was loaded from keyring
 }
 
 type keysStep struct {
@@ -608,6 +659,7 @@ type keysStep struct {
 	keyringOK      bool
 	done           bool
 	collectedKeys  map[string]string // service -> key value
+	hasExisting    bool              // true if any entry was pre-filled from keyring
 }
 
 // newKeysStep builds the API key collection step. For each service that needs
@@ -667,6 +719,24 @@ func newKeysStep(
 		}
 	}
 
+	// Check keyring for existing keys and pre-fill.
+	hasExisting := false
+	collectedKeys := make(map[string]string)
+	if config.KeyringAvailable() {
+		for i := range entries {
+			keyName := entries[i].service + "-api-key"
+			if existing, err := config.GetKey(keyName); err == nil && existing != "" {
+				entries[i].prefilled = true
+				hasExisting = true
+				// Pre-populate collectedKeys so Enter without changes keeps the key.
+				collectedKeys[entries[i].service] = existing
+				for _, svc := range entries[i].services {
+					collectedKeys[svc] = existing
+				}
+			}
+		}
+	}
+
 	inputs := make([]textinput.Model, len(entries))
 	for i := range entries {
 		ti := textinput.New()
@@ -674,6 +744,9 @@ func newKeysStep(
 		ti.CharLimit = 256
 		ti.Width = 50
 		ti.EchoMode = textinput.EchoPassword
+		if entries[i].prefilled {
+			ti.SetValue(collectedKeys[entries[i].service])
+		}
 		inputs[i] = ti
 	}
 	if len(inputs) > 0 {
@@ -684,7 +757,8 @@ func newKeysStep(
 		entries:       entries,
 		inputs:        inputs,
 		keyringOK:     config.KeyringAvailable(),
-		collectedKeys: make(map[string]string),
+		collectedKeys: collectedKeys,
+		hasExisting:   hasExisting,
 	}
 }
 
@@ -767,11 +841,28 @@ func (k keysStep) View(width int) string {
 	}
 	b.WriteString("\n\n")
 
+	// Show a note if any keys were pre-filled from the keyring.
+	hasPrefilled := false
+	for _, e := range k.entries {
+		if e.prefilled {
+			hasPrefilled = true
+			break
+		}
+	}
+	if hasPrefilled {
+		b.WriteString(mutedStyle.Render("Existing API keys found. Press Enter to keep."))
+		b.WriteString("\n\n")
+	}
+
 	for i, entry := range k.entries {
+		label := entry.label + ":"
+		if entry.prefilled {
+			label += " (saved)"
+		}
 		if i == k.cursor {
-			b.WriteString(selectedStyle.Render(entry.label + ":"))
+			b.WriteString(selectedStyle.Render(label))
 		} else {
-			b.WriteString(labelStyle.Render(entry.label + ":"))
+			b.WriteString(labelStyle.Render(label))
 		}
 		b.WriteString("\n")
 		b.WriteString(k.inputs[i].View())

--- a/internal/tui/setup/wizard_test.go
+++ b/internal/tui/setup/wizard_test.go
@@ -277,8 +277,12 @@ func TestWizardModel_FullFlow_SkipAll(t *testing.T) {
 	m = result.(WizardModel)
 	assert.Equal(t, 4, m.step) // Triplex step
 
-	// Skip Triplex by pressing S.
-	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	// Skip Triplex: navigate to Skip option (tab twice), then Enter.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // endpoint→model
+	m = result.(WizardModel)
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // model→skip
+	m = result.(WizardModel)
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = result.(WizardModel)
 	// Should jump to confirm since no keys needed.
 	assert.Equal(t, 6, m.step)
@@ -323,7 +327,11 @@ func TestWizardModel_View_AllSteps(t *testing.T) {
 func TestTriplexStep_Skip(t *testing.T) {
 	ts := newTriplexStep(nil)
 
-	// Press S to skip.
+	// Navigate to Skip option (skipCursor=2), then press S to skip.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyTab}) // 0→1
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyTab}) // 1→2
+	assert.Equal(t, 2, ts.skipCursor, "should be on Skip option")
+
 	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
 	assert.True(t, ts.done, "skip should mark done")
 	assert.True(t, ts.skip, "skip should set skip=true")
@@ -378,20 +386,36 @@ func TestTriplexStep_CursorNavigation(t *testing.T) {
 	ts := newTriplexStep(nil)
 	assert.Equal(t, 0, ts.skipCursor, "should start with endpoint focused")
 
+	// Tab moves to model input.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyTab})
+	assert.Equal(t, 1, ts.skipCursor, "tab from endpoint should go to model")
+
 	// Tab moves to skip option.
 	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyTab})
-	assert.Equal(t, 1, ts.skipCursor)
+	assert.Equal(t, 2, ts.skipCursor, "tab from model should go to skip")
 
-	// Up moves back to endpoint.
+	// Tab wraps back to endpoint.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyTab})
+	assert.Equal(t, 0, ts.skipCursor, "tab from skip should wrap to endpoint")
+
+	// Up from model goes to endpoint.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyTab}) // 0→1
 	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyUp})
-	assert.Equal(t, 0, ts.skipCursor)
+	assert.Equal(t, 0, ts.skipCursor, "up from model should go to endpoint")
+
+	// Up from skip goes to model.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyTab}) // 0→1
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyTab}) // 1→2
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyUp})
+	assert.Equal(t, 1, ts.skipCursor, "up from skip should go to model")
 }
 
 func TestTriplexStep_View(t *testing.T) {
 	ts := newTriplexStep(nil)
 	view := ts.View(80)
 	assert.Contains(t, view, "Triple Extraction (Triplex)")
-	assert.Contains(t, view, "Phi-3-mini-128k-instruct (Triplex fine-tune)")
+	assert.Contains(t, view, "Model:")
+	assert.Contains(t, view, triplexModelName, "editable model input should show default")
 	assert.Contains(t, view, "Skip")
 }
 
@@ -451,6 +475,107 @@ func TestWizardModel_EscFromTriplex_GoesBackToRerank(t *testing.T) {
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	wm := result.(WizardModel)
 	assert.Equal(t, 3, wm.step, "Esc from triplex should go back to rerank")
+}
+
+// ---------------------------------------------------------------------------
+// Triplex editable model tests
+// ---------------------------------------------------------------------------
+
+func TestTriplexStep_CustomModel(t *testing.T) {
+	ts := newTriplexStep(nil)
+
+	// Model input should be pre-filled with the default.
+	assert.Equal(t, triplexModelName, ts.modelIn.Value(), "model should default to triplexModelName")
+
+	// Set a custom endpoint and custom model.
+	ts.endpointIn.SetValue("http://localhost:11434")
+	ts.modelIn.SetValue("my-custom-triplex-v2")
+
+	// Press Enter to confirm.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, ts.done)
+	assert.False(t, ts.skip)
+	assert.Equal(t, "http://localhost:11434", ts.selected.Endpoint)
+	assert.Equal(t, "my-custom-triplex-v2", ts.selected.Model, "custom model name should be used")
+	assert.False(t, ts.needsKey)
+}
+
+func TestTriplexStep_DefaultModel_WhenEmpty(t *testing.T) {
+	ts := newTriplexStep(nil)
+
+	ts.endpointIn.SetValue("http://localhost:11434")
+	ts.modelIn.SetValue("") // empty model should fall back to default
+
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, ts.done)
+	assert.Equal(t, triplexModelName, ts.selected.Model, "empty model should fall back to default")
+}
+
+func TestTriplexStep_ModelPreFilled(t *testing.T) {
+	ts := newTriplexStep(nil)
+	assert.Equal(t, triplexModelName, ts.modelIn.Value(), "model input should be pre-filled with default")
+}
+
+func TestTriplexStep_SInEndpointInput_PassesThrough(t *testing.T) {
+	ts := newTriplexStep(nil)
+	assert.Equal(t, 0, ts.skipCursor, "should start on endpoint")
+
+	// Pressing 's' in endpoint input should NOT skip — it should type 's'.
+	ts, _ = ts.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	assert.False(t, ts.done, "pressing s in endpoint input should not skip")
+	assert.False(t, ts.skip)
+}
+
+// ---------------------------------------------------------------------------
+// Keyring pre-fill tests
+// ---------------------------------------------------------------------------
+
+func TestKeysStep_PrefilledFlag(t *testing.T) {
+	// Create a keysStep and manually simulate pre-fill.
+	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "")
+	assert.Len(t, ks.entries, 1)
+
+	// Manually set prefilled (since we can't use real keyring in tests).
+	ks.entries[0].prefilled = true
+	ks.inputs[0].SetValue("sk-existing-key")
+	ks.collectedKeys["embed"] = "sk-existing-key"
+
+	// Pressing Enter without changes should keep the pre-filled key.
+	ks, _ = ks.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, ks.done)
+	assert.Equal(t, "sk-existing-key", ks.collectedKeys["embed"])
+}
+
+func TestKeysStep_PrefilledView(t *testing.T) {
+	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "")
+	ks.entries[0].prefilled = true
+
+	view := ks.View(80)
+	assert.Contains(t, view, "Existing API keys found", "should show pre-fill note")
+	assert.Contains(t, view, "(saved)", "should show saved indicator on entry")
+}
+
+func TestKeysStep_PrefilledOverwrite(t *testing.T) {
+	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "")
+	ks.entries[0].prefilled = true
+	ks.inputs[0].SetValue("sk-old-key")
+	ks.collectedKeys["embed"] = "sk-old-key"
+
+	// Type a new key (simulate by setting value directly).
+	ks.inputs[0].SetValue("sk-new-key")
+
+	// Press Enter — should use the new value.
+	ks, _ = ks.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, ks.done)
+	assert.Equal(t, "sk-new-key", ks.collectedKeys["embed"], "new key should overwrite old")
+}
+
+func TestKeysStep_NoPrefillNote_WhenNoPrefill(t *testing.T) {
+	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "")
+
+	view := ks.View(80)
+	assert.NotContains(t, view, "Existing API keys found", "should not show pre-fill note when no keys pre-filled")
+	assert.NotContains(t, view, "(saved)")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Triplex model editable**: Changed the Triplex step's model name from read-only display to an editable `textinput.Model`, pre-filled with the default `Phi-3-mini-128k-instruct/triplex`. Users on different hosts can now override the model identifier. Navigation cycles endpoint(0) -> model(1) -> skip(2) via Tab/Up/Down.
- **Keyring pre-fill**: The API keys step now checks `config.GetKey()` for each service on initialization. Existing keys are pre-filled into password-masked inputs, with "(saved)" labels and an "Existing API keys found. Press Enter to keep." note. Pressing Enter without changes retains the existing key; typing a new value overwrites it.
- **Tests**: Updated existing triplex tests for the new 3-position cursor and editable model. Added `TestTriplexStep_CustomModel`, `TestTriplexStep_DefaultModel_WhenEmpty`, `TestTriplexStep_ModelPreFilled`, `TestTriplexStep_SInEndpointInput_PassesThrough`, and 4 keyring pre-fill tests.

Closes #94

## Test plan
- [x] `go test ./...` passes (37 setup tests, all green)
- [x] `go vet ./...` clean
- [ ] Manual: run `markedup tui`, open Settings -> Setup Wizard, verify Triplex step shows editable model field
- [ ] Manual: store an API key via keyring, re-run wizard, verify key is pre-filled with "(saved)" indicator
- [ ] Manual: verify Tab/Up/Down cycles through endpoint -> model -> skip correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made Triplex model field user-editable with a pre-filled default value
  * Added automatic API key pre-fill from system keyring during setup wizard

* **Improvements**
  * Enhanced setup wizard keyboard navigation and focus management
  * Display indicator for saved credentials with prompt to press Enter to keep existing API keys

<!-- end of auto-generated comment: release notes by coderabbit.ai -->