### PR TITLE
feat: [NX-3] config NuExtract block + Format field + auto-detect

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,10 +5,13 @@ package config
 
 // Config holds all service configurations for markedup.
 type Config struct {
-	Embed   ServiceConfig `yaml:"embed"`
-	Rerank  RerankConfig  `yaml:"rerank"`
-	LLM     ServiceConfig `yaml:"llm"`
-	Triplex ServiceConfig `yaml:"triplex,omitempty"`
+	Embed     ServiceConfig   `yaml:"embed"`
+	Rerank    RerankConfig    `yaml:"rerank"`
+	LLM       ServiceConfig   `yaml:"llm"`
+	Triplex   ServiceConfig   `yaml:"triplex,omitempty"`
+	NuExtract NuExtractConfig `yaml:"nuextract,omitempty"`
+	// Format selects the Tier 2 extractor: "triplex", "nuextract", "generic", or "" (auto).
+	Format string `yaml:"format,omitempty"`
 }
 
 // ServiceConfig holds endpoint, model, and authentication for a single service.
@@ -22,4 +25,18 @@ type ServiceConfig struct {
 type RerankConfig struct {
 	ServiceConfig `yaml:",inline"`
 	Format        string `yaml:"format,omitempty"`
+}
+
+// NuExtractConfig configures the NuExtract-2.0 template-based extractor.
+// Mode controls the two-pass runner: "parallel" (default) fires entities and
+// relations calls simultaneously; "single" sends one combined template.
+// Transport selects request shape: "native" uses chat_template_kwargs for
+// vLLM/HF; "manual" renders the prompt client-side for GGUF runtimes.
+// Empty Transport auto-detects from the endpoint URL.
+type NuExtractConfig struct {
+	ServiceConfig `yaml:",inline"`
+	Mode          string   `yaml:"mode,omitempty"`
+	Transport     string   `yaml:"transport,omitempty"`
+	Predicates    []string `yaml:"predicates,omitempty"`
+	EntityTypes   []string `yaml:"entity_types,omitempty"`
 }

--- a/config/detect.go
+++ b/config/detect.go
@@ -29,11 +29,18 @@ type Endpoint struct {
 }
 
 // IsNuExtractModel reports whether a model id names a NuExtract-2.0 model.
-// Matches "nuextract-2.0-*" or "numind/nuextract-2.0-*" case-insensitively.
+// Matches the canonical form `nuextract-2.0-*` (anchored on the trailing dash)
+// with any `publisher/` prefix stripped. Case-insensitive.
+// Examples matched: "nuextract-2.0-8b", "numind/NuExtract-2.0-2B",
+// "someorg/nuextract-2.0-4b-gguf".
+// Examples rejected: "nuextract-2.0", "nuextract-2.0foo", "nuextract-1.5-*",
+// "nuextract2.0-8b".
 func IsNuExtractModel(id string) bool {
 	lower := strings.ToLower(id)
-	lower = strings.TrimPrefix(lower, "numind/")
-	return strings.HasPrefix(lower, "nuextract-2.0") || strings.HasPrefix(lower, "nuextract2.0")
+	if i := strings.LastIndex(lower, "/"); i >= 0 {
+		lower = lower[i+1:]
+	}
+	return strings.HasPrefix(lower, "nuextract-2.0-")
 }
 
 // probeSpec defines how to detect a single local service.

--- a/config/detect.go
+++ b/config/detect.go
@@ -23,6 +23,17 @@ type Endpoint struct {
 	Type    string   // "embed", "llm", "rerank", "multi"
 	Healthy bool
 	Models  []string // populated when the service exposes a models API
+	// Formats lists Tier 2 extractors this endpoint can serve (e.g. "nuextract"
+	// when a NuExtract-2.0 model id is present in Models).
+	Formats []string
+}
+
+// IsNuExtractModel reports whether a model id names a NuExtract-2.0 model.
+// Matches "nuextract-2.0-*" or "numind/nuextract-2.0-*" case-insensitively.
+func IsNuExtractModel(id string) bool {
+	lower := strings.ToLower(id)
+	lower = strings.TrimPrefix(lower, "numind/")
+	return strings.HasPrefix(lower, "nuextract-2.0") || strings.HasPrefix(lower, "nuextract2.0")
 }
 
 // probeSpec defines how to detect a single local service.
@@ -231,6 +242,13 @@ func probeEndpoint(ctx context.Context, p probeSpec) *Endpoint {
 			}
 		}
 		ep.Models = p.ParseModels(modelsBody)
+	}
+
+	for _, m := range ep.Models {
+		if IsNuExtractModel(m) {
+			ep.Formats = append(ep.Formats, "nuextract")
+			break
+		}
 	}
 
 	return ep

--- a/config/detect_test.go
+++ b/config/detect_test.go
@@ -390,3 +390,37 @@ func TestLlamaCppHealthOkInBody(t *testing.T) {
 	assert.True(t, eps[0].Healthy)
 	assert.Equal(t, []string{"test-model"}, eps[0].Models)
 }
+
+func TestIsNuExtractModel(t *testing.T) {
+	cases := map[string]bool{
+		"numind/NuExtract-2.0-8B":      true,
+		"numind/nuextract-2.0-2b":      true,
+		"NuExtract-2.0-4B":             true,
+		"nuextract-2.0-8B-GGUF":        true,
+		"triplex":                      false,
+		"llama3.1":                     false,
+		"numind/NuExtract-1.5":         false,
+		"":                             false,
+	}
+	for id, want := range cases {
+		assert.Equal(t, want, IsNuExtractModel(id), "id=%q", id)
+	}
+}
+
+func TestDetectLocal_NuExtractFormatTagged(t *testing.T) {
+	srv := newOpenAIModelsServer(t, []string{"numind/NuExtract-2.0-8B"})
+	defer srv.Close()
+
+	probes := []probeSpec{{
+		Name:         "LM Studio",
+		Port:         testServerPort(t, srv),
+		ProbePath:    "/v1/models",
+		SuccessCheck: func(code int, _ []byte) bool { return code == http.StatusOK },
+		Type:         "multi",
+		ParseModels:  parseOpenAIModels,
+	}}
+
+	eps := detectLocalWithProbes(context.Background(), probes)
+	require.Len(t, eps, 1)
+	assert.Contains(t, eps[0].Formats, "nuextract")
+}

--- a/config/detect_test.go
+++ b/config/detect_test.go
@@ -393,18 +393,60 @@ func TestLlamaCppHealthOkInBody(t *testing.T) {
 
 func TestIsNuExtractModel(t *testing.T) {
 	cases := map[string]bool{
-		"numind/NuExtract-2.0-8B":      true,
-		"numind/nuextract-2.0-2b":      true,
-		"NuExtract-2.0-4B":             true,
-		"nuextract-2.0-8B-GGUF":        true,
-		"triplex":                      false,
-		"llama3.1":                     false,
-		"numind/NuExtract-1.5":         false,
-		"":                             false,
+		// Canonical matches
+		"numind/NuExtract-2.0-8B":       true,
+		"numind/nuextract-2.0-2b":       true,
+		"NuExtract-2.0-4B":              true,
+		"nuextract-2.0-8B-GGUF":         true,
+		"someorg/nuextract-2.0-4b-gguf": true, // alt publisher
+		// Rejections
+		"triplex":              false,
+		"llama3.1":             false,
+		"numind/NuExtract-1.5": false,
+		"nuextract-2.0":        false, // missing size suffix
+		"nuextract-2.0foo":     false, // no dash separator
+		"nuextract2.0-8b":      false, // missing hyphen before 2.0
+		"":                     false,
 	}
 	for id, want := range cases {
 		assert.Equal(t, want, IsNuExtractModel(id), "id=%q", id)
 	}
+}
+
+func TestDetectLocal_NuExtractFormatNotTagged(t *testing.T) {
+	srv := newOpenAIModelsServer(t, []string{"llama3.1", "mistral-7b"})
+	defer srv.Close()
+	probes := []probeSpec{{
+		Name:         "LM Studio",
+		Port:         testServerPort(t, srv),
+		ProbePath:    "/v1/models",
+		SuccessCheck: func(code int, _ []byte) bool { return code == http.StatusOK },
+		Type:         "multi",
+		ParseModels:  parseOpenAIModels,
+	}}
+	eps := detectLocalWithProbes(context.Background(), probes)
+	require.Len(t, eps, 1)
+	assert.Empty(t, eps[0].Formats, "non-NuExtract models should not tag Formats")
+}
+
+func TestDetectLocal_NuExtractTaggedOnce(t *testing.T) {
+	srv := newOpenAIModelsServer(t, []string{
+		"numind/NuExtract-2.0-8B",
+		"numind/NuExtract-2.0-2B",
+		"llama3.1",
+	})
+	defer srv.Close()
+	probes := []probeSpec{{
+		Name:         "LM Studio",
+		Port:         testServerPort(t, srv),
+		ProbePath:    "/v1/models",
+		SuccessCheck: func(code int, _ []byte) bool { return code == http.StatusOK },
+		Type:         "multi",
+		ParseModels:  parseOpenAIModels,
+	}}
+	eps := detectLocalWithProbes(context.Background(), probes)
+	require.Len(t, eps, 1)
+	assert.Equal(t, []string{"nuextract"}, eps[0].Formats, "should tag nuextract exactly once")
 }
 
 func TestDetectLocal_NuExtractFormatTagged(t *testing.T) {

--- a/config/load.go
+++ b/config/load.go
@@ -121,10 +121,12 @@ func mergeNuExtract(base, override NuExtractConfig) NuExtractConfig {
 	if override.Transport != "" {
 		out.Transport = override.Transport
 	}
-	if len(override.Predicates) > 0 {
+	// nil = absent from YAML (inherit base); non-nil (including []) = explicit override.
+	// Lets `predicates: []` in local YAML clear an inherited list.
+	if override.Predicates != nil {
 		out.Predicates = override.Predicates
 	}
-	if len(override.EntityTypes) > 0 {
+	if override.EntityTypes != nil {
 		out.EntityTypes = override.EntityTypes
 	}
 	return out

--- a/config/load.go
+++ b/config/load.go
@@ -97,7 +97,36 @@ func mergeConfigs(base, override *Config) *Config {
 	out.LLM = mergeService(base.LLM, override.LLM)
 	out.Triplex = mergeService(base.Triplex, override.Triplex)
 	out.Rerank = mergeRerank(base.Rerank, override.Rerank)
+	out.NuExtract = mergeNuExtract(base.NuExtract, override.NuExtract)
 
+	out.Format = base.Format
+	if override.Format != "" {
+		out.Format = override.Format
+	}
+
+	return out
+}
+
+func mergeNuExtract(base, override NuExtractConfig) NuExtractConfig {
+	out := NuExtractConfig{
+		ServiceConfig: mergeService(base.ServiceConfig, override.ServiceConfig),
+		Mode:          base.Mode,
+		Transport:     base.Transport,
+		Predicates:    base.Predicates,
+		EntityTypes:   base.EntityTypes,
+	}
+	if override.Mode != "" {
+		out.Mode = override.Mode
+	}
+	if override.Transport != "" {
+		out.Transport = override.Transport
+	}
+	if len(override.Predicates) > 0 {
+		out.Predicates = override.Predicates
+	}
+	if len(override.EntityTypes) > 0 {
+		out.EntityTypes = override.EntityTypes
+	}
 	return out
 }
 
@@ -141,6 +170,18 @@ func applyEnvOverrides(cfg *Config) {
 	setFromEnv(&cfg.LLM.Endpoint, "MARKEDUP_LLM_ENDPOINT")
 	setFromEnv(&cfg.LLM.Model, "MARKEDUP_LLM_MODEL")
 	setFromEnv(&cfg.LLM.APIKey, "MARKEDUP_LLM_API_KEY")
+
+	setFromEnv(&cfg.Triplex.Endpoint, "MARKEDUP_TRIPLEX_ENDPOINT")
+	setFromEnv(&cfg.Triplex.Model, "MARKEDUP_TRIPLEX_MODEL")
+	setFromEnv(&cfg.Triplex.APIKey, "MARKEDUP_TRIPLEX_API_KEY")
+
+	setFromEnv(&cfg.NuExtract.Endpoint, "MARKEDUP_NUEXTRACT_ENDPOINT")
+	setFromEnv(&cfg.NuExtract.Model, "MARKEDUP_NUEXTRACT_MODEL")
+	setFromEnv(&cfg.NuExtract.APIKey, "MARKEDUP_NUEXTRACT_API_KEY")
+	setFromEnv(&cfg.NuExtract.Mode, "MARKEDUP_NUEXTRACT_MODE")
+	setFromEnv(&cfg.NuExtract.Transport, "MARKEDUP_NUEXTRACT_TRANSPORT")
+
+	setFromEnv(&cfg.Format, "MARKEDUP_FORMAT")
 }
 
 func setFromEnv(target *string, envKey string) {

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -358,6 +358,56 @@ func TestMergeNuExtract_LocalOverrides(t *testing.T) {
 	assert.Equal(t, "nuextract", out.Format)
 }
 
+func TestLoad_EnvOverridesLocalYAML(t *testing.T) {
+	kbDir := t.TempDir()
+	writeYAML(t, filepath.Join(kbDir, ".markedup.yaml"), `
+nuextract:
+  endpoint: http://from-yaml
+  mode: parallel
+format: triplex
+`)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MARKEDUP_NUEXTRACT_ENDPOINT", "http://from-env")
+	t.Setenv("MARKEDUP_NUEXTRACT_MODE", "single")
+	t.Setenv("MARKEDUP_FORMAT", "nuextract")
+
+	cfg, err := Load(kbDir)
+	require.NoError(t, err)
+	assert.Equal(t, "http://from-env", cfg.NuExtract.Endpoint)
+	assert.Equal(t, "single", cfg.NuExtract.Mode)
+	assert.Equal(t, "nuextract", cfg.Format)
+}
+
+func TestMergeNuExtract_EmptySliceClearsInheritedList(t *testing.T) {
+	base := &Config{
+		NuExtract: NuExtractConfig{
+			Predicates:  []string{"a", "b"},
+			EntityTypes: []string{"X"},
+		},
+	}
+	// nil slice = absent = inherit
+	out := mergeConfigs(base, &Config{NuExtract: NuExtractConfig{}})
+	assert.Equal(t, []string{"a", "b"}, out.NuExtract.Predicates, "nil override should inherit base")
+
+	// empty-but-non-nil slice = explicit clear
+	out = mergeConfigs(base, &Config{NuExtract: NuExtractConfig{
+		Predicates:  []string{},
+		EntityTypes: []string{},
+	}})
+	assert.NotNil(t, out.NuExtract.Predicates)
+	assert.Empty(t, out.NuExtract.Predicates, "[] override should clear inherited predicates")
+	assert.Empty(t, out.NuExtract.EntityTypes)
+}
+
+func TestMergeNuExtract_TransportPreservedAndOverridden(t *testing.T) {
+	base := &Config{NuExtract: NuExtractConfig{Transport: "native"}}
+	out := mergeConfigs(base, &Config{})
+	assert.Equal(t, "native", out.NuExtract.Transport, "base preserved when override empty")
+
+	out = mergeConfigs(base, &Config{NuExtract: NuExtractConfig{Transport: "manual"}})
+	assert.Equal(t, "manual", out.NuExtract.Transport)
+}
+
 // writeYAML is a test helper that writes content to a file.
 func writeYAML(t *testing.T, path, content string) {
 	t.Helper()

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -287,6 +287,77 @@ func TestMergeConfigs_BothZero(t *testing.T) {
 	assert.Equal(t, &Config{}, cfg)
 }
 
+func TestLoad_NuExtractBlock(t *testing.T) {
+	kbDir := t.TempDir()
+	writeYAML(t, filepath.Join(kbDir, ".markedup.yaml"), `
+nuextract:
+  endpoint: http://localhost:1234
+  model: numind/NuExtract-2.0-8B
+  mode: parallel
+  transport: native
+  predicates: [works_for, uses]
+  entity_types: [PERSON, ORG]
+format: nuextract
+`)
+	t.Setenv("HOME", t.TempDir()) // ensure no global config leaks in
+
+	cfg, err := Load(kbDir)
+	require.NoError(t, err)
+	assert.Equal(t, "nuextract", cfg.Format)
+	assert.Equal(t, "http://localhost:1234", cfg.NuExtract.Endpoint)
+	assert.Equal(t, "numind/NuExtract-2.0-8B", cfg.NuExtract.Model)
+	assert.Equal(t, "parallel", cfg.NuExtract.Mode)
+	assert.Equal(t, "native", cfg.NuExtract.Transport)
+	assert.Equal(t, []string{"works_for", "uses"}, cfg.NuExtract.Predicates)
+	assert.Equal(t, []string{"PERSON", "ORG"}, cfg.NuExtract.EntityTypes)
+}
+
+func TestApplyEnvOverrides_NuExtract(t *testing.T) {
+	t.Setenv("MARKEDUP_NUEXTRACT_ENDPOINT", "http://hf.example")
+	t.Setenv("MARKEDUP_NUEXTRACT_MODEL", "numind/NuExtract-2.0-2B")
+	t.Setenv("MARKEDUP_NUEXTRACT_API_KEY", "hf_xxx")
+	t.Setenv("MARKEDUP_NUEXTRACT_MODE", "single")
+	t.Setenv("MARKEDUP_NUEXTRACT_TRANSPORT", "manual")
+	t.Setenv("MARKEDUP_FORMAT", "nuextract")
+	t.Setenv("MARKEDUP_TRIPLEX_ENDPOINT", "http://triplex.example")
+
+	cfg := &Config{}
+	applyEnvOverrides(cfg)
+
+	assert.Equal(t, "http://hf.example", cfg.NuExtract.Endpoint)
+	assert.Equal(t, "numind/NuExtract-2.0-2B", cfg.NuExtract.Model)
+	assert.Equal(t, "hf_xxx", cfg.NuExtract.APIKey)
+	assert.Equal(t, "single", cfg.NuExtract.Mode)
+	assert.Equal(t, "manual", cfg.NuExtract.Transport)
+	assert.Equal(t, "nuextract", cfg.Format)
+	assert.Equal(t, "http://triplex.example", cfg.Triplex.Endpoint)
+}
+
+func TestMergeNuExtract_LocalOverrides(t *testing.T) {
+	base := &Config{
+		NuExtract: NuExtractConfig{
+			ServiceConfig: ServiceConfig{Endpoint: "http://base", Model: "base-model"},
+			Mode:          "parallel",
+			Predicates:    []string{"a"},
+		},
+		Format: "triplex",
+	}
+	override := &Config{
+		NuExtract: NuExtractConfig{
+			ServiceConfig: ServiceConfig{Endpoint: "http://override"},
+			Mode:          "single",
+			Predicates:    []string{"b", "c"},
+		},
+		Format: "nuextract",
+	}
+	out := mergeConfigs(base, override)
+	assert.Equal(t, "http://override", out.NuExtract.Endpoint)
+	assert.Equal(t, "base-model", out.NuExtract.Model) // not overridden
+	assert.Equal(t, "single", out.NuExtract.Mode)
+	assert.Equal(t, []string{"b", "c"}, out.NuExtract.Predicates)
+	assert.Equal(t, "nuextract", out.Format)
+}
+
 // writeYAML is a test helper that writes content to a file.
 func writeYAML(t *testing.T, path, content string) {
 	t.Helper()


### PR DESCRIPTION
## Summary
- New \`Config.NuExtract\` block: inline \`ServiceConfig\` + \`Mode\`, \`Transport\`, \`Predicates\`, \`EntityTypes\`
- New \`Config.Format\` field selects Tier 2 extractor (\"triplex\"|\"nuextract\"|\"generic\"|\"\")
- Env vars: \`MARKEDUP_NUEXTRACT_*\`, \`MARKEDUP_TRIPLEX_*\`, \`MARKEDUP_FORMAT\`
- \`Endpoint.Formats\` auto-tagged \`nuextract\` when a \`numind/NuExtract-2.0-*\` id appears in \`/v1/models\`
- \`IsNuExtractModel(id)\` exported helper

## Why
Part of Wave NX: adding NuExtract-2.0 as an alternative Tier 2 extractor alongside Triplex. Triplex's memory footprint has been blocking users; NuExtract-2.0 (MIT, 2B/8B) runs on HF Inference Endpoints, vLLM, and GGUF runtimes. This PR is the config plumbing. NX-1 (enrich parser) and NX-4 (CLI flags) build on it.

## Test plan
- [x] \`go test ./config/...\` — all passing
- [x] Tests cover: YAML load with nuextract block, env overrides, merge precedence, model-id detection, endpoint auto-tagging
- [x] Triplex and existing service configs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable Tier 2 extractor support (NuExtract, Triplex, Generic, or auto)
  * Introduced NuExtract configuration options (mode, transport, predicates, entity types) and environment-variable overrides
  * Endpoints now auto-detect and tag NuExtract-compatible models

* **Tests**
  * Added comprehensive tests for NuExtract detection, config parsing, merging behavior, and env-var overrides
<!-- end of auto-generated comment: release notes by coderabbit.ai -->