### PR TITLE
feat: [NX-1] NuExtract-2.0 extractor with parallel two-pass runner

### DIFF
--- a/enrich/model.go
+++ b/enrich/model.go
@@ -83,15 +83,17 @@ type ModelResult struct {
 // Extract sends the document body to the model and returns enriched fields.
 // entityTypes and predicates constrain the extraction. If nil, defaults are used.
 func (m *ModelExtractor) Extract(ctx context.Context, body string, entityTypes, predicates []string) (*ModelResult, error) {
+	if m.cfg.Format == FormatNuExtract {
+		// NuExtract has its own uppercased defaults; let runNuExtract apply them
+		// so caller-supplied zero-values don't get preempted by FormatGeneric defaults.
+		return m.runNuExtract(ctx, entityTypes, predicates, body)
+	}
+
 	if len(entityTypes) == 0 {
 		entityTypes = DefaultEntityTypes
 	}
 	if len(predicates) == 0 {
 		predicates = DefaultPredicates
-	}
-
-	if m.cfg.Format == FormatNuExtract {
-		return m.runNuExtract(ctx, entityTypes, predicates, body)
 	}
 
 	if m.cfg.Format == FormatTriplex {

--- a/enrich/model.go
+++ b/enrich/model.go
@@ -15,8 +15,9 @@ import (
 type ModelFormat int
 
 const (
-	FormatGeneric ModelFormat = iota // default: generic chat completion
-	FormatTriplex                    // Triplex NER fine-tune format
+	FormatGeneric   ModelFormat = iota // default: generic chat completion
+	FormatTriplex                      // Triplex NER fine-tune format
+	FormatNuExtract                    // NuExtract-2.0 template-based extraction
 )
 
 // DefaultEntityTypes are the entity types used when none are specified.
@@ -36,6 +37,20 @@ type ModelConfig struct {
 	APIKey     string       // Optional API key for authentication
 	HTTPClient *http.Client // Optional; defaults to http.DefaultClient
 	Format     ModelFormat  // zero value = FormatGeneric, no breaking change
+	NuExtract  NuExtractOptions
+}
+
+// NuExtractOptions configures the NuExtract-2.0 extractor.
+// Mode: "parallel" (default) fires entities and relations in parallel; "single"
+// sends one combined template.
+// Transport: "native" uses chat_template_kwargs at the request root for
+// vLLM/HF endpoints; "manual" renders the prompt client-side for GGUF runtimes
+// (llama.cpp, LM Studio, Ollama). Empty auto-detects from the endpoint URL.
+type NuExtractOptions struct {
+	Mode        string
+	Transport   string
+	Predicates  []string // overrides Extract's predicates arg when set
+	EntityTypes []string // overrides Extract's entityTypes arg when set
 }
 
 // ModelExtractor calls a chat-completion API to extract structured knowledge.
@@ -73,6 +88,10 @@ func (m *ModelExtractor) Extract(ctx context.Context, body string, entityTypes, 
 	}
 	if len(predicates) == 0 {
 		predicates = DefaultPredicates
+	}
+
+	if m.cfg.Format == FormatNuExtract {
+		return m.runNuExtract(ctx, entityTypes, predicates, body)
 	}
 
 	if m.cfg.Format == FormatTriplex {

--- a/enrich/nuextract.go
+++ b/enrich/nuextract.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 
@@ -66,15 +67,52 @@ func (m *ModelExtractor) runNuExtract(ctx context.Context, entityTypes, predicat
 
 // autodetectTransport picks "native" for cloud URLs and "manual" for
 // localhost / private-network endpoints where GGUF runtimes typically live.
+// Matches RFC1918 IPv4 ranges, IPv6 loopback, 0.0.0.0, and .local/.lan/.home
+// DNS suffixes. Err on the side of "manual" — a false positive on a
+// GGUF-local endpoint would send unsupported chat_template_kwargs.
 func autodetectTransport(endpoint string) string {
-	lower := strings.ToLower(endpoint)
-	if strings.Contains(lower, "localhost") ||
-		strings.Contains(lower, "127.0.0.1") ||
-		strings.Contains(lower, "192.168.") ||
-		strings.Contains(lower, "10.0.") {
+	host := hostFromEndpoint(endpoint)
+	if host == "" {
+		return "native"
+	}
+	lower := strings.ToLower(host)
+
+	if lower == "localhost" || lower == "127.0.0.1" || lower == "0.0.0.0" ||
+		lower == "::1" {
 		return "manual"
 	}
+	for _, suffix := range []string{".local", ".lan", ".home", ".internal"} {
+		if strings.HasSuffix(lower, suffix) {
+			return "manual"
+		}
+	}
+	if ip := net.ParseIP(lower); ip != nil {
+		if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+			return "manual"
+		}
+	}
 	return "native"
+}
+
+// hostFromEndpoint extracts the hostname from a URL-like endpoint, stripping
+// scheme, path, port, and IPv6 brackets. Falls back to the raw string.
+func hostFromEndpoint(endpoint string) string {
+	s := strings.TrimSpace(endpoint)
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	if i := strings.IndexAny(s, "/?#"); i >= 0 {
+		s = s[:i]
+	}
+	if strings.HasPrefix(s, "[") {
+		if end := strings.Index(s, "]"); end >= 0 {
+			return s[1:end]
+		}
+	}
+	if strings.Count(s, ":") == 1 {
+		s = strings.SplitN(s, ":", 2)[0]
+	}
+	return s
 }
 
 func buildNuExtractEntitiesTemplate(entityTypes []string) string {
@@ -311,7 +349,7 @@ func dedupEntities(in []schema.Entity) []schema.Entity {
 	seen := map[string]bool{}
 	out := make([]schema.Entity, 0, len(in))
 	for _, e := range in {
-		k := strings.ToLower(e.Name)
+		k := strings.ToLower(e.Name) + "|" + strings.ToLower(e.Role)
 		if seen[k] {
 			continue
 		}

--- a/enrich/nuextract.go
+++ b/enrich/nuextract.go
@@ -1,0 +1,336 @@
+package enrich
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/KHAEntertainment/markedup/llm"
+	"github.com/KHAEntertainment/markedup/schema"
+	"golang.org/x/sync/errgroup"
+)
+
+// NuExtract-2.0 default predicate enum, used when config.NuExtract.Predicates
+// and the Extract predicates arg are both empty. Enums must be small and
+// stable because the model constrains outputs to them.
+var defaultNuExtractPredicates = []string{
+	"works_for", "located_in", "part_of", "depends_on",
+	"created_by", "uses", "relates_to", "mentions", "precedes",
+}
+
+// defaultNuExtractEntityTypes mirrors DefaultEntityTypes but uppercased for
+// NuExtract's verbatim-string convention.
+var defaultNuExtractEntityTypes = []string{
+	"PERSON", "ORGANIZATION", "LOCATION", "CONCEPT",
+	"PROJECT", "TECHNOLOGY", "EVENT", "DATE", "OTHER",
+}
+
+// nuExtractStrength is the default relationship strength for NuExtract output.
+// Slightly lower than Triplex's 0.8 because NuExtract has no co-reference pass.
+const nuExtractStrength = 0.7
+
+// nuExtractManualTemplate is the client-side chat template for GGUF runtimes
+// (llama.cpp, LM Studio, Ollama) that don't honor chat_template_kwargs.
+// The shape — "# Template:\n...\n# Context:\n..." — matches NuMind's
+// recommended rendering from the model card.
+const nuExtractManualTemplate = "# Template:\n%s\n\n# Context:\n%s"
+
+// runNuExtract is the dispatcher invoked by ModelExtractor.Extract when
+// cfg.Format == FormatNuExtract. It honors NuExtractOptions overrides and
+// resolves mode + transport before delegating.
+func (m *ModelExtractor) runNuExtract(ctx context.Context, entityTypes, predicates []string, body string) (*ModelResult, error) {
+	opts := m.cfg.NuExtract
+	if len(opts.EntityTypes) > 0 {
+		entityTypes = opts.EntityTypes
+	} else if len(entityTypes) == 0 {
+		entityTypes = defaultNuExtractEntityTypes
+	}
+	if len(opts.Predicates) > 0 {
+		predicates = opts.Predicates
+	} else if len(predicates) == 0 {
+		predicates = defaultNuExtractPredicates
+	}
+
+	transport := opts.Transport
+	if transport == "" {
+		transport = autodetectTransport(m.cfg.Endpoint)
+	}
+
+	if opts.Mode == "single" {
+		return m.nuExtractSingle(ctx, entityTypes, predicates, body, transport)
+	}
+	return m.nuExtractParallel(ctx, entityTypes, predicates, body, transport)
+}
+
+// autodetectTransport picks "native" for cloud URLs and "manual" for
+// localhost / private-network endpoints where GGUF runtimes typically live.
+func autodetectTransport(endpoint string) string {
+	lower := strings.ToLower(endpoint)
+	if strings.Contains(lower, "localhost") ||
+		strings.Contains(lower, "127.0.0.1") ||
+		strings.Contains(lower, "192.168.") ||
+		strings.Contains(lower, "10.0.") {
+		return "manual"
+	}
+	return "native"
+}
+
+func buildNuExtractEntitiesTemplate(entityTypes []string) string {
+	tmpl := map[string]any{
+		"entities": []map[string]any{
+			{
+				"name": "verbatim-string",
+				"type": entityTypes,
+			},
+		},
+	}
+	b, _ := json.Marshal(tmpl)
+	return string(b)
+}
+
+func buildNuExtractRelationsTemplate(predicates []string) string {
+	tmpl := map[string]any{
+		"relationships": []map[string]any{
+			{
+				"subject":   "verbatim-string",
+				"predicate": predicates,
+				"object":    "verbatim-string",
+			},
+		},
+	}
+	b, _ := json.Marshal(tmpl)
+	return string(b)
+}
+
+func buildNuExtractCombinedTemplate(entityTypes, predicates []string) string {
+	tmpl := map[string]any{
+		"entities": []map[string]any{
+			{"name": "verbatim-string", "type": entityTypes},
+		},
+		"relationships": []map[string]any{
+			{"subject": "verbatim-string", "predicate": predicates, "object": "verbatim-string"},
+		},
+	}
+	b, _ := json.Marshal(tmpl)
+	return string(b)
+}
+
+// callNuExtract sends a template + body to the model and returns the raw
+// response content. Transport selects native (chat_template_kwargs) vs.
+// manual (client-rendered prompt).
+func (m *ModelExtractor) callNuExtract(ctx context.Context, template, body, transport string) (string, error) {
+	if transport == "native" {
+		req := llm.Request{
+			Messages: []llm.Message{
+				{Role: "user", Content: body},
+			},
+			Extra: map[string]any{
+				"chat_template_kwargs": map[string]any{"template": template},
+				"temperature":          0,
+			},
+		}
+		return m.llmClient.ChatCompletionWith(ctx, req)
+	}
+	// manual
+	content := fmt.Sprintf(nuExtractManualTemplate, template, body)
+	return m.llmClient.ChatCompletion(ctx, []llm.Message{{Role: "user", Content: content}})
+}
+
+func (m *ModelExtractor) nuExtractParallel(ctx context.Context, entityTypes, predicates []string, body, transport string) (*ModelResult, error) {
+	entTmpl := buildNuExtractEntitiesTemplate(entityTypes)
+	relTmpl := buildNuExtractRelationsTemplate(predicates)
+
+	var (
+		entContent, relContent string
+		mu                     sync.Mutex
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		c, err := m.callNuExtract(gctx, entTmpl, body, transport)
+		if err != nil {
+			return fmt.Errorf("nuextract entities: %w", err)
+		}
+		mu.Lock()
+		entContent = c
+		mu.Unlock()
+		return nil
+	})
+	g.Go(func() error {
+		c, err := m.callNuExtract(gctx, relTmpl, body, transport)
+		if err != nil {
+			return fmt.Errorf("nuextract relations: %w", err)
+		}
+		mu.Lock()
+		relContent = c
+		mu.Unlock()
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	entities, entType, err := parseNuExtractEntities(entContent)
+	if err != nil {
+		return nil, err
+	}
+	relationships, err := parseNuExtractRelations(relContent)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ModelResult{
+		Entities:      dedupEntities(entities),
+		Relationships: dedupRelationships(relationships),
+		EntityType:    entType,
+	}, nil
+}
+
+func (m *ModelExtractor) nuExtractSingle(ctx context.Context, entityTypes, predicates []string, body, transport string) (*ModelResult, error) {
+	tmpl := buildNuExtractCombinedTemplate(entityTypes, predicates)
+	content, err := m.callNuExtract(ctx, tmpl, body, transport)
+	if err != nil {
+		return nil, fmt.Errorf("nuextract combined: %w", err)
+	}
+	entities, rels, entType, err := parseNuExtractCombined(content)
+	if err != nil {
+		return nil, err
+	}
+	return &ModelResult{
+		Entities:      dedupEntities(entities),
+		Relationships: dedupRelationships(rels),
+		EntityType:    entType,
+	}, nil
+}
+
+// stripJSONFences removes surrounding ```json ... ``` if present.
+func stripJSONFences(s string) string {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "```") {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) < 3 {
+		return s
+	}
+	return strings.TrimSpace(strings.Join(lines[1:len(lines)-1], "\n"))
+}
+
+type nuextractEntity struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type nuextractRelation struct {
+	Subject   string `json:"subject"`
+	Predicate string `json:"predicate"`
+	Object    string `json:"object"`
+}
+
+func parseNuExtractEntities(content string) ([]schema.Entity, string, error) {
+	var raw struct {
+		Entities []nuextractEntity `json:"entities"`
+	}
+	content = stripJSONFences(content)
+	if err := json.Unmarshal([]byte(content), &raw); err != nil {
+		return nil, "", fmt.Errorf("parse nuextract entities: %w\nraw: %s", err, truncate(content, 500))
+	}
+	return entitiesFromRaw(raw.Entities)
+}
+
+func parseNuExtractRelations(content string) ([]schema.Relationship, error) {
+	var raw struct {
+		Relationships []nuextractRelation `json:"relationships"`
+	}
+	content = stripJSONFences(content)
+	if err := json.Unmarshal([]byte(content), &raw); err != nil {
+		return nil, fmt.Errorf("parse nuextract relations: %w\nraw: %s", err, truncate(content, 500))
+	}
+	return relationshipsFromRaw(raw.Relationships), nil
+}
+
+func parseNuExtractCombined(content string) ([]schema.Entity, []schema.Relationship, string, error) {
+	var raw struct {
+		Entities      []nuextractEntity   `json:"entities"`
+		Relationships []nuextractRelation `json:"relationships"`
+	}
+	content = stripJSONFences(content)
+	if err := json.Unmarshal([]byte(content), &raw); err != nil {
+		return nil, nil, "", fmt.Errorf("parse nuextract combined: %w\nraw: %s", err, truncate(content, 500))
+	}
+	entities, entType, err := entitiesFromRaw(raw.Entities)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	return entities, relationshipsFromRaw(raw.Relationships), entType, nil
+}
+
+func entitiesFromRaw(raw []nuextractEntity) ([]schema.Entity, string, error) {
+	entities := make([]schema.Entity, 0, len(raw))
+	typeCounts := map[string]int{}
+	for _, e := range raw {
+		name := strings.TrimSpace(e.Name)
+		if name == "" {
+			continue
+		}
+		entities = append(entities, schema.Entity{Name: name, Role: e.Type})
+		if e.Type != "" {
+			typeCounts[e.Type]++
+		}
+	}
+	bestType := ""
+	bestCount := 0
+	for t, c := range typeCounts {
+		if c > bestCount || (c == bestCount && bestType == "") {
+			bestType = t
+			bestCount = c
+		}
+	}
+	return entities, strings.ToLower(bestType), nil
+}
+
+func relationshipsFromRaw(raw []nuextractRelation) []schema.Relationship {
+	rels := make([]schema.Relationship, 0, len(raw))
+	for _, r := range raw {
+		target := strings.TrimSpace(r.Object)
+		if target == "" || strings.TrimSpace(r.Predicate) == "" {
+			continue
+		}
+		rels = append(rels, schema.Relationship{
+			Target:   target,
+			Type:     r.Predicate,
+			Strength: nuExtractStrength,
+		})
+	}
+	return rels
+}
+
+func dedupEntities(in []schema.Entity) []schema.Entity {
+	seen := map[string]bool{}
+	out := make([]schema.Entity, 0, len(in))
+	for _, e := range in {
+		k := strings.ToLower(e.Name)
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, e)
+	}
+	return out
+}
+
+func dedupRelationships(in []schema.Relationship) []schema.Relationship {
+	seen := map[string]bool{}
+	out := make([]schema.Relationship, 0, len(in))
+	for _, r := range in {
+		k := strings.ToLower(r.Target) + "|" + strings.ToLower(r.Type)
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, r)
+	}
+	return out
+}

--- a/enrich/nuextract_test.go
+++ b/enrich/nuextract_test.go
@@ -1,0 +1,256 @@
+package enrich
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func nuextractEntitiesResp(t *testing.T, entities []nuextractEntity) string {
+	t.Helper()
+	b, _ := json.Marshal(map[string]any{"entities": entities})
+	return string(b)
+}
+
+func nuextractRelsResp(t *testing.T, rels []nuextractRelation) string {
+	t.Helper()
+	b, _ := json.Marshal(map[string]any{"relationships": rels})
+	return string(b)
+}
+
+// wrapChatCompletion returns a full OpenAI chat-completion response body with
+// the given content as the assistant message.
+func wrapChatCompletion(content string) string {
+	out, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{
+			{"message": map[string]any{"role": "assistant", "content": content}},
+		},
+	})
+	return string(out)
+}
+
+func TestNuExtract_Parallel_HappyPath(t *testing.T) {
+	var calls int32
+	var gotEntitiesReq, gotRelsReq bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		atomic.AddInt32(&calls, 1)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(body, &parsed))
+		kw, _ := parsed["chat_template_kwargs"].(map[string]any)
+		tmpl, _ := kw["template"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(tmpl, `"entities"`) && !strings.Contains(tmpl, `"relationships"`):
+			gotEntitiesReq = true
+			w.Write([]byte(wrapChatCompletion(nuextractEntitiesResp(t, []nuextractEntity{
+				{Name: "Alice", Type: "PERSON"},
+				{Name: "Acme", Type: "ORGANIZATION"},
+			}))))
+		case strings.Contains(tmpl, `"relationships"`):
+			gotRelsReq = true
+			w.Write([]byte(wrapChatCompletion(nuextractRelsResp(t, []nuextractRelation{
+				{Subject: "Alice", Predicate: "works_for", Object: "Acme"},
+			}))))
+		default:
+			t.Fatalf("unexpected template: %s", tmpl)
+		}
+	}))
+	defer srv.Close()
+
+	m := NewModelExtractor(ModelConfig{
+		Endpoint: srv.URL,
+		Model:    "numind/NuExtract-2.0-8B",
+		Format:   FormatNuExtract,
+		NuExtract: NuExtractOptions{
+			Mode:      "parallel",
+			Transport: "native",
+		},
+	})
+
+	res, err := m.Extract(context.Background(), "Alice works at Acme.", nil, nil)
+	require.NoError(t, err)
+
+	assert.True(t, gotEntitiesReq, "entities request fired")
+	assert.True(t, gotRelsReq, "relations request fired")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+	assert.Len(t, res.Entities, 2)
+	assert.Equal(t, "Alice", res.Entities[0].Name)
+	require.Len(t, res.Relationships, 1)
+	assert.Equal(t, "Acme", res.Relationships[0].Target)
+	assert.Equal(t, "works_for", res.Relationships[0].Type)
+	assert.InDelta(t, nuExtractStrength, res.Relationships[0].Strength, 0.0001)
+}
+
+func TestNuExtract_Single_HappyPath(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		combined, _ := json.Marshal(map[string]any{
+			"entities":      []nuextractEntity{{Name: "X", Type: "CONCEPT"}},
+			"relationships": []nuextractRelation{{Subject: "X", Predicate: "uses", Object: "Y"}},
+		})
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(wrapChatCompletion(string(combined))))
+	}))
+	defer srv.Close()
+
+	m := NewModelExtractor(ModelConfig{
+		Endpoint:  srv.URL,
+		Model:     "numind/NuExtract-2.0-2B",
+		Format:    FormatNuExtract,
+		NuExtract: NuExtractOptions{Mode: "single", Transport: "native"},
+	})
+
+	res, err := m.Extract(context.Background(), "body", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	assert.Len(t, res.Entities, 1)
+	assert.Len(t, res.Relationships, 1)
+	assert.Equal(t, "concept", res.EntityType)
+}
+
+func TestNuExtract_ManualTransport_ClientRendersTemplate(t *testing.T) {
+	var capturedContent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed struct {
+			Messages []struct {
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		require.NoError(t, json.Unmarshal(body, &parsed))
+		require.Len(t, parsed.Messages, 1)
+		capturedContent = parsed.Messages[0].Content
+
+		// chat_template_kwargs should NOT be in manual mode
+		assert.NotContains(t, string(body), "chat_template_kwargs")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(wrapChatCompletion(nuextractEntitiesResp(t, []nuextractEntity{{Name: "Z", Type: "OTHER"}}))))
+	}))
+	defer srv.Close()
+
+	m := NewModelExtractor(ModelConfig{
+		Endpoint:  srv.URL,
+		Model:     "nuextract-2.0-2b",
+		Format:    FormatNuExtract,
+		NuExtract: NuExtractOptions{Mode: "single", Transport: "manual"},
+	})
+
+	_, err := m.Extract(context.Background(), "document", nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, capturedContent, "# Template:")
+	assert.Contains(t, capturedContent, "# Context:\ndocument")
+}
+
+func TestNuExtract_MarkdownWrappedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wrapped := "```json\n" + nuextractEntitiesResp(t, []nuextractEntity{{Name: "W", Type: "EVENT"}}) + "\n```"
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(wrapChatCompletion(wrapped)))
+	}))
+	defer srv.Close()
+
+	m := NewModelExtractor(ModelConfig{
+		Endpoint:  srv.URL,
+		Model:     "x",
+		Format:    FormatNuExtract,
+		NuExtract: NuExtractOptions{Mode: "single", Transport: "manual"},
+	})
+	res, err := m.Extract(context.Background(), "b", nil, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Entities, 1)
+	assert.Equal(t, "W", res.Entities[0].Name)
+}
+
+func TestNuExtract_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(wrapChatCompletion("not json at all")))
+	}))
+	defer srv.Close()
+
+	m := NewModelExtractor(ModelConfig{
+		Endpoint:  srv.URL,
+		Model:     "x",
+		Format:    FormatNuExtract,
+		NuExtract: NuExtractOptions{Mode: "single", Transport: "manual"},
+	})
+	_, err := m.Extract(context.Background(), "b", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse nuextract")
+}
+
+func TestNuExtract_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("upstream exploded"))
+	}))
+	defer srv.Close()
+
+	m := NewModelExtractor(ModelConfig{
+		Endpoint:  srv.URL,
+		Model:     "x",
+		Format:    FormatNuExtract,
+		NuExtract: NuExtractOptions{Mode: "parallel", Transport: "native"},
+	})
+	_, err := m.Extract(context.Background(), "b", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 500")
+}
+
+func TestNuExtract_Dedup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		combined, _ := json.Marshal(map[string]any{
+			"entities": []nuextractEntity{
+				{Name: "Alice", Type: "PERSON"},
+				{Name: "alice", Type: "PERSON"}, // case-dup
+				{Name: "Bob", Type: "PERSON"},
+			},
+			"relationships": []nuextractRelation{
+				{Subject: "Alice", Predicate: "knows", Object: "Bob"},
+				{Subject: "X", Predicate: "knows", Object: "bob"}, // dup via target+type
+			},
+		})
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(wrapChatCompletion(string(combined))))
+	}))
+	defer srv.Close()
+
+	m := NewModelExtractor(ModelConfig{
+		Endpoint:  srv.URL,
+		Model:     "x",
+		Format:    FormatNuExtract,
+		NuExtract: NuExtractOptions{Mode: "single", Transport: "manual"},
+	})
+	res, err := m.Extract(context.Background(), "b", nil, nil)
+	require.NoError(t, err)
+	assert.Len(t, res.Entities, 2) // Alice and Bob
+	assert.Len(t, res.Relationships, 1)
+}
+
+func TestAutodetectTransport(t *testing.T) {
+	cases := map[string]string{
+		"http://localhost:1234":      "manual",
+		"http://127.0.0.1:8080":      "manual",
+		"http://192.168.1.5:11434":   "manual",
+		"https://api.openai.com/v1":  "native",
+		"https://xyz.hf.space":       "native",
+		"https://inference.endpoint": "native",
+	}
+	for url, want := range cases {
+		assert.Equal(t, want, autodetectTransport(url), "url=%s", url)
+	}
+}

--- a/enrich/nuextract_test.go
+++ b/enrich/nuextract_test.go
@@ -243,14 +243,76 @@ func TestNuExtract_Dedup(t *testing.T) {
 
 func TestAutodetectTransport(t *testing.T) {
 	cases := map[string]string{
-		"http://localhost:1234":      "manual",
-		"http://127.0.0.1:8080":      "manual",
-		"http://192.168.1.5:11434":   "manual",
+		// loopback / localhost
+		"http://localhost:1234": "manual",
+		"http://127.0.0.1:8080": "manual",
+		"http://0.0.0.0:8080":   "manual",
+		"http://[::1]:8080":     "manual",
+		"http://[::1]":          "manual",
+		// RFC1918 — all private ranges
+		"http://192.168.1.5:11434": "manual",
+		"http://10.0.1.5:8080":     "manual",
+		"http://10.1.2.3:8080":     "manual",
+		"http://10.42.0.1:8080":    "manual",
+		"http://172.16.0.5:8080":   "manual",
+		"http://172.31.255.254":    "manual",
+		// link-local
+		"http://169.254.1.1:8080": "manual",
+		// local DNS
+		"http://ollama.local:11434": "manual",
+		"http://radxa.lan:8081":     "manual",
+		"http://server.home/v1":     "manual",
+		"http://gpu.internal/v1":    "manual",
+		// public / cloud
 		"https://api.openai.com/v1":  "native",
 		"https://xyz.hf.space":       "native",
 		"https://inference.endpoint": "native",
+		"https://my-endpoint.us-east-1.aws.endpoints.huggingface.cloud/v1": "native",
+		// 172.32 is NOT in the private range
+		"http://172.32.0.1:8080": "native",
 	}
 	for url, want := range cases {
 		assert.Equal(t, want, autodetectTransport(url), "url=%s", url)
 	}
+}
+
+func TestDedupEntities_DifferentRolesPreserved(t *testing.T) {
+	raw := []nuextractEntity{
+		{Name: "Apple", Type: "ORGANIZATION"},
+		{Name: "Apple", Type: "PRODUCT"},
+		{Name: "apple", Type: "ORGANIZATION"},
+	}
+	entities, _, err := entitiesFromRaw(raw)
+	require.NoError(t, err)
+	out := dedupEntities(entities)
+	require.Len(t, out, 2)
+	roles := []string{out[0].Role, out[1].Role}
+	assert.Contains(t, roles, "ORGANIZATION")
+	assert.Contains(t, roles, "PRODUCT")
+}
+
+func TestNuExtract_DefaultsApplied_WhenExtractCalledWithNil(t *testing.T) {
+	var capturedTemplate string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(body, &parsed)
+		if kw, ok := parsed["chat_template_kwargs"].(map[string]any); ok {
+			capturedTemplate, _ = kw["template"].(string)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(wrapChatCompletion(`{"entities":[]}`)))
+	}))
+	defer srv.Close()
+
+	m := NewModelExtractor(ModelConfig{
+		Endpoint:  srv.URL,
+		Model:     "numind/NuExtract-2.0-2B",
+		Format:    FormatNuExtract,
+		NuExtract: NuExtractOptions{Mode: "single", Transport: "native"},
+	})
+	_, err := m.Extract(context.Background(), "b", nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, capturedTemplate, "ORGANIZATION")
+	assert.Contains(t, capturedTemplate, "PERSON")
 }


### PR DESCRIPTION
## Summary
- New \`FormatNuExtract\` in the \`enrich.ModelFormat\` enum
- \`NuExtractOptions\` on \`ModelConfig\`: \`Mode\` (parallel|single), \`Transport\` (native|manual), \`Predicates\`, \`EntityTypes\`
- Parallel mode fires entities + relations chat calls concurrently via \`errgroup\`
- Native transport uses \`chat_template_kwargs\` (vLLM / HF Endpoints) via \`llm.ChatCompletionWith\`
- Manual transport renders the template client-side for GGUF runtimes (llama.cpp, LM Studio, Ollama)
- Transport auto-detects from endpoint URL when unset (localhost/private → manual, else native)
- Relationship strength 0.7 (Triplex uses 0.8 with co-reference; NuExtract output is schema-driven)

## Why
Triplex's ~30GB RAM balloon has been blocking us on HF Inference Endpoints, GCP, and local Mac runtimes. NuExtract-2.0 (MIT, 2B/8B) is a schema-driven alternative that runs within budget on those same runtimes. Triplex stays first-class — this is additive.

## Test plan
- [x] \`go test ./enrich/...\` — all passing (7 new tests)
- [x] Covers: parallel happy path, single happy path, manual transport template rendering, markdown-wrapped JSON, malformed JSON error, HTTP error, dedup (case-insensitive for entities; target+type for relationships), transport auto-detection
- [ ] Integration with config.Format (NX-4) and wizard (NX-5) in follow-up PRs
- [ ] Live test against HF / Ollama after NX-4 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NuExtract model format with configurable extraction options (mode, transport, predicates, entity types), automatic transport detection, and support for combined or parallel extraction flows.
  * Default relationship scoring and fallback prompt handling for runtimes without native transport.

* **Improvements**
  * Robust parsing of JSON responses (including fenced code), case-insensitive deduplication, and clearer contextual error messages.

* **Tests**
  * Comprehensive tests covering modes, transports, parsing, error cases, and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->