### PR TITLE
improve: add --timeout flag to enrich command

### DIFF
--- a/internal/cli/enrich.go
+++ b/internal/cli/enrich.go
@@ -27,6 +27,7 @@ var (
 	enrichAPIKey      string
 	enrichEntityTypes string
 	enrichPredicates  string
+	enrichTimeout     time.Duration
 )
 
 func newEnrichCmd() *cobra.Command {
@@ -52,6 +53,7 @@ Partial frontmatter is filled in without overwriting existing fields.`,
 	cmd.Flags().StringVar(&enrichAPIKey, "api-key", "", "API key for model endpoint (optional)")
 	cmd.Flags().StringVar(&enrichEntityTypes, "entity-types", "", "comma-separated entity types for model extraction")
 	cmd.Flags().StringVar(&enrichPredicates, "predicates", "", "comma-separated relationship predicates for model extraction")
+	cmd.Flags().DurationVar(&enrichTimeout, "timeout", 5*time.Minute, "timeout per file for model extraction (e.g. 5m, 10m)")
 
 	return cmd
 }
@@ -196,7 +198,7 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 			}
 			fmt.Fprintf(out, "Model enriching %s...\n", relPath)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), enrichTimeout)
 			modelResult, modelErr := modelExtractor.Extract(ctx, page.Body, entityTypes, predicates)
 			cancel()
 
@@ -209,7 +211,7 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 			// Generate summary (separate call for focused one-sentence output).
 			if merged.Summary == "" || enrichForce {
 				bodyPreview := enrich.BodyPreview(page.Body, 500)
-				summaryCtx, summaryCancel := context.WithTimeout(context.Background(), 1*time.Minute)
+				summaryCtx, summaryCancel := context.WithTimeout(context.Background(), enrichTimeout)
 				summary, summaryErr := modelExtractor.GenerateSummary(summaryCtx, merged.Title, merged.EntityType, merged.Tags, bodyPreview)
 				summaryCancel()
 


### PR DESCRIPTION
## Summary
- Adds `--timeout` flag to `markedup enrich` (default 5 minutes, was hardcoded 2min extraction + 1min summary)
- Applies to both Tier 2 model extraction and summary generation calls
- Fixes context deadline exceeded errors when using network-hosted models (e.g. Triplex on remote llama.cpp)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `markedup enrich --help` shows the new `--timeout` flag
- [ ] Manual test with `--timeout 10m` on remote model endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--timeout` CLI flag to control enrichment operation timeouts (default: 5 minutes).
  * Model extraction and summary generation now share the same timeout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->