### PR TITLE
feat: [NX-4] enrich --format flag + NuExtract CLI wiring

### DIFF
--- a/internal/cli/enrich.go
+++ b/internal/cli/enrich.go
@@ -107,14 +107,28 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Resolve Tier 2 format: CLI flag > config.Format > legacy auto-detect.
-	formatName := strings.ToLower(strings.TrimSpace(enrichFormat))
-	if formatName == "" {
-		formatName = strings.ToLower(strings.TrimSpace(appConfig.Format))
+	// Validate format, mode, transport flags at the CLI boundary.
+	formatName, err := validateFormatName(firstNonEmpty(enrichFormat, appConfig.Format))
+	if err != nil {
+		return err
+	}
+	if err := validateNuExtractMode(enrichNuExtractMode); err != nil {
+		return err
+	}
+	if err := validateNuExtractTransport(enrichNuExtractTransport); err != nil {
+		return err
 	}
 
-	// Fill endpoint/model/apikey from the matching config block for the
-	// resolved format. Falls back to LLM when the format-specific block is empty.
+	// Resolve format BEFORE filling credentials so the credential fallback
+	// reads from the matching config block. --endpoint that matches
+	// cfg.NuExtract.Endpoint must NOT end up with Triplex credentials.
+	if enrichEndpoint != "" && formatName == "" {
+		// Endpoint-origin auto-detect.
+		formatName = detectFormatFromEndpoint(enrichEndpoint)
+	}
+
+	// Fill endpoint/model/apikey from the config block matching the resolved
+	// format. "" (unresolved) falls back to the legacy Triplex-first path.
 	switch formatName {
 	case "nuextract":
 		if enrichEndpoint == "" {
@@ -126,8 +140,18 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 		if enrichAPIKey == "" {
 			enrichAPIKey = firstNonEmpty(appConfig.NuExtract.APIKey, appConfig.LLM.APIKey)
 		}
+	case "triplex":
+		if enrichEndpoint == "" {
+			enrichEndpoint = firstNonEmpty(appConfig.Triplex.Endpoint, appConfig.LLM.Endpoint)
+		}
+		if enrichModel == "" {
+			enrichModel = firstNonEmpty(appConfig.Triplex.Model, appConfig.LLM.Model)
+		}
+		if enrichAPIKey == "" {
+			enrichAPIKey = firstNonEmpty(appConfig.Triplex.APIKey, appConfig.LLM.APIKey)
+		}
 	default:
-		// triplex (explicit), generic, or empty — preserve legacy Triplex-first fallback.
+		// "generic" or "" (nothing resolved) — legacy Triplex-first fallback.
 		if enrichEndpoint == "" {
 			enrichEndpoint = firstNonEmpty(appConfig.Triplex.Endpoint, appConfig.LLM.Endpoint)
 		}
@@ -310,6 +334,50 @@ func printDryRun(out io.Writer, relPath string, fm *schema.GraphFrontmatter) {
 	fmt.Fprintf(out, "--- %s ---\n", relPath)
 	fmt.Fprint(out, string(yamlBytes))
 	fmt.Fprintln(out)
+}
+
+// validateFormatName normalizes and validates a --format / config.format value.
+// Empty input is allowed (returns "" for auto-detect). Unknown names error.
+func validateFormatName(name string) (string, error) {
+	n := strings.ToLower(strings.TrimSpace(name))
+	switch n {
+	case "", "triplex", "nuextract", "generic":
+		return n, nil
+	}
+	return "", fmt.Errorf("invalid --format %q: must be triplex, nuextract, or generic", name)
+}
+
+// validateNuExtractMode validates the --nuextract-mode value. Empty allowed.
+func validateNuExtractMode(mode string) error {
+	m := strings.ToLower(strings.TrimSpace(mode))
+	switch m {
+	case "", "parallel", "single":
+		return nil
+	}
+	return fmt.Errorf("invalid --nuextract-mode %q: must be parallel or single", mode)
+}
+
+// validateNuExtractTransport validates the --nuextract-transport value. Empty allowed.
+func validateNuExtractTransport(transport string) error {
+	t := strings.ToLower(strings.TrimSpace(transport))
+	switch t {
+	case "", "native", "manual":
+		return nil
+	}
+	return fmt.Errorf("invalid --nuextract-transport %q: must be native or manual", transport)
+}
+
+// detectFormatFromEndpoint returns a format name if the endpoint matches a
+// configured block. Triplex wins on tie to preserve legacy behavior; if both
+// blocks share the same endpoint, the user should pass --format explicitly.
+func detectFormatFromEndpoint(endpoint string) string {
+	if appConfig.Triplex.Endpoint != "" && endpoint == appConfig.Triplex.Endpoint {
+		return "triplex"
+	}
+	if appConfig.NuExtract.Endpoint != "" && endpoint == appConfig.NuExtract.Endpoint {
+		return "nuextract"
+	}
+	return ""
 }
 
 // resolveModelFormat picks the enrich.ModelFormat based on (in order):

--- a/internal/cli/enrich.go
+++ b/internal/cli/enrich.go
@@ -19,15 +19,18 @@ import (
 )
 
 var (
-	enrichDryRun      bool
-	enrichForce       bool
-	enrichSkipExist   bool
-	enrichModel       string
-	enrichEndpoint    string
-	enrichAPIKey      string
-	enrichEntityTypes string
-	enrichPredicates  string
-	enrichTimeout     time.Duration
+	enrichDryRun             bool
+	enrichForce              bool
+	enrichSkipExist          bool
+	enrichModel              string
+	enrichEndpoint           string
+	enrichAPIKey             string
+	enrichEntityTypes        string
+	enrichPredicates         string
+	enrichTimeout            time.Duration
+	enrichFormat             string
+	enrichNuExtractMode      string
+	enrichNuExtractTransport string
 )
 
 func newEnrichCmd() *cobra.Command {
@@ -54,6 +57,9 @@ Partial frontmatter is filled in without overwriting existing fields.`,
 	cmd.Flags().StringVar(&enrichEntityTypes, "entity-types", "", "comma-separated entity types for model extraction")
 	cmd.Flags().StringVar(&enrichPredicates, "predicates", "", "comma-separated relationship predicates for model extraction")
 	cmd.Flags().DurationVar(&enrichTimeout, "timeout", 5*time.Minute, "timeout per file for model extraction (e.g. 5m, 10m)")
+	cmd.Flags().StringVar(&enrichFormat, "format", "", "Tier 2 extractor format: triplex, nuextract, generic (default: auto from config)")
+	cmd.Flags().StringVar(&enrichNuExtractMode, "nuextract-mode", "", "NuExtract run mode: parallel (default) or single")
+	cmd.Flags().StringVar(&enrichNuExtractTransport, "nuextract-transport", "", "NuExtract request transport: native (vLLM/HF) or manual (GGUF). Empty = auto-detect")
 
 	return cmd
 }
@@ -101,27 +107,35 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Fall back to config values when CLI flags are empty.
-	// Use Triplex config if available, otherwise fall back to LLM config.
-	if enrichEndpoint == "" {
-		if appConfig.Triplex.Endpoint != "" {
-			enrichEndpoint = appConfig.Triplex.Endpoint
-		} else {
-			enrichEndpoint = appConfig.LLM.Endpoint
-		}
+	// Resolve Tier 2 format: CLI flag > config.Format > legacy auto-detect.
+	formatName := strings.ToLower(strings.TrimSpace(enrichFormat))
+	if formatName == "" {
+		formatName = strings.ToLower(strings.TrimSpace(appConfig.Format))
 	}
-	if enrichModel == "" {
-		if appConfig.Triplex.Model != "" {
-			enrichModel = appConfig.Triplex.Model
-		} else {
-			enrichModel = appConfig.LLM.Model
+
+	// Fill endpoint/model/apikey from the matching config block for the
+	// resolved format. Falls back to LLM when the format-specific block is empty.
+	switch formatName {
+	case "nuextract":
+		if enrichEndpoint == "" {
+			enrichEndpoint = firstNonEmpty(appConfig.NuExtract.Endpoint, appConfig.LLM.Endpoint)
 		}
-	}
-	if enrichAPIKey == "" {
-		if appConfig.Triplex.APIKey != "" {
-			enrichAPIKey = appConfig.Triplex.APIKey
-		} else {
-			enrichAPIKey = appConfig.LLM.APIKey
+		if enrichModel == "" {
+			enrichModel = firstNonEmpty(appConfig.NuExtract.Model, appConfig.LLM.Model)
+		}
+		if enrichAPIKey == "" {
+			enrichAPIKey = firstNonEmpty(appConfig.NuExtract.APIKey, appConfig.LLM.APIKey)
+		}
+	default:
+		// triplex (explicit), generic, or empty — preserve legacy Triplex-first fallback.
+		if enrichEndpoint == "" {
+			enrichEndpoint = firstNonEmpty(appConfig.Triplex.Endpoint, appConfig.LLM.Endpoint)
+		}
+		if enrichModel == "" {
+			enrichModel = firstNonEmpty(appConfig.Triplex.Model, appConfig.LLM.Model)
+		}
+		if enrichAPIKey == "" {
+			enrichAPIKey = firstNonEmpty(appConfig.Triplex.APIKey, appConfig.LLM.APIKey)
 		}
 	}
 
@@ -133,19 +147,24 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("--endpoint is required when --model is specified")
 		}
 
-		// Detect Triplex format: use FormatTriplex when the model came from
-		// the Triplex config section (not the LLM fallback).
-		modelFormat := enrich.FormatGeneric
-		if appConfig.Triplex.Endpoint != "" && enrichEndpoint == appConfig.Triplex.Endpoint {
-			modelFormat = enrich.FormatTriplex
-		}
+		modelFormat := resolveModelFormat(formatName, enrichEndpoint)
 
-		modelExtractor = enrich.NewModelExtractor(enrich.ModelConfig{
+		mc := enrich.ModelConfig{
 			Endpoint: enrichEndpoint,
 			Model:    enrichModel,
 			APIKey:   enrichAPIKey,
 			Format:   modelFormat,
-		})
+		}
+		if modelFormat == enrich.FormatNuExtract {
+			mc.NuExtract = enrich.NuExtractOptions{
+				Mode:        firstNonEmpty(enrichNuExtractMode, appConfig.NuExtract.Mode),
+				Transport:   firstNonEmpty(enrichNuExtractTransport, appConfig.NuExtract.Transport),
+				Predicates:  appConfig.NuExtract.Predicates,
+				EntityTypes: appConfig.NuExtract.EntityTypes,
+			}
+		}
+
+		modelExtractor = enrich.NewModelExtractor(mc)
 		if enrichEntityTypes != "" {
 			entityTypes = strings.Split(enrichEntityTypes, ",")
 			for i := range entityTypes {
@@ -291,6 +310,38 @@ func printDryRun(out io.Writer, relPath string, fm *schema.GraphFrontmatter) {
 	fmt.Fprintf(out, "--- %s ---\n", relPath)
 	fmt.Fprint(out, string(yamlBytes))
 	fmt.Fprintln(out)
+}
+
+// resolveModelFormat picks the enrich.ModelFormat based on (in order):
+// explicit CLI/config format name, then legacy endpoint-origin Triplex
+// match for backward compat, falling back to FormatGeneric.
+func resolveModelFormat(formatName, endpoint string) enrich.ModelFormat {
+	switch formatName {
+	case "nuextract":
+		return enrich.FormatNuExtract
+	case "triplex":
+		return enrich.FormatTriplex
+	case "generic":
+		return enrich.FormatGeneric
+	}
+	// Legacy auto-detect: endpoint matches the Triplex config block.
+	if appConfig.Triplex.Endpoint != "" && endpoint == appConfig.Triplex.Endpoint {
+		return enrich.FormatTriplex
+	}
+	// Auto-detect: endpoint matches the NuExtract config block.
+	if appConfig.NuExtract.Endpoint != "" && endpoint == appConfig.NuExtract.Endpoint {
+		return enrich.FormatNuExtract
+	}
+	return enrich.FormatGeneric
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // collectMarkdownFiles walks a directory and returns .md file paths,

--- a/internal/cli/enrich_test.go
+++ b/internal/cli/enrich_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/KHAEntertainment/markedup/config"
-	"github.com/KHAEntertainment/markedup/enrich"
+	"github.com/Clarit-AI/markedup/config"
+	"github.com/Clarit-AI/markedup/enrich"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -230,4 +230,112 @@ func TestFirstNonEmpty(t *testing.T) {
 	assert.Equal(t, "c", firstNonEmpty("", "", "c"))
 	assert.Equal(t, "", firstNonEmpty("", "", ""))
 	assert.Equal(t, "", firstNonEmpty())
+}
+
+func TestValidateFormatName(t *testing.T) {
+	cases := map[string]bool{
+		"":          true,
+		"triplex":   true,
+		"NuExtract": true,
+		" generic ": true,
+		"nu-extract": false,
+		"nuextracts": false,
+		"typo":      false,
+	}
+	for input, ok := range cases {
+		_, err := validateFormatName(input)
+		if ok {
+			assert.NoError(t, err, "input=%q", input)
+		} else {
+			assert.Error(t, err, "input=%q", input)
+		}
+	}
+}
+
+func TestValidateNuExtractMode(t *testing.T) {
+	assert.NoError(t, validateNuExtractMode(""))
+	assert.NoError(t, validateNuExtractMode("parallel"))
+	assert.NoError(t, validateNuExtractMode("SINGLE"))
+	assert.Error(t, validateNuExtractMode("parllel"))
+	assert.Error(t, validateNuExtractMode("dual"))
+}
+
+func TestValidateNuExtractTransport(t *testing.T) {
+	assert.NoError(t, validateNuExtractTransport(""))
+	assert.NoError(t, validateNuExtractTransport("native"))
+	assert.NoError(t, validateNuExtractTransport("MANUAL"))
+	assert.Error(t, validateNuExtractTransport("manuel"))
+}
+
+func TestDetectFormatFromEndpoint(t *testing.T) {
+	origCfg := appConfig
+	defer func() { appConfig = origCfg }()
+
+	// Triplex wins on tie (legacy precedence).
+	appConfig = &config.Config{
+		Triplex: config.ServiceConfig{Endpoint: "http://shared"},
+		NuExtract: config.NuExtractConfig{
+			ServiceConfig: config.ServiceConfig{Endpoint: "http://shared"},
+		},
+	}
+	assert.Equal(t, "triplex", detectFormatFromEndpoint("http://shared"))
+
+	appConfig = &config.Config{
+		NuExtract: config.NuExtractConfig{
+			ServiceConfig: config.ServiceConfig{Endpoint: "http://nuextract.cloud"},
+		},
+	}
+	assert.Equal(t, "nuextract", detectFormatFromEndpoint("http://nuextract.cloud"))
+	assert.Equal(t, "", detectFormatFromEndpoint("http://unknown"))
+}
+
+// Regression for Codex finding #3: --endpoint matching NuExtract must not
+// pull Triplex credentials when both config blocks exist and no --format set.
+func TestRunEnrich_EndpointMatchesNuExtract_UsesNuExtractCredentials(t *testing.T) {
+	origCfg := appConfig
+	defer func() {
+		appConfig = origCfg
+		enrichEndpoint, enrichModel, enrichAPIKey = "", "", ""
+		enrichFormat, enrichNuExtractMode, enrichNuExtractTransport = "", "", ""
+	}()
+
+	appConfig = &config.Config{
+		Triplex: config.ServiceConfig{
+			Endpoint: "http://triplex.local",
+			Model:    "phi3-triplex",
+			APIKey:   "triplex-secret",
+		},
+		NuExtract: config.NuExtractConfig{
+			ServiceConfig: config.ServiceConfig{
+				Endpoint: "https://nx.hf.space",
+				Model:    "numind/NuExtract-2.0-8B",
+				APIKey:   "nuextract-secret",
+			},
+		},
+	}
+
+	// Simulate: user passes --endpoint matching NuExtract, no --format.
+	// The resolution logic should detect nuextract and fill NuExtract creds.
+	enrichEndpoint = "https://nx.hf.space"
+	enrichModel, enrichAPIKey = "", ""
+	formatName, err := validateFormatName("")
+	require.NoError(t, err)
+	if formatName == "" && enrichEndpoint != "" {
+		formatName = detectFormatFromEndpoint(enrichEndpoint)
+	}
+	require.Equal(t, "nuextract", formatName)
+
+	// Apply the same switch logic from runEnrich.
+	switch formatName {
+	case "nuextract":
+		if enrichModel == "" {
+			enrichModel = firstNonEmpty(appConfig.NuExtract.Model, appConfig.LLM.Model)
+		}
+		if enrichAPIKey == "" {
+			enrichAPIKey = firstNonEmpty(appConfig.NuExtract.APIKey, appConfig.LLM.APIKey)
+		}
+	}
+
+	assert.Equal(t, "numind/NuExtract-2.0-8B", enrichModel, "should use NuExtract model")
+	assert.Equal(t, "nuextract-secret", enrichAPIKey, "should use NuExtract API key, not Triplex")
 }

--- a/internal/cli/enrich_test.go
+++ b/internal/cli/enrich_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/KHAEntertainment/markedup/config"
+	"github.com/KHAEntertainment/markedup/enrich"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -185,4 +187,47 @@ func TestRunEnrich_SingleFile(t *testing.T) {
 	data, err := os.ReadFile(filePath)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "id: single")
+}
+
+func TestEnrichCmd_FormatFlags(t *testing.T) {
+	cmd := newEnrichCmd()
+	for _, name := range []string{"format", "nuextract-mode", "nuextract-transport"} {
+		require.NotNilf(t, cmd.Flags().Lookup(name), "flag --%s should exist", name)
+	}
+}
+
+func TestResolveModelFormat(t *testing.T) {
+	origCfg := appConfig
+	defer func() { appConfig = origCfg }()
+
+	// Explicit CLI/config names win regardless of endpoint.
+	appConfig = &config.Config{
+		Triplex: config.ServiceConfig{Endpoint: "http://triplex.local"},
+	}
+	assert.Equal(t, enrich.FormatNuExtract, resolveModelFormat("nuextract", "http://triplex.local"))
+	assert.Equal(t, enrich.FormatTriplex, resolveModelFormat("triplex", "http://anything"))
+	assert.Equal(t, enrich.FormatGeneric, resolveModelFormat("generic", "http://triplex.local"))
+
+	// Legacy Triplex endpoint-origin auto-detect when name is empty.
+	assert.Equal(t, enrich.FormatTriplex, resolveModelFormat("", "http://triplex.local"))
+
+	// NuExtract endpoint-origin auto-detect when name is empty.
+	appConfig = &config.Config{
+		NuExtract: config.NuExtractConfig{
+			ServiceConfig: config.ServiceConfig{Endpoint: "http://nuextract.cloud"},
+		},
+	}
+	assert.Equal(t, enrich.FormatNuExtract, resolveModelFormat("", "http://nuextract.cloud"))
+
+	// No match → generic.
+	appConfig = &config.Config{}
+	assert.Equal(t, enrich.FormatGeneric, resolveModelFormat("", "http://other"))
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	assert.Equal(t, "a", firstNonEmpty("a", "b"))
+	assert.Equal(t, "b", firstNonEmpty("", "b"))
+	assert.Equal(t, "c", firstNonEmpty("", "", "c"))
+	assert.Equal(t, "", firstNonEmpty("", "", ""))
+	assert.Equal(t, "", firstNonEmpty())
 }


### PR DESCRIPTION
## Summary
- \`--format triplex|nuextract|generic\` selects the Tier 2 extractor explicitly
- \`--nuextract-mode parallel|single\` and \`--nuextract-transport native|manual\` plumb NuExtract options
- Endpoint/model/apikey fallback is now format-aware — \`nuextract\` reads from \`config.NuExtract\` first; \`triplex\` and \`generic\` preserve the existing Triplex-first legacy
- \`resolveModelFormat\` precedence: CLI flag > \`config.Format\` > endpoint-origin auto-detect (Triplex or NuExtract) > \`FormatGeneric\`
- \`config.NuExtract.{Mode,Transport,Predicates,EntityTypes}\` feed into \`enrich.ModelConfig.NuExtract\` when the format is nuextract

## Test plan
- [x] \`go test ./internal/cli/... ./enrich/... ./config/... ./llm/...\` — all passing
- [x] New tests: format-flag surface, resolveModelFormat precedence (5 branches), firstNonEmpty
- [ ] Live validation against HF NuExtract-2.0 endpoint after NX-5 merges (wizard scaffolding)

Follows #98 / #99 / #100. Wave NX-B completes with #NX-5 (wizard step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI flags for enrichment: --format, --nuextract-mode, --nuextract-transport.
  * Format resolution now validates inputs, uses CLI → config → auto-detect precedence, and auto-detects format from endpoints (defined tie-breaking).
  * Model/endpoint/API key selection follows the resolved format, with improved NuExtract handling when selected.

* **Tests**
  * Added extensive unit tests covering new flags, validation, format resolution, endpoint detection, and precedence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->