### PR TITLE
feat: [NX-2] llm.Client Extra field for chat_template_kwargs

### DIFF
--- a/llm/client.go
+++ b/llm/client.go
@@ -41,9 +41,41 @@ type Message struct {
 }
 
 // Request is the OpenAI-compatible chat completion request.
+// ExtraBody is merged into the root of the marshalled JSON body. Collisions
+// with core fields (Model/Messages) are ignored — core fields always win.
+// Used for non-standard extensions like vLLM's chat_template_kwargs.
 type Request struct {
-	Model    string    `json:"model"`
-	Messages []Message `json:"messages"`
+	Model    string         `json:"model"`
+	Messages []Message      `json:"messages"`
+	Extra    map[string]any `json:"-"`
+}
+
+// marshalRequest marshals a Request to JSON. When Extra is empty, the output
+// is byte-identical to json.Marshal(r). Otherwise Extra keys are merged at the
+// root of the body; keys that collide with core struct fields are dropped.
+func marshalRequest(r Request) ([]byte, error) {
+	if len(r.Extra) == 0 {
+		return json.Marshal(r)
+	}
+	core, err := json.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(core, &root); err != nil {
+		return nil, err
+	}
+	for k, v := range r.Extra {
+		if _, exists := root[k]; exists {
+			continue
+		}
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("llm: marshal extra field %q: %w", k, err)
+		}
+		root[k] = raw
+	}
+	return json.Marshal(root)
 }
 
 // Response is the OpenAI-compatible chat completion response.
@@ -58,28 +90,34 @@ type Choice struct {
 
 // ChatCompletion sends a chat completion request and returns the first choice's content.
 func (c *Client) ChatCompletion(ctx context.Context, messages []Message) (string, error) {
-	reqBody := Request{
-		Model:    c.cfg.Model,
-		Messages: messages,
+	return c.ChatCompletionWith(ctx, Request{Messages: messages})
+}
+
+// ChatCompletionWith sends a chat completion request with an explicit Request,
+// allowing callers to set Extra fields (e.g. chat_template_kwargs for NuExtract
+// on vLLM/HF). Model is taken from the client Config unless overridden on req.
+func (c *Client) ChatCompletionWith(ctx context.Context, req Request) (string, error) {
+	if req.Model == "" {
+		req.Model = c.cfg.Model
 	}
 
-	jsonBody, err := json.Marshal(reqBody)
+	jsonBody, err := marshalRequest(req)
 	if err != nil {
 		return "", fmt.Errorf("llm: marshal request: %w", err)
 	}
 
 	endpoint := strings.TrimRight(c.cfg.Endpoint, "/") + "/v1/chat/completions"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(jsonBody))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(jsonBody))
 	if err != nil {
 		return "", fmt.Errorf("llm: create request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Content-Type", "application/json")
 	if c.cfg.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
+		httpReq.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		return "", fmt.Errorf("llm: request failed: %w", err)
 	}

--- a/llm/client_test.go
+++ b/llm/client_test.go
@@ -143,6 +143,63 @@ func TestClient_EndpointTrailingSlash(t *testing.T) {
 	assert.Equal(t, "ok", result)
 }
 
+func TestClient_ExtraBody_MergedAtRoot(t *testing.T) {
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+		resp := Response{Choices: []Choice{{Message: Message{Role: "assistant", Content: "ok"}}}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Endpoint: server.URL, Model: "numind/NuExtract-2.0-8B"})
+
+	_, err := client.ChatCompletionWith(context.Background(), Request{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Extra: map[string]any{
+			"chat_template_kwargs": map[string]any{"template": `{"x":"verbatim-string"}`},
+			"temperature":          0,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "numind/NuExtract-2.0-8B", capturedBody["model"])
+	assert.NotNil(t, capturedBody["messages"])
+	kw, ok := capturedBody["chat_template_kwargs"].(map[string]any)
+	require.True(t, ok, "chat_template_kwargs should be at root")
+	assert.Equal(t, `{"x":"verbatim-string"}`, kw["template"])
+	assert.Equal(t, float64(0), capturedBody["temperature"])
+}
+
+func TestClient_ExtraBody_CoreFieldsWin(t *testing.T) {
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+		resp := Response{Choices: []Choice{{Message: Message{Role: "assistant", Content: "ok"}}}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Endpoint: server.URL, Model: "real-model"})
+	_, err := client.ChatCompletionWith(context.Background(), Request{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Extra:    map[string]any{"model": "evil-override"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "real-model", capturedBody["model"])
+}
+
+func TestMarshalRequest_EmptyExtraIsIdentical(t *testing.T) {
+	req := Request{Model: "m", Messages: []Message{{Role: "user", Content: "hi"}}}
+	plain, err := json.Marshal(req)
+	require.NoError(t, err)
+	merged, err := marshalRequest(req)
+	require.NoError(t, err)
+	assert.Equal(t, plain, merged)
+}
+
 func TestClient_ContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// This handler will never respond in time.


### PR DESCRIPTION
## Summary
- Adds `Request.Extra map[string]any` merged into the root of the chat-completion request body
- New public method `ChatCompletionWith(ctx, Request)`; existing `ChatCompletion(ctx, messages)` delegates (no breakage)
- Core fields (`Model`, `Messages`) always win on collision — ExtraBody cannot override them
- When `Extra` is empty, marshalled output is byte-identical to the prior path (no regression)

## Why
NuExtract-2.0 on vLLM / HF Inference Endpoints requires the extraction template to be sent via \`chat_template_kwargs.template\` at the JSON root — not inside \`messages\`. The standard OpenAI chat request shape doesn't accommodate this. This PR is the enabling plumbing for NX-1 (NuExtract extractor).

## Test plan
- [x] \`go test ./llm/...\` — all passing
- [x] New tests: ExtraBody merges at root, core fields win on collision, empty Extra is byte-identical to plain Marshal
- [ ] Integrated by NX-1 against a live NuExtract endpoint (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Requests now support additional custom parameters that automatically merge into API payloads
  * Core request fields take precedence when parameter names conflict
  * New method enables more flexible request customization

* **Tests**
  * Added tests to validate custom parameter merging and precedence handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->