### PR TITLE
fix: enrich command sets FormatTriplex when using Triplex config

### DIFF
--- a/internal/cli/enrich.go
+++ b/internal/cli/enrich.go
@@ -132,10 +132,19 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 		if enrichEndpoint == "" {
 			return fmt.Errorf("--endpoint is required when --model is specified")
 		}
+
+		// Detect Triplex format: use FormatTriplex when the model came from
+		// the Triplex config section (not the LLM fallback).
+		modelFormat := enrich.FormatGeneric
+		if appConfig.Triplex.Endpoint != "" && enrichEndpoint == appConfig.Triplex.Endpoint {
+			modelFormat = enrich.FormatTriplex
+		}
+
 		modelExtractor = enrich.NewModelExtractor(enrich.ModelConfig{
 			Endpoint: enrichEndpoint,
 			Model:    enrichModel,
 			APIKey:   enrichAPIKey,
+			Format:   modelFormat,
 		})
 		if enrichEntityTypes != "" {
 			entityTypes = strings.Split(enrichEntityTypes, ",")


### PR DESCRIPTION
## Summary
- Enrich command was sending generic chat prompt to Triplex instead of the NER preamble format
- Now auto-detects when `enrichEndpoint` matches `appConfig.Triplex.Endpoint` and sets `FormatTriplex`
- This was the root cause of slow/incorrect Triplex enrichment — the model was confused by the wrong prompt format

Closes the FormatTriplex pipeline blocker identified during IRL testing.

## Test plan
- [x] `go build && go vet && go test ./...` all pass
- [ ] Manual test with Triplex endpoint — should see `"Perform Named Entity Recognition"` in the request

🤖 Generated with [Claude Code](https://claude.com/claude-code)