### PR TITLE
feat: Phase B — MarkedUp API refinements for Plexium integration

### DIFF
--- a/embed/openai_compat.go
+++ b/embed/openai_compat.go
@@ -39,6 +39,24 @@ type OpenAICompatibleEmbedder struct {
 	httpClient *http.Client
 }
 
+// NewFromProvider is a convenience constructor for external callers that want
+// to build an OpenAI-compatible embedder from flat provider settings (e.g.
+// config inheritance from a host application like Plexium's assistiveAgent
+// provider block). It is equivalent to NewOpenAICompatible with a Config
+// populated from the given parameters and sensible defaults.
+//
+// endpoint is the base URL (without trailing /v1/embeddings); model is the
+// embedding model identifier; apiKey is the bearer token (empty for local
+// endpoints); dims is the expected embedding dimensionality.
+func NewFromProvider(endpoint, model, apiKey string, dims int) *OpenAICompatibleEmbedder {
+	return NewOpenAICompatible(Config{
+		Endpoint:  endpoint,
+		ModelName: model,
+		APIKey:    apiKey,
+		Dims:      dims,
+	})
+}
+
 // NewOpenAICompatible creates an OpenAICompatibleEmbedder from the given config.
 func NewOpenAICompatible(cfg Config) *OpenAICompatibleEmbedder {
 	batchSize := cfg.BatchSize

--- a/embed/openai_compat_from_provider_test.go
+++ b/embed/openai_compat_from_provider_test.go
@@ -1,0 +1,37 @@
+package embed
+
+import "testing"
+
+func TestNewFromProvider_BuildsEquivalentEmbedder(t *testing.T) {
+	e := NewFromProvider("http://localhost:11434", "nomic-embed-text", "sk-test", 768)
+
+	if e == nil {
+		t.Fatal("NewFromProvider returned nil")
+	}
+	if e.Model() != "nomic-embed-text" {
+		t.Errorf("expected Model=nomic-embed-text, got %q", e.Model())
+	}
+	if e.Dimensions() != 768 {
+		t.Errorf("expected Dimensions=768, got %d", e.Dimensions())
+	}
+}
+
+func TestNewFromProvider_EmptyAPIKey(t *testing.T) {
+	// Local endpoints often don't need a key.
+	e := NewFromProvider("http://localhost:11434", "model", "", 384)
+	if e == nil {
+		t.Fatal("NewFromProvider returned nil with empty APIKey")
+	}
+	if e.Dimensions() != 384 {
+		t.Errorf("expected Dimensions=384, got %d", e.Dimensions())
+	}
+}
+
+func TestNewFromProvider_TrimsTrailingSlash(t *testing.T) {
+	// Verifies the convenience constructor delegates to NewOpenAICompatible
+	// which trims the trailing slash on Endpoint.
+	e := NewFromProvider("http://localhost:11434/", "m", "", 0)
+	if e.endpoint != "http://localhost:11434" {
+		t.Errorf("expected endpoint trimmed, got %q", e.endpoint)
+	}
+}

--- a/enrich/enrich_page.go
+++ b/enrich/enrich_page.go
@@ -1,6 +1,8 @@
 package enrich
 
 import (
+	"strings"
+
 	"github.com/KHAEntertainment/markedup/schema"
 )
 
@@ -9,25 +11,50 @@ import (
 // result of enrichment without having to diff the before/after frontmatter
 // themselves.
 //
-// A field appears in the delta if it was empty/zero in the input frontmatter
-// AND populated by the extracted fields. In Force mode, fields appear if the
-// extracted value differed from the input value.
+// Semantics:
+//   - Scalar *Changed fields are true iff the post-merge value differs from
+//     the pre-merge value. This captures both default-mode fills and
+//     force-mode overwrites uniformly.
+//   - *Added slices hold items present after but absent before (matched
+//     case-insensitively for string fields, by Target for relationships, by
+//     Name for entities).
+//   - *Removed slices hold items present before but absent after. These are
+//     only populated in force mode (MergeOptions.Force=true); default mode
+//     is union-only and cannot drop items.
+//   - RelationshipsModified holds the post-merge value of relationships whose
+//     Target is present both before and after but whose Type or Strength
+//     differs. This catches force-mode per-target replacements that neither
+//     Added nor Removed would surface.
+//   - Changed is true iff any of the above is non-zero — the recommended
+//     single-source signal for "should I persist this page?"
 type EnrichmentDelta struct {
-	// Scalar fields that were changed by the merge.
+	// Scalar changes
 	IDChanged         bool
 	TitleChanged      bool
 	EntityTypeChanged bool
 	ConfidenceChanged bool
 	CreatedByChanged  bool
+	SummaryChanged    bool
 
-	// Collection fields. The slices hold only the newly-added items (not
-	// the full post-merge list).
-	TagsAdded          []string
-	RelationshipsAdded []schema.Relationship
-	SourcesAdded       []string
+	// Collection additions/removals. Added/Removed are symmetric; Modified
+	// captures relationship body changes with the same Target.
+	TagsAdded             []string
+	TagsRemoved           []string
+	RelationshipsAdded    []schema.Relationship
+	RelationshipsRemoved  []schema.Relationship
+	RelationshipsModified []schema.Relationship
+	SourcesAdded          []string
+	SourcesRemoved        []string
+	EntitiesAdded         []schema.Entity
+	EntitiesRemoved       []schema.Entity
+	SemanticHintsAdded    []string
+	SemanticHintsRemoved  []string
+	QuestionsAdded        []string
+	QuestionsRemoved      []string
 
-	// Changed reports whether any field in the delta is non-zero. Useful
-	// for callers that want to skip writing unchanged pages.
+	// Changed is true iff any field above is non-zero. Callers that only
+	// need a persist/skip signal can read this instead of inspecting
+	// individual fields.
 	Changed bool
 }
 
@@ -36,21 +63,21 @@ type EnrichmentDelta struct {
 // fields into the page's existing frontmatter, and returns the enriched
 // page plus a structured delta describing what changed.
 //
-// The input page is not mutated. The returned page is a copy with the
-// merged frontmatter; its Body and SourcePath are preserved from the input.
-// Nothing is written to disk — that is the caller's responsibility.
+// The input page and the slices inside its Frontmatter are not mutated;
+// the returned page's Frontmatter holds deep-copied slices. Body and
+// SourcePath are preserved by value. Nothing is written to disk.
 //
 // This is the preferred entry point for external callers that want to
 // capture enrichment results structurally (e.g. to populate a separate
-// manifest or database) without the side effect of frontmatter being
-// written back to the markdown file on disk.
+// manifest or database) without frontmatter being written back to the
+// markdown file on disk.
 func EnrichPage(page *schema.Page, filePath, rootDir string, opts MergeOptions) (*schema.Page, EnrichmentDelta) {
 	extracted := ExtractFromDocument(filePath, page.Body, rootDir)
 	merged := MergeFrontmatter(page.Frontmatter, extracted, opts)
-	delta := computeDelta(page.Frontmatter, merged, extracted, opts)
+	delta := computeDelta(page.Frontmatter, merged)
 
 	out := &schema.Page{
-		Frontmatter: merged,
+		Frontmatter: cloneFrontmatter(merged),
 		Body:        page.Body,
 		SourcePath:  page.SourcePath,
 	}
@@ -61,7 +88,8 @@ func EnrichPage(page *schema.Page, filePath, rootDir string, opts MergeOptions) 
 // ModelResult (from ModelExtractor.Extract and/or a generated summary) into
 // the page's frontmatter and returns the enriched page plus delta.
 //
-// The input page is not mutated and nothing is written to disk.
+// Ownership semantics match EnrichPage: input page and its frontmatter
+// slices are not mutated, returned page holds deep-copied slices.
 func EnrichPageWithModel(page *schema.Page, model *ModelResult, summary string, opts MergeOptions) (*schema.Page, EnrichmentDelta) {
 	merged := page.Frontmatter
 	if model != nil {
@@ -70,20 +98,21 @@ func EnrichPageWithModel(page *schema.Page, model *ModelResult, summary string, 
 	if summary != "" {
 		merged = MergeSummary(merged, summary, opts)
 	}
-	delta := computeModelDelta(page.Frontmatter, merged)
+	delta := computeDelta(page.Frontmatter, merged)
 
 	out := &schema.Page{
-		Frontmatter: merged,
+		Frontmatter: cloneFrontmatter(merged),
 		Body:        page.Body,
 		SourcePath:  page.SourcePath,
 	}
 	return out, delta
 }
 
-// computeDelta produces an EnrichmentDelta by comparing the pre-merge
-// frontmatter against the post-merge frontmatter, using the extracted
-// fields to identify which collection items are "new".
-func computeDelta(before, after schema.GraphFrontmatter, extracted ExtractedFields, opts MergeOptions) EnrichmentDelta {
+// computeDelta produces an EnrichmentDelta by structurally comparing before
+// and after frontmatter. It captures default-mode additions, force-mode
+// replacements (add + remove on the same field), and relationship body
+// changes against a shared Target.
+func computeDelta(before, after schema.GraphFrontmatter) EnrichmentDelta {
 	d := EnrichmentDelta{}
 
 	if before.ID != after.ID {
@@ -101,137 +130,150 @@ func computeDelta(before, after schema.GraphFrontmatter, extracted ExtractedFiel
 	if before.Provenance.CreatedBy != after.Provenance.CreatedBy {
 		d.CreatedByChanged = true
 	}
+	if before.Summary != after.Summary {
+		d.SummaryChanged = true
+	}
 
-	d.TagsAdded = addedStrings(before.Tags, after.Tags)
-	d.RelationshipsAdded = addedRelationships(before.Relationships, after.Relationships)
-	d.SourcesAdded = addedStrings(before.Provenance.Sources, after.Provenance.Sources)
+	d.TagsAdded, d.TagsRemoved = diffStringsCaseInsensitive(before.Tags, after.Tags)
+	d.SourcesAdded, d.SourcesRemoved = diffStringsCaseInsensitive(before.Provenance.Sources, after.Provenance.Sources)
+	d.SemanticHintsAdded, d.SemanticHintsRemoved = diffStringsCaseInsensitive(before.SemanticHints, after.SemanticHints)
+	d.QuestionsAdded, d.QuestionsRemoved = diffStringsCaseInsensitive(before.PossibleQuestions, after.PossibleQuestions)
 
-	// Suppress unused param warning; opts is accepted for future extension
-	// (e.g. reporting overwritten-in-force-mode).
-	_ = opts
+	d.RelationshipsAdded, d.RelationshipsRemoved, d.RelationshipsModified =
+		diffRelationships(before.Relationships, after.Relationships)
+
+	d.EntitiesAdded, d.EntitiesRemoved = diffEntities(before.Entities, after.Entities)
 
 	d.Changed = d.IDChanged || d.TitleChanged || d.EntityTypeChanged ||
-		d.ConfidenceChanged || d.CreatedByChanged ||
-		len(d.TagsAdded) > 0 || len(d.RelationshipsAdded) > 0 ||
-		len(d.SourcesAdded) > 0
+		d.ConfidenceChanged || d.CreatedByChanged || d.SummaryChanged ||
+		len(d.TagsAdded) > 0 || len(d.TagsRemoved) > 0 ||
+		len(d.SourcesAdded) > 0 || len(d.SourcesRemoved) > 0 ||
+		len(d.SemanticHintsAdded) > 0 || len(d.SemanticHintsRemoved) > 0 ||
+		len(d.QuestionsAdded) > 0 || len(d.QuestionsRemoved) > 0 ||
+		len(d.RelationshipsAdded) > 0 || len(d.RelationshipsRemoved) > 0 ||
+		len(d.RelationshipsModified) > 0 ||
+		len(d.EntitiesAdded) > 0 || len(d.EntitiesRemoved) > 0
+
 	return d
 }
 
-// computeModelDelta is the Tier 2 version — it additionally tracks entity
-// and summary-field changes that model extraction can introduce.
-func computeModelDelta(before, after schema.GraphFrontmatter) EnrichmentDelta {
-	d := EnrichmentDelta{}
-
-	if before.ID != after.ID {
-		d.IDChanged = true
-	}
-	if before.Title != after.Title {
-		d.TitleChanged = true
-	}
-	if before.EntityType != after.EntityType {
-		d.EntityTypeChanged = true
-	}
-	if before.Confidence != after.Confidence {
-		d.ConfidenceChanged = true
-	}
-	if before.Provenance.CreatedBy != after.Provenance.CreatedBy {
-		d.CreatedByChanged = true
-	}
-
-	d.TagsAdded = addedStrings(before.Tags, after.Tags)
-	d.RelationshipsAdded = addedRelationships(before.Relationships, after.Relationships)
-	d.SourcesAdded = addedStrings(before.Provenance.Sources, after.Provenance.Sources)
-
-	d.Changed = d.IDChanged || d.TitleChanged || d.EntityTypeChanged ||
-		d.ConfidenceChanged || d.CreatedByChanged ||
-		before.Summary != after.Summary ||
-		len(d.TagsAdded) > 0 || len(d.RelationshipsAdded) > 0 ||
-		len(d.SourcesAdded) > 0 ||
-		!entitySlicesEqual(before.Entities, after.Entities) ||
-		!stringSlicesEqual(before.SemanticHints, after.SemanticHints) ||
-		!stringSlicesEqual(before.PossibleQuestions, after.PossibleQuestions)
-	return d
-}
-
-// addedStrings returns elements in after that are not in before
-// (case-insensitive match), preserving after's order.
-func addedStrings(before, after []string) []string {
-	if len(after) == 0 {
-		return nil
-	}
+// diffStringsCaseInsensitive returns (added, removed) where items are
+// compared via strings.ToLower, matching unionStrings in merge.go. Result
+// order is preserved from the input slices.
+func diffStringsCaseInsensitive(before, after []string) (added, removed []string) {
 	beforeSet := make(map[string]struct{}, len(before))
 	for _, s := range before {
-		beforeSet[stringsFold(s)] = struct{}{}
+		beforeSet[strings.ToLower(s)] = struct{}{}
 	}
-	var added []string
+	afterSet := make(map[string]struct{}, len(after))
 	for _, s := range after {
-		if _, ok := beforeSet[stringsFold(s)]; !ok {
+		afterSet[strings.ToLower(s)] = struct{}{}
+	}
+	for _, s := range after {
+		if _, ok := beforeSet[strings.ToLower(s)]; !ok {
 			added = append(added, s)
 		}
 	}
-	return added
+	for _, s := range before {
+		if _, ok := afterSet[strings.ToLower(s)]; !ok {
+			removed = append(removed, s)
+		}
+	}
+	return added, removed
 }
 
-// addedRelationships returns relationships in after whose Target is not in
-// before, preserving after's order.
-func addedRelationships(before, after []schema.Relationship) []schema.Relationship {
-	if len(after) == 0 {
+// diffRelationships categorizes the post-merge relationships into:
+//   - added:    Target present in after but not before
+//   - removed:  Target present in before but not after
+//   - modified: Target in both but Type or Strength differs (post-merge value)
+//
+// This mirrors unionRelationships in merge.go (which dedupes by Target) and
+// additionally detects the force-mode case where MergeFrontmatter replaces
+// the entire slice.
+func diffRelationships(before, after []schema.Relationship) (added, removed, modified []schema.Relationship) {
+	beforeByTarget := make(map[string]schema.Relationship, len(before))
+	for _, r := range before {
+		beforeByTarget[r.Target] = r
+	}
+	afterByTarget := make(map[string]schema.Relationship, len(after))
+	for _, r := range after {
+		afterByTarget[r.Target] = r
+	}
+
+	for _, r := range after {
+		if prev, ok := beforeByTarget[r.Target]; !ok {
+			added = append(added, r)
+		} else if prev.Type != r.Type || prev.Strength != r.Strength {
+			modified = append(modified, r)
+		}
+	}
+	for _, r := range before {
+		if _, ok := afterByTarget[r.Target]; !ok {
+			removed = append(removed, r)
+		}
+	}
+	return added, removed, modified
+}
+
+// diffEntities returns (added, removed) compared by Name.
+func diffEntities(before, after []schema.Entity) (added, removed []schema.Entity) {
+	beforeByName := make(map[string]struct{}, len(before))
+	for _, e := range before {
+		beforeByName[e.Name] = struct{}{}
+	}
+	afterByName := make(map[string]struct{}, len(after))
+	for _, e := range after {
+		afterByName[e.Name] = struct{}{}
+	}
+	for _, e := range after {
+		if _, ok := beforeByName[e.Name]; !ok {
+			added = append(added, e)
+		}
+	}
+	for _, e := range before {
+		if _, ok := afterByName[e.Name]; !ok {
+			removed = append(removed, e)
+		}
+	}
+	return added, removed
+}
+
+// cloneFrontmatter returns a deep copy of the given GraphFrontmatter. All
+// slice fields (including nested Entity.Aliases) get fresh backing arrays
+// so the caller can safely mutate them without affecting the source.
+func cloneFrontmatter(fm schema.GraphFrontmatter) schema.GraphFrontmatter {
+	cp := fm
+	cp.Tags = cloneStrings(fm.Tags)
+	cp.Relationships = cloneRelationships(fm.Relationships)
+	cp.SemanticHints = cloneStrings(fm.SemanticHints)
+	cp.PossibleQuestions = cloneStrings(fm.PossibleQuestions)
+	cp.Provenance.Sources = cloneStrings(fm.Provenance.Sources)
+	if len(fm.Entities) > 0 {
+		cp.Entities = make([]schema.Entity, len(fm.Entities))
+		for i, e := range fm.Entities {
+			cp.Entities[i] = e
+			cp.Entities[i].Aliases = cloneStrings(e.Aliases)
+		}
+	} else {
+		cp.Entities = nil
+	}
+	return cp
+}
+
+func cloneStrings(s []string) []string {
+	if len(s) == 0 {
 		return nil
 	}
-	beforeSet := make(map[string]struct{}, len(before))
-	for _, r := range before {
-		beforeSet[r.Target] = struct{}{}
-	}
-	var added []schema.Relationship
-	for _, r := range after {
-		if _, ok := beforeSet[r.Target]; !ok {
-			added = append(added, r)
-		}
-	}
-	return added
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
 }
 
-// stringsFold is a minimal case-fold helper that matches the semantics used
-// by unionStrings (lower-case equivalence).
-func stringsFold(s string) string {
-	out := make([]byte, len(s))
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c >= 'A' && c <= 'Z' {
-			c += 'a' - 'A'
-		}
-		out[i] = c
+func cloneRelationships(r []schema.Relationship) []schema.Relationship {
+	if len(r) == 0 {
+		return nil
 	}
-	return string(out)
-}
-
-// stringSlicesEqual returns true iff a and b have the same elements in the
-// same order.
-func stringSlicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// entitySlicesEqual returns true iff a and b have the same entities in the
-// same order (comparing Name, Aliases, and Role).
-func entitySlicesEqual(a, b []schema.Entity) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i].Name != b[i].Name || a[i].Role != b[i].Role {
-			return false
-		}
-		if !stringSlicesEqual(a[i].Aliases, b[i].Aliases) {
-			return false
-		}
-	}
-	return true
+	out := make([]schema.Relationship, len(r))
+	copy(out, r)
+	return out
 }

--- a/enrich/enrich_page.go
+++ b/enrich/enrich_page.go
@@ -1,0 +1,237 @@
+package enrich
+
+import (
+	"github.com/KHAEntertainment/markedup/schema"
+)
+
+// EnrichmentDelta describes what changed when enriching a page. It lets
+// external callers (e.g. Plexium's MarkedUp plugin) capture the structured
+// result of enrichment without having to diff the before/after frontmatter
+// themselves.
+//
+// A field appears in the delta if it was empty/zero in the input frontmatter
+// AND populated by the extracted fields. In Force mode, fields appear if the
+// extracted value differed from the input value.
+type EnrichmentDelta struct {
+	// Scalar fields that were changed by the merge.
+	IDChanged         bool
+	TitleChanged      bool
+	EntityTypeChanged bool
+	ConfidenceChanged bool
+	CreatedByChanged  bool
+
+	// Collection fields. The slices hold only the newly-added items (not
+	// the full post-merge list).
+	TagsAdded          []string
+	RelationshipsAdded []schema.Relationship
+	SourcesAdded       []string
+
+	// Changed reports whether any field in the delta is non-zero. Useful
+	// for callers that want to skip writing unchanged pages.
+	Changed bool
+}
+
+// EnrichPage runs Tier 1 deterministic enrichment against the given page
+// (using filePath and rootDir for ID/tag derivation), merges the extracted
+// fields into the page's existing frontmatter, and returns the enriched
+// page plus a structured delta describing what changed.
+//
+// The input page is not mutated. The returned page is a copy with the
+// merged frontmatter; its Body and SourcePath are preserved from the input.
+// Nothing is written to disk — that is the caller's responsibility.
+//
+// This is the preferred entry point for external callers that want to
+// capture enrichment results structurally (e.g. to populate a separate
+// manifest or database) without the side effect of frontmatter being
+// written back to the markdown file on disk.
+func EnrichPage(page *schema.Page, filePath, rootDir string, opts MergeOptions) (*schema.Page, EnrichmentDelta) {
+	extracted := ExtractFromDocument(filePath, page.Body, rootDir)
+	merged := MergeFrontmatter(page.Frontmatter, extracted, opts)
+	delta := computeDelta(page.Frontmatter, merged, extracted, opts)
+
+	out := &schema.Page{
+		Frontmatter: merged,
+		Body:        page.Body,
+		SourcePath:  page.SourcePath,
+	}
+	return out, delta
+}
+
+// EnrichPageWithModel is the Tier 2 variant: it merges a pre-computed
+// ModelResult (from ModelExtractor.Extract and/or a generated summary) into
+// the page's frontmatter and returns the enriched page plus delta.
+//
+// The input page is not mutated and nothing is written to disk.
+func EnrichPageWithModel(page *schema.Page, model *ModelResult, summary string, opts MergeOptions) (*schema.Page, EnrichmentDelta) {
+	merged := page.Frontmatter
+	if model != nil {
+		merged = MergeModelResult(merged, model, opts)
+	}
+	if summary != "" {
+		merged = MergeSummary(merged, summary, opts)
+	}
+	delta := computeModelDelta(page.Frontmatter, merged)
+
+	out := &schema.Page{
+		Frontmatter: merged,
+		Body:        page.Body,
+		SourcePath:  page.SourcePath,
+	}
+	return out, delta
+}
+
+// computeDelta produces an EnrichmentDelta by comparing the pre-merge
+// frontmatter against the post-merge frontmatter, using the extracted
+// fields to identify which collection items are "new".
+func computeDelta(before, after schema.GraphFrontmatter, extracted ExtractedFields, opts MergeOptions) EnrichmentDelta {
+	d := EnrichmentDelta{}
+
+	if before.ID != after.ID {
+		d.IDChanged = true
+	}
+	if before.Title != after.Title {
+		d.TitleChanged = true
+	}
+	if before.EntityType != after.EntityType {
+		d.EntityTypeChanged = true
+	}
+	if before.Confidence != after.Confidence {
+		d.ConfidenceChanged = true
+	}
+	if before.Provenance.CreatedBy != after.Provenance.CreatedBy {
+		d.CreatedByChanged = true
+	}
+
+	d.TagsAdded = addedStrings(before.Tags, after.Tags)
+	d.RelationshipsAdded = addedRelationships(before.Relationships, after.Relationships)
+	d.SourcesAdded = addedStrings(before.Provenance.Sources, after.Provenance.Sources)
+
+	// Suppress unused param warning; opts is accepted for future extension
+	// (e.g. reporting overwritten-in-force-mode).
+	_ = opts
+
+	d.Changed = d.IDChanged || d.TitleChanged || d.EntityTypeChanged ||
+		d.ConfidenceChanged || d.CreatedByChanged ||
+		len(d.TagsAdded) > 0 || len(d.RelationshipsAdded) > 0 ||
+		len(d.SourcesAdded) > 0
+	return d
+}
+
+// computeModelDelta is the Tier 2 version — it additionally tracks entity
+// and summary-field changes that model extraction can introduce.
+func computeModelDelta(before, after schema.GraphFrontmatter) EnrichmentDelta {
+	d := EnrichmentDelta{}
+
+	if before.ID != after.ID {
+		d.IDChanged = true
+	}
+	if before.Title != after.Title {
+		d.TitleChanged = true
+	}
+	if before.EntityType != after.EntityType {
+		d.EntityTypeChanged = true
+	}
+	if before.Confidence != after.Confidence {
+		d.ConfidenceChanged = true
+	}
+	if before.Provenance.CreatedBy != after.Provenance.CreatedBy {
+		d.CreatedByChanged = true
+	}
+
+	d.TagsAdded = addedStrings(before.Tags, after.Tags)
+	d.RelationshipsAdded = addedRelationships(before.Relationships, after.Relationships)
+	d.SourcesAdded = addedStrings(before.Provenance.Sources, after.Provenance.Sources)
+
+	d.Changed = d.IDChanged || d.TitleChanged || d.EntityTypeChanged ||
+		d.ConfidenceChanged || d.CreatedByChanged ||
+		before.Summary != after.Summary ||
+		len(d.TagsAdded) > 0 || len(d.RelationshipsAdded) > 0 ||
+		len(d.SourcesAdded) > 0 ||
+		!entitySlicesEqual(before.Entities, after.Entities) ||
+		!stringSlicesEqual(before.SemanticHints, after.SemanticHints) ||
+		!stringSlicesEqual(before.PossibleQuestions, after.PossibleQuestions)
+	return d
+}
+
+// addedStrings returns elements in after that are not in before
+// (case-insensitive match), preserving after's order.
+func addedStrings(before, after []string) []string {
+	if len(after) == 0 {
+		return nil
+	}
+	beforeSet := make(map[string]struct{}, len(before))
+	for _, s := range before {
+		beforeSet[stringsFold(s)] = struct{}{}
+	}
+	var added []string
+	for _, s := range after {
+		if _, ok := beforeSet[stringsFold(s)]; !ok {
+			added = append(added, s)
+		}
+	}
+	return added
+}
+
+// addedRelationships returns relationships in after whose Target is not in
+// before, preserving after's order.
+func addedRelationships(before, after []schema.Relationship) []schema.Relationship {
+	if len(after) == 0 {
+		return nil
+	}
+	beforeSet := make(map[string]struct{}, len(before))
+	for _, r := range before {
+		beforeSet[r.Target] = struct{}{}
+	}
+	var added []schema.Relationship
+	for _, r := range after {
+		if _, ok := beforeSet[r.Target]; !ok {
+			added = append(added, r)
+		}
+	}
+	return added
+}
+
+// stringsFold is a minimal case-fold helper that matches the semantics used
+// by unionStrings (lower-case equivalence).
+func stringsFold(s string) string {
+	out := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		out[i] = c
+	}
+	return string(out)
+}
+
+// stringSlicesEqual returns true iff a and b have the same elements in the
+// same order.
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// entitySlicesEqual returns true iff a and b have the same entities in the
+// same order (comparing Name, Aliases, and Role).
+func entitySlicesEqual(a, b []schema.Entity) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name || a[i].Role != b[i].Role {
+			return false
+		}
+		if !stringSlicesEqual(a[i].Aliases, b[i].Aliases) {
+			return false
+		}
+	}
+	return true
+}

--- a/enrich/enrich_page.go
+++ b/enrich/enrich_page.go
@@ -37,7 +37,8 @@ type EnrichmentDelta struct {
 	SummaryChanged    bool
 
 	// Collection additions/removals. Added/Removed are symmetric; Modified
-	// captures relationship body changes with the same Target.
+	// captures body changes where the identity key (Target for
+	// relationships, Name for entities) is present on both sides.
 	TagsAdded             []string
 	TagsRemoved           []string
 	RelationshipsAdded    []schema.Relationship
@@ -47,6 +48,7 @@ type EnrichmentDelta struct {
 	SourcesRemoved        []string
 	EntitiesAdded         []schema.Entity
 	EntitiesRemoved       []schema.Entity
+	EntitiesModified      []schema.Entity
 	SemanticHintsAdded    []string
 	SemanticHintsRemoved  []string
 	QuestionsAdded        []string
@@ -142,7 +144,8 @@ func computeDelta(before, after schema.GraphFrontmatter) EnrichmentDelta {
 	d.RelationshipsAdded, d.RelationshipsRemoved, d.RelationshipsModified =
 		diffRelationships(before.Relationships, after.Relationships)
 
-	d.EntitiesAdded, d.EntitiesRemoved = diffEntities(before.Entities, after.Entities)
+	d.EntitiesAdded, d.EntitiesRemoved, d.EntitiesModified =
+		diffEntities(before.Entities, after.Entities)
 
 	d.Changed = d.IDChanged || d.TitleChanged || d.EntityTypeChanged ||
 		d.ConfidenceChanged || d.CreatedByChanged || d.SummaryChanged ||
@@ -152,7 +155,8 @@ func computeDelta(before, after schema.GraphFrontmatter) EnrichmentDelta {
 		len(d.QuestionsAdded) > 0 || len(d.QuestionsRemoved) > 0 ||
 		len(d.RelationshipsAdded) > 0 || len(d.RelationshipsRemoved) > 0 ||
 		len(d.RelationshipsModified) > 0 ||
-		len(d.EntitiesAdded) > 0 || len(d.EntitiesRemoved) > 0
+		len(d.EntitiesAdded) > 0 || len(d.EntitiesRemoved) > 0 ||
+		len(d.EntitiesModified) > 0
 
 	return d
 }
@@ -190,6 +194,12 @@ func diffStringsCaseInsensitive(before, after []string) (added, removed []string
 // This mirrors unionRelationships in merge.go (which dedupes by Target) and
 // additionally detects the force-mode case where MergeFrontmatter replaces
 // the entire slice.
+//
+// Invariant: Target is assumed unique within each input slice, matching
+// the invariant unionRelationships relies on. If duplicates are present
+// the later occurrence wins in the lookup maps; cardinality changes
+// between duplicated targets may therefore be underreported. Enforcement
+// of this invariant is upstream in the merge logic.
 func diffRelationships(before, after []schema.Relationship) (added, removed, modified []schema.Relationship) {
 	beforeByTarget := make(map[string]schema.Relationship, len(before))
 	for _, r := range before {
@@ -215,19 +225,30 @@ func diffRelationships(before, after []schema.Relationship) (added, removed, mod
 	return added, removed, modified
 }
 
-// diffEntities returns (added, removed) compared by Name.
-func diffEntities(before, after []schema.Entity) (added, removed []schema.Entity) {
-	beforeByName := make(map[string]struct{}, len(before))
+// diffEntities categorizes entities into (added, removed, modified),
+// comparing identity by Name. Modified entities are those whose Name is
+// present on both sides but whose Role or Aliases differ. This catches
+// force-mode replacements like Alice{Role:"person"} -> Alice{Role:"author"}
+// that Added/Removed alone would miss.
+//
+// Invariant: entity Name is assumed unique within each input slice.
+// Duplicate Names follow the same "last wins" behavior as
+// diffRelationships and rely on upstream merge logic for enforcement.
+func diffEntities(before, after []schema.Entity) (added, removed, modified []schema.Entity) {
+	beforeByName := make(map[string]schema.Entity, len(before))
 	for _, e := range before {
-		beforeByName[e.Name] = struct{}{}
+		beforeByName[e.Name] = e
 	}
-	afterByName := make(map[string]struct{}, len(after))
+	afterByName := make(map[string]schema.Entity, len(after))
 	for _, e := range after {
-		afterByName[e.Name] = struct{}{}
+		afterByName[e.Name] = e
 	}
+
 	for _, e := range after {
-		if _, ok := beforeByName[e.Name]; !ok {
+		if prev, ok := beforeByName[e.Name]; !ok {
 			added = append(added, e)
+		} else if !entityBodyEqual(prev, e) {
+			modified = append(modified, e)
 		}
 	}
 	for _, e := range before {
@@ -235,7 +256,24 @@ func diffEntities(before, after []schema.Entity) (added, removed []schema.Entity
 			removed = append(removed, e)
 		}
 	}
-	return added, removed
+	return added, removed, modified
+}
+
+// entityBodyEqual returns true iff two entities with the same Name also
+// share identical Role and Aliases (order-sensitive).
+func entityBodyEqual(a, b schema.Entity) bool {
+	if a.Role != b.Role {
+		return false
+	}
+	if len(a.Aliases) != len(b.Aliases) {
+		return false
+	}
+	for i := range a.Aliases {
+		if a.Aliases[i] != b.Aliases[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // cloneFrontmatter returns a deep copy of the given GraphFrontmatter. All

--- a/enrich/enrich_page_test.go
+++ b/enrich/enrich_page_test.go
@@ -278,6 +278,75 @@ func TestEnrichPage_ReturnedPageIsDeepCopy(t *testing.T) {
 	}
 }
 
+// Direct coverage for EnrichPageWithModel's deep-copy-on-return contract,
+// symmetric to TestEnrichPage_ReturnedPageIsDeepCopy. Both entry points
+// share cloneFrontmatter, but the contract is documented on both and
+// deserves its own assertion.
+func TestEnrichPageWithModel_ReturnedPageIsDeepCopy(t *testing.T) {
+	page := &schema.Page{
+		Frontmatter: schema.GraphFrontmatter{
+			Entities:          []schema.Entity{{Name: "Alice", Aliases: []string{"A"}}},
+			SemanticHints:     []string{"hint"},
+			PossibleQuestions: []string{"who?"},
+			Tags:              []string{"tag"},
+		},
+		Body:       "body",
+		SourcePath: "/tmp/p.md",
+	}
+
+	inputSnapshot := schema.GraphFrontmatter{
+		Entities:          []schema.Entity{{Name: "Alice", Aliases: []string{"A"}}},
+		SemanticHints:     []string{"hint"},
+		PossibleQuestions: []string{"who?"},
+		Tags:              []string{"tag"},
+	}
+
+	model := &ModelResult{
+		Entities:          []schema.Entity{{Name: "Bob", Role: "editor"}},
+		SemanticHints:     []string{"another hint"},
+		PossibleQuestions: []string{"what?"},
+	}
+
+	enriched, _ := EnrichPageWithModel(page, model, "summary", MergeOptions{})
+
+	// Mutate every slice on the returned frontmatter.
+	if len(enriched.Frontmatter.Tags) > 0 {
+		enriched.Frontmatter.Tags[0] = "MUTATED"
+	}
+	if len(enriched.Frontmatter.SemanticHints) > 0 {
+		enriched.Frontmatter.SemanticHints[0] = "MUTATED"
+	}
+	if len(enriched.Frontmatter.PossibleQuestions) > 0 {
+		enriched.Frontmatter.PossibleQuestions[0] = "MUTATED"
+	}
+	if len(enriched.Frontmatter.Entities) > 0 {
+		enriched.Frontmatter.Entities[0].Name = "MUTATED"
+		if len(enriched.Frontmatter.Entities[0].Aliases) > 0 {
+			enriched.Frontmatter.Entities[0].Aliases[0] = "MUTATED"
+		}
+	}
+
+	// Input slices must be unchanged.
+	if !reflect.DeepEqual(page.Frontmatter.Tags, inputSnapshot.Tags) {
+		t.Errorf("Tags mutated: got %v, want %v", page.Frontmatter.Tags, inputSnapshot.Tags)
+	}
+	if !reflect.DeepEqual(page.Frontmatter.SemanticHints, inputSnapshot.SemanticHints) {
+		t.Errorf("SemanticHints mutated: got %v, want %v",
+			page.Frontmatter.SemanticHints, inputSnapshot.SemanticHints)
+	}
+	if !reflect.DeepEqual(page.Frontmatter.PossibleQuestions, inputSnapshot.PossibleQuestions) {
+		t.Errorf("PossibleQuestions mutated: got %v, want %v",
+			page.Frontmatter.PossibleQuestions, inputSnapshot.PossibleQuestions)
+	}
+	if page.Frontmatter.Entities[0].Name != "Alice" {
+		t.Errorf("Entity.Name mutated: got %q", page.Frontmatter.Entities[0].Name)
+	}
+	if !reflect.DeepEqual(page.Frontmatter.Entities[0].Aliases, inputSnapshot.Entities[0].Aliases) {
+		t.Errorf("Entity.Aliases mutated: got %v, want %v",
+			page.Frontmatter.Entities[0].Aliases, inputSnapshot.Entities[0].Aliases)
+	}
+}
+
 func TestEnrichPage_PreservesBodyAndSourcePath(t *testing.T) {
 	page := &schema.Page{
 		Frontmatter: schema.GraphFrontmatter{},

--- a/enrich/enrich_page_test.go
+++ b/enrich/enrich_page_test.go
@@ -168,6 +168,48 @@ func TestEnrichPage_RelationshipBodyChangeIsDetected(t *testing.T) {
 	}
 }
 
+// Entity body-only replacement (same Name, different Role/Aliases) must be
+// detected via EntitiesModified. This mirrors the relationship body-change
+// case and is the class of bug that slipped past EntitiesAdded/Removed alone.
+func TestEnrichPage_EntityBodyChangeIsDetected(t *testing.T) {
+	before := schema.GraphFrontmatter{
+		ID:         "x",
+		Title:      "X",
+		EntityType: "document",
+		Confidence: 0.9,
+		Entities: []schema.Entity{
+			{Name: "Alice", Role: "person", Aliases: []string{"A"}},
+		},
+	}
+	after := schema.GraphFrontmatter{
+		ID:         "x",
+		Title:      "X",
+		EntityType: "document",
+		Confidence: 0.9,
+		Entities: []schema.Entity{
+			{Name: "Alice", Role: "author", Aliases: []string{"Al"}},
+		},
+	}
+
+	delta := computeDelta(before, after)
+
+	if !delta.Changed {
+		t.Fatal("expected delta.Changed=true when entity body differs")
+	}
+	if len(delta.EntitiesModified) != 1 {
+		t.Fatalf("expected 1 modified entity, got %d: %+v",
+			len(delta.EntitiesModified), delta.EntitiesModified)
+	}
+	if delta.EntitiesModified[0].Role != "author" {
+		t.Errorf("expected modified entity to carry post-merge Role, got %q",
+			delta.EntitiesModified[0].Role)
+	}
+	if len(delta.EntitiesAdded) != 0 || len(delta.EntitiesRemoved) != 0 {
+		t.Errorf("expected no add/remove for same-name change; got add=%v remove=%v",
+			delta.EntitiesAdded, delta.EntitiesRemoved)
+	}
+}
+
 // Deep-copy semantics: mutating the returned frontmatter must not affect
 // the input. Addresses Codex review Must-Fix #2.
 func TestEnrichPage_ReturnedPageIsDeepCopy(t *testing.T) {

--- a/enrich/enrich_page_test.go
+++ b/enrich/enrich_page_test.go
@@ -1,0 +1,171 @@
+package enrich
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/KHAEntertainment/markedup/schema"
+)
+
+func TestEnrichPage_EmptyFrontmatterGetsPopulated(t *testing.T) {
+	page := &schema.Page{
+		Frontmatter: schema.GraphFrontmatter{},
+		Body:        "# Hello World\n\nSome text with #example and [[other-page]].",
+		SourcePath:  "/tmp/root/notes/hello.md",
+	}
+
+	enriched, delta := EnrichPage(page, "/tmp/root/notes/hello.md", "/tmp/root", MergeOptions{})
+
+	if !delta.Changed {
+		t.Fatal("expected delta.Changed=true for empty frontmatter")
+	}
+	if !delta.IDChanged {
+		t.Error("expected IDChanged")
+	}
+	if !delta.TitleChanged {
+		t.Error("expected TitleChanged")
+	}
+	if !delta.EntityTypeChanged {
+		t.Error("expected EntityTypeChanged")
+	}
+	if !delta.ConfidenceChanged {
+		t.Error("expected ConfidenceChanged")
+	}
+	if enriched.Frontmatter.Title != "Hello World" {
+		t.Errorf("expected Title=Hello World, got %q", enriched.Frontmatter.Title)
+	}
+	if enriched.Frontmatter.ID != "hello" {
+		t.Errorf("expected ID=hello, got %q", enriched.Frontmatter.ID)
+	}
+	if len(delta.TagsAdded) == 0 {
+		t.Error("expected TagsAdded to include extracted tags")
+	}
+	if len(delta.RelationshipsAdded) == 0 {
+		t.Error("expected RelationshipsAdded from wikilink")
+	}
+}
+
+func TestEnrichPage_AlreadyCompleteIsUnchanged(t *testing.T) {
+	// Pre-populated frontmatter with matching content — Tier 1 extraction
+	// will find the same tags/relationships (already present), so delta
+	// should have no additions.
+	page := &schema.Page{
+		Frontmatter: schema.GraphFrontmatter{
+			ID:         "hello",
+			Title:      "Hello World",
+			EntityType: "document",
+			Confidence: 0.9,
+			Tags:       []string{"example"},
+			Relationships: []schema.Relationship{
+				{Target: "other-page", Type: "related-to", Strength: 0.5},
+			},
+			Provenance: schema.Provenance{CreatedBy: "manual"},
+		},
+		Body:       "# Hello World\n\nSome text with #example and [[other-page]].",
+		SourcePath: "/tmp/root/notes/hello.md",
+	}
+
+	_, delta := EnrichPage(page, "/tmp/root/notes/hello.md", "/tmp/root", MergeOptions{})
+
+	if delta.IDChanged {
+		t.Error("ID should not change")
+	}
+	if delta.TitleChanged {
+		t.Error("Title should not change")
+	}
+	if delta.ConfidenceChanged {
+		t.Error("Confidence should not change in non-force mode")
+	}
+	if len(delta.RelationshipsAdded) != 0 {
+		t.Errorf("expected no added relationships, got %+v", delta.RelationshipsAdded)
+	}
+}
+
+func TestEnrichPage_DoesNotMutateInput(t *testing.T) {
+	original := schema.GraphFrontmatter{
+		Tags: []string{"original"},
+	}
+	page := &schema.Page{
+		Frontmatter: original,
+		Body:        "# Title\n\n#newtag",
+		SourcePath:  "/tmp/root/a.md",
+	}
+
+	EnrichPage(page, "/tmp/root/a.md", "/tmp/root", MergeOptions{})
+
+	if !reflect.DeepEqual(page.Frontmatter.Tags, []string{"original"}) {
+		t.Errorf("input frontmatter was mutated: %+v", page.Frontmatter.Tags)
+	}
+}
+
+func TestEnrichPage_PreservesBodyAndSourcePath(t *testing.T) {
+	page := &schema.Page{
+		Frontmatter: schema.GraphFrontmatter{},
+		Body:        "body content",
+		SourcePath:  "/some/path.md",
+	}
+
+	enriched, _ := EnrichPage(page, "/some/path.md", "/some", MergeOptions{})
+
+	if enriched.Body != page.Body {
+		t.Errorf("Body was not preserved: got %q", enriched.Body)
+	}
+	if enriched.SourcePath != page.SourcePath {
+		t.Errorf("SourcePath was not preserved: got %q", enriched.SourcePath)
+	}
+}
+
+func TestEnrichPageWithModel_PopulatesEntitiesAndSummary(t *testing.T) {
+	page := &schema.Page{
+		Frontmatter: schema.GraphFrontmatter{
+			ID:    "existing",
+			Title: "Existing Title",
+		},
+		Body:       "body",
+		SourcePath: "/p.md",
+	}
+
+	model := &ModelResult{
+		Entities: []schema.Entity{
+			{Name: "Alice", Role: "author"},
+		},
+		SemanticHints:     []string{"who wrote this"},
+		PossibleQuestions: []string{"who is Alice?"},
+		EntityType:        "person",
+	}
+
+	enriched, delta := EnrichPageWithModel(page, model, "A short summary.", MergeOptions{})
+
+	if !delta.Changed {
+		t.Fatal("expected delta.Changed=true")
+	}
+	if enriched.Frontmatter.Summary != "A short summary." {
+		t.Errorf("expected summary populated, got %q", enriched.Frontmatter.Summary)
+	}
+	if len(enriched.Frontmatter.Entities) != 1 {
+		t.Errorf("expected 1 entity, got %d", len(enriched.Frontmatter.Entities))
+	}
+	if enriched.Frontmatter.EntityType != "person" {
+		t.Errorf("expected EntityType=person, got %q", enriched.Frontmatter.EntityType)
+	}
+}
+
+func TestEnrichPageWithModel_NilModelOnlyAppliesSummary(t *testing.T) {
+	page := &schema.Page{
+		Frontmatter: schema.GraphFrontmatter{ID: "x", Title: "X"},
+		Body:        "",
+		SourcePath:  "/x.md",
+	}
+
+	enriched, delta := EnrichPageWithModel(page, nil, "summary only", MergeOptions{})
+
+	if !delta.Changed {
+		t.Fatal("expected delta.Changed=true")
+	}
+	if enriched.Frontmatter.Summary != "summary only" {
+		t.Errorf("expected summary populated")
+	}
+	if len(enriched.Frontmatter.Entities) != 0 {
+		t.Errorf("expected no entities when model is nil")
+	}
+}

--- a/enrich/enrich_page_test.go
+++ b/enrich/enrich_page_test.go
@@ -40,15 +40,15 @@ func TestEnrichPage_EmptyFrontmatterGetsPopulated(t *testing.T) {
 	if len(delta.TagsAdded) == 0 {
 		t.Error("expected TagsAdded to include extracted tags")
 	}
+	if len(delta.TagsRemoved) != 0 {
+		t.Errorf("expected no tags removed on empty -> populated, got %v", delta.TagsRemoved)
+	}
 	if len(delta.RelationshipsAdded) == 0 {
 		t.Error("expected RelationshipsAdded from wikilink")
 	}
 }
 
 func TestEnrichPage_AlreadyCompleteIsUnchanged(t *testing.T) {
-	// Pre-populated frontmatter with matching content — Tier 1 extraction
-	// will find the same tags/relationships (already present), so delta
-	// should have no additions.
 	page := &schema.Page{
 		Frontmatter: schema.GraphFrontmatter{
 			ID:         "hello",
@@ -79,22 +79,160 @@ func TestEnrichPage_AlreadyCompleteIsUnchanged(t *testing.T) {
 	if len(delta.RelationshipsAdded) != 0 {
 		t.Errorf("expected no added relationships, got %+v", delta.RelationshipsAdded)
 	}
+	if len(delta.RelationshipsModified) != 0 {
+		t.Errorf("expected no modified relationships, got %+v", delta.RelationshipsModified)
+	}
 }
 
-func TestEnrichPage_DoesNotMutateInput(t *testing.T) {
-	original := schema.GraphFrontmatter{
-		Tags: []string{"original"},
-	}
+// Force-mode replacement is the regression captured by Codex review point #1.
+// Overwriting an existing tag set / relationship with different values MUST
+// set delta.Changed=true, even though Tier 1 extraction would normally
+// produce a superset.
+func TestEnrichPage_ForceModeReplacementIsDetected(t *testing.T) {
+	// Pre-populated page with tags and relationships that will NOT appear
+	// in the body — so Tier 1 extraction produces a completely different
+	// set, and force mode replaces the originals.
 	page := &schema.Page{
-		Frontmatter: original,
-		Body:        "# Title\n\n#newtag",
-		SourcePath:  "/tmp/root/a.md",
+		Frontmatter: schema.GraphFrontmatter{
+			ID:         "hello",
+			Title:      "Hello",
+			EntityType: "concept",
+			Confidence: 0.9,
+			Tags:       []string{"stale-tag", "obsolete"},
+			Relationships: []schema.Relationship{
+				{Target: "removed-page", Type: "related-to", Strength: 0.5},
+			},
+		},
+		Body:       "# Hello\n\n#brandnew and [[new-target]]",
+		SourcePath: "/tmp/root/hello.md",
 	}
 
-	EnrichPage(page, "/tmp/root/a.md", "/tmp/root", MergeOptions{})
+	_, delta := EnrichPage(page, "/tmp/root/hello.md", "/tmp/root", MergeOptions{Force: true})
 
-	if !reflect.DeepEqual(page.Frontmatter.Tags, []string{"original"}) {
-		t.Errorf("input frontmatter was mutated: %+v", page.Frontmatter.Tags)
+	if !delta.Changed {
+		t.Fatal("expected delta.Changed=true after force-mode replacement")
+	}
+	// Old tags should appear as Removed; new tags as Added.
+	if len(delta.TagsRemoved) == 0 {
+		t.Errorf("expected TagsRemoved to include stale-tag/obsolete, got %v", delta.TagsRemoved)
+	}
+	if len(delta.TagsAdded) == 0 {
+		t.Errorf("expected TagsAdded to include brandnew, got %v", delta.TagsAdded)
+	}
+	if len(delta.RelationshipsRemoved) == 0 {
+		t.Errorf("expected RelationshipsRemoved to include removed-page, got %v", delta.RelationshipsRemoved)
+	}
+	if len(delta.RelationshipsAdded) == 0 {
+		t.Errorf("expected RelationshipsAdded to include new-target, got %v", delta.RelationshipsAdded)
+	}
+}
+
+// Same Target, different Type/Strength should show up as Modified — the
+// case that would otherwise slip past an "added only" delta.
+func TestEnrichPage_RelationshipBodyChangeIsDetected(t *testing.T) {
+	before := schema.GraphFrontmatter{
+		ID:         "x",
+		Title:      "X",
+		EntityType: "concept",
+		Confidence: 0.9,
+		Relationships: []schema.Relationship{
+			{Target: "y", Type: "old-predicate", Strength: 0.1},
+		},
+	}
+	after := schema.GraphFrontmatter{
+		ID:         "x",
+		Title:      "X",
+		EntityType: "concept",
+		Confidence: 0.9,
+		Relationships: []schema.Relationship{
+			{Target: "y", Type: "new-predicate", Strength: 0.9},
+		},
+	}
+
+	delta := computeDelta(before, after)
+
+	if !delta.Changed {
+		t.Fatal("expected delta.Changed=true when relationship body differs")
+	}
+	if len(delta.RelationshipsModified) != 1 {
+		t.Fatalf("expected 1 modified relationship, got %d: %+v",
+			len(delta.RelationshipsModified), delta.RelationshipsModified)
+	}
+	if delta.RelationshipsModified[0].Type != "new-predicate" {
+		t.Errorf("expected modified rel to carry post-merge Type, got %q",
+			delta.RelationshipsModified[0].Type)
+	}
+	if len(delta.RelationshipsAdded) != 0 || len(delta.RelationshipsRemoved) != 0 {
+		t.Errorf("expected no add/remove for same-target change; got add=%v remove=%v",
+			delta.RelationshipsAdded, delta.RelationshipsRemoved)
+	}
+}
+
+// Deep-copy semantics: mutating the returned frontmatter must not affect
+// the input. Addresses Codex review Must-Fix #2.
+func TestEnrichPage_ReturnedPageIsDeepCopy(t *testing.T) {
+	page := &schema.Page{
+		Frontmatter: schema.GraphFrontmatter{
+			Tags:          []string{"original"},
+			SemanticHints: []string{"hint1"},
+			Relationships: []schema.Relationship{{Target: "x", Type: "r", Strength: 1}},
+			Provenance:    schema.Provenance{Sources: []string{"http://a"}},
+			Entities:      []schema.Entity{{Name: "Alice", Aliases: []string{"A"}}},
+		},
+		Body:       "# Title",
+		SourcePath: "/tmp/root/a.md",
+	}
+
+	inputSnapshot := schema.GraphFrontmatter{
+		Tags:          append([]string(nil), page.Frontmatter.Tags...),
+		SemanticHints: append([]string(nil), page.Frontmatter.SemanticHints...),
+		Relationships: append([]schema.Relationship(nil), page.Frontmatter.Relationships...),
+		Provenance:    schema.Provenance{Sources: append([]string(nil), page.Frontmatter.Provenance.Sources...)},
+		Entities: []schema.Entity{{
+			Name:    "Alice",
+			Aliases: append([]string(nil), page.Frontmatter.Entities[0].Aliases...),
+		}},
+	}
+
+	enriched, _ := EnrichPage(page, "/tmp/root/a.md", "/tmp/root", MergeOptions{})
+
+	// Mutate every slice on the returned frontmatter.
+	if len(enriched.Frontmatter.Tags) > 0 {
+		enriched.Frontmatter.Tags[0] = "MUTATED"
+	}
+	if len(enriched.Frontmatter.SemanticHints) > 0 {
+		enriched.Frontmatter.SemanticHints[0] = "MUTATED"
+	}
+	if len(enriched.Frontmatter.Relationships) > 0 {
+		enriched.Frontmatter.Relationships[0].Type = "MUTATED"
+	}
+	if len(enriched.Frontmatter.Provenance.Sources) > 0 {
+		enriched.Frontmatter.Provenance.Sources[0] = "MUTATED"
+	}
+	if len(enriched.Frontmatter.Entities) > 0 && len(enriched.Frontmatter.Entities[0].Aliases) > 0 {
+		enriched.Frontmatter.Entities[0].Aliases[0] = "MUTATED"
+		enriched.Frontmatter.Entities[0].Name = "MUTATED"
+	}
+
+	// Input slice contents must be unchanged.
+	if !reflect.DeepEqual(page.Frontmatter.Tags, inputSnapshot.Tags) {
+		t.Errorf("Tags mutated: got %v, want %v", page.Frontmatter.Tags, inputSnapshot.Tags)
+	}
+	if !reflect.DeepEqual(page.Frontmatter.SemanticHints, inputSnapshot.SemanticHints) {
+		t.Errorf("SemanticHints mutated: got %v, want %v", page.Frontmatter.SemanticHints, inputSnapshot.SemanticHints)
+	}
+	if !reflect.DeepEqual(page.Frontmatter.Relationships, inputSnapshot.Relationships) {
+		t.Errorf("Relationships mutated: got %+v, want %+v", page.Frontmatter.Relationships, inputSnapshot.Relationships)
+	}
+	if !reflect.DeepEqual(page.Frontmatter.Provenance.Sources, inputSnapshot.Provenance.Sources) {
+		t.Errorf("Sources mutated: got %v, want %v", page.Frontmatter.Provenance.Sources, inputSnapshot.Provenance.Sources)
+	}
+	if page.Frontmatter.Entities[0].Name != "Alice" {
+		t.Errorf("Entity.Name mutated: got %q", page.Frontmatter.Entities[0].Name)
+	}
+	if !reflect.DeepEqual(page.Frontmatter.Entities[0].Aliases, inputSnapshot.Entities[0].Aliases) {
+		t.Errorf("Entity.Aliases mutated: got %v, want %v",
+			page.Frontmatter.Entities[0].Aliases, inputSnapshot.Entities[0].Aliases)
 	}
 }
 
@@ -139,11 +277,20 @@ func TestEnrichPageWithModel_PopulatesEntitiesAndSummary(t *testing.T) {
 	if !delta.Changed {
 		t.Fatal("expected delta.Changed=true")
 	}
+	if !delta.SummaryChanged {
+		t.Error("expected SummaryChanged=true")
+	}
+	if len(delta.EntitiesAdded) != 1 || delta.EntitiesAdded[0].Name != "Alice" {
+		t.Errorf("expected EntitiesAdded=[Alice], got %+v", delta.EntitiesAdded)
+	}
+	if len(delta.SemanticHintsAdded) != 1 {
+		t.Errorf("expected SemanticHintsAdded=1, got %v", delta.SemanticHintsAdded)
+	}
+	if len(delta.QuestionsAdded) != 1 {
+		t.Errorf("expected QuestionsAdded=1, got %v", delta.QuestionsAdded)
+	}
 	if enriched.Frontmatter.Summary != "A short summary." {
 		t.Errorf("expected summary populated, got %q", enriched.Frontmatter.Summary)
-	}
-	if len(enriched.Frontmatter.Entities) != 1 {
-		t.Errorf("expected 1 entity, got %d", len(enriched.Frontmatter.Entities))
 	}
 	if enriched.Frontmatter.EntityType != "person" {
 		t.Errorf("expected EntityType=person, got %q", enriched.Frontmatter.EntityType)
@@ -162,10 +309,28 @@ func TestEnrichPageWithModel_NilModelOnlyAppliesSummary(t *testing.T) {
 	if !delta.Changed {
 		t.Fatal("expected delta.Changed=true")
 	}
+	if !delta.SummaryChanged {
+		t.Error("expected SummaryChanged=true")
+	}
 	if enriched.Frontmatter.Summary != "summary only" {
 		t.Errorf("expected summary populated")
 	}
-	if len(enriched.Frontmatter.Entities) != 0 {
+	if len(delta.EntitiesAdded) != 0 {
 		t.Errorf("expected no entities when model is nil")
+	}
+}
+
+// Regression: ensure the delta helpers use strings.ToLower (matching
+// unionStrings) rather than ASCII-only folding.
+func TestDiffStringsCaseInsensitive_MatchesUnionSemantics(t *testing.T) {
+	// "Ångström" vs "ångström" — Unicode differs but should be treated as
+	// equal under strings.ToLower.
+	added, removed := diffStringsCaseInsensitive(
+		[]string{"Ångström"},
+		[]string{"ångström"},
+	)
+	if len(added) != 0 || len(removed) != 0 {
+		t.Errorf("expected case-insensitive match under Unicode; got added=%v removed=%v",
+			added, removed)
 	}
 }

--- a/index/index.go
+++ b/index/index.go
@@ -12,10 +12,11 @@ import (
 // KnowledgeIndex is the core read-only index over all parsed pages. It is
 // built by Load (or Import) and is never mutated by its own methods.
 //
-// Concurrency: all read methods (Get, All, Pages, Entities, Relationships,
-// Tags, ByTag, ForwardRels, ReverseRefs, Export, CompactGraphSummary,
-// Search, Traverse) are safe for concurrent use from multiple goroutines
-// **provided callers do not mutate the values they return**. Get and All
+// Concurrency: the read methods (Get, All, Pages, Entities, Relationships,
+// Tags, ByTag, ForwardRels, ReverseRefs, Export, CompactGraphSummary) and
+// the package-level APIs that take *KnowledgeIndex (Search, Traverse) are
+// safe for concurrent use from multiple goroutines **provided callers do
+// not mutate the values they return**. Get and All
 // hand out *schema.Page pointers into the internal map; ByTag, ForwardRels,
 // and ReverseRefs return the internal slices directly. Mutating any of
 // these would be observable by other readers. Treat everything the index

--- a/index/index.go
+++ b/index/index.go
@@ -10,17 +10,22 @@ import (
 )
 
 // KnowledgeIndex is the core read-only index over all parsed pages. It is
-// built by Load (or Import) and is immutable thereafter — no exported or
-// internal mutation methods exist.
+// built by Load (or Import) and is never mutated by its own methods.
 //
 // Concurrency: all read methods (Get, All, Pages, Entities, Relationships,
 // Tags, ByTag, ForwardRels, ReverseRefs, Export, CompactGraphSummary,
 // Search, Traverse) are safe for concurrent use from multiple goroutines
-// without external synchronization. The typical pattern for long-running
-// hosts (daemons, MCP servers) is to hold a *KnowledgeIndex behind an
-// atomic.Pointer or a sync.RWMutex, rebuild a new index on the side via
-// Load/Reload, then atomically swap the pointer. In-flight readers on the
-// old index remain valid and cannot observe partial state.
+// **provided callers do not mutate the values they return**. Get and All
+// hand out *schema.Page pointers into the internal map; ByTag, ForwardRels,
+// and ReverseRefs return the internal slices directly. Mutating any of
+// these would be observable by other readers. Treat everything the index
+// returns as read-only; clone first if you need to modify.
+//
+// The typical pattern for long-running hosts (daemons, MCP servers) is to
+// hold a *KnowledgeIndex behind an atomic.Pointer or sync.RWMutex, rebuild
+// a new index on the side via Load/Reload, then atomically swap the
+// pointer. In-flight readers on the old index remain valid and cannot
+// observe partial state.
 type KnowledgeIndex struct {
 	byID       map[string]*schema.Page
 	byTag      map[string][]*schema.Page

--- a/index/index.go
+++ b/index/index.go
@@ -10,8 +10,17 @@ import (
 )
 
 // KnowledgeIndex is the core read-only index over all parsed pages. It is
-// built by Load and is safe for concurrent reads after construction (no
-// internal mutation methods are exposed).
+// built by Load (or Import) and is immutable thereafter — no exported or
+// internal mutation methods exist.
+//
+// Concurrency: all read methods (Get, All, Pages, Entities, Relationships,
+// Tags, ByTag, ForwardRels, ReverseRefs, Export, CompactGraphSummary,
+// Search, Traverse) are safe for concurrent use from multiple goroutines
+// without external synchronization. The typical pattern for long-running
+// hosts (daemons, MCP servers) is to hold a *KnowledgeIndex behind an
+// atomic.Pointer or a sync.RWMutex, rebuild a new index on the side via
+// Load/Reload, then atomically swap the pointer. In-flight readers on the
+// old index remain valid and cannot observe partial state.
 type KnowledgeIndex struct {
 	byID       map[string]*schema.Page
 	byTag      map[string][]*schema.Page

--- a/index/load.go
+++ b/index/load.go
@@ -308,6 +308,24 @@ func Load(ctx context.Context, root string, opts ...LoadOption) (*LoadResult, er
 	}, nil
 }
 
+// Reload rebuilds the knowledge index from root using the given options. It
+// is a semantic alias for Load intended for long-running hosts (daemons, MCP
+// servers, TUI) that need to refresh the index after the underlying markdown
+// files change.
+//
+// Load is already idempotent — calling it twice with the same root produces
+// equivalent indexes — but Reload exists as a named entry point so callers
+// can express intent clearly and so future implementations can add
+// incremental or cache-aware refresh behavior without changing the signature.
+//
+// Concurrency: Reload returns a brand-new *KnowledgeIndex; it never mutates
+// any previously returned index. Callers holding a reference to the old
+// index may continue to read from it safely. See KnowledgeIndex for the
+// recommended swap pattern.
+func Reload(ctx context.Context, root string, opts ...LoadOption) (*LoadResult, error) {
+	return Load(ctx, root, opts...)
+}
+
 // autoEnrichFile reads a file without frontmatter, enriches it with Tier 1
 // deterministic extraction, writes the enriched frontmatter back to disk,
 // and returns the enriched Page.

--- a/index/reload_test.go
+++ b/index/reload_test.go
@@ -1,0 +1,75 @@
+package index
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReload_IsEquivalentToLoad verifies that Reload produces the same index
+// as Load given the same inputs, and that calling it twice on the same root
+// yields equivalent indexes.
+func TestReload_IsEquivalentToLoad(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed with two simple pages.
+	writeTestPage(t, dir, "a.md", "# Page A\n\nContent.\n")
+	writeTestPage(t, dir, "b.md", "# Page B\n\n[[a]]\n")
+
+	ctx := context.Background()
+
+	loadRes, err := Load(ctx, dir, WithAutoEnrich(true))
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	reloadRes, err := Reload(ctx, dir, WithAutoEnrich(true))
+	if err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+
+	if loadRes.Index.Pages() != reloadRes.Index.Pages() {
+		t.Errorf("page counts differ: Load=%d Reload=%d",
+			loadRes.Index.Pages(), reloadRes.Index.Pages())
+	}
+	if loadRes.Index.Relationships() != reloadRes.Index.Relationships() {
+		t.Errorf("relationship counts differ: Load=%d Reload=%d",
+			loadRes.Index.Relationships(), reloadRes.Index.Relationships())
+	}
+}
+
+// TestReload_ReturnsFreshPointer confirms Reload does not return the same
+// *KnowledgeIndex pointer as a prior Load — callers must be able to hold
+// the old pointer while swapping in the new one.
+func TestReload_ReturnsFreshPointer(t *testing.T) {
+	dir := t.TempDir()
+	writeTestPage(t, dir, "a.md", "# A\n")
+
+	ctx := context.Background()
+	first, err := Load(ctx, dir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	second, err := Reload(ctx, dir)
+	if err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+
+	if first.Index == second.Index {
+		t.Error("Reload returned same *KnowledgeIndex pointer; should be a fresh index")
+	}
+
+	// Old index must still be queryable after Reload.
+	if _, ok := first.Index.Get("a"); !ok {
+		t.Error("old index became invalid after Reload")
+	}
+}
+
+func writeTestPage(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

Phase B of the [MarkedUp + Plexium integration plan](https://github.com/KHAEntertainment/markedup/pull/previous). Four **additive** changes that smooth the path for MarkedUp to be consumed as a Go dependency by Plexium (and other hosts). **No existing APIs change, no breaking changes.**

## What's in this PR

### 1. `embed.NewFromProvider(endpoint, model, apiKey, dims)`
Convenience constructor for external callers to build an OpenAI-compatible embedder from flat provider settings. Plexium's `assistiveAgent` provider block maps onto this directly — no need to construct an `embed.Config` just to inherit credentials.

### 2. `KnowledgeIndex` thread-safety documentation
Strengthened doc comment. Explicitly states: built once by `Load`/`Import`, immutable thereafter, all read methods safe for concurrent use. Documents the `atomic.Pointer` swap pattern for hosts (daemons, MCP servers) that refresh the index while serving reads.

### 3. `index.Reload(ctx, root, ...opts)`
Semantic alias for `Load`. `Load` is already idempotent; `Reload` gives callers an explicit entry point for refresh intent and keeps room for future incremental/cache-aware implementations without signature changes.

### 4. `enrich.EnrichPage` + `EnrichmentDelta` (the main deliverable)
Lets external callers run Tier 1 (`EnrichPage`) or Tier 2 (`EnrichPageWithModel`) enrichment against an in-memory `*schema.Page` and get back `(enrichedPage, delta)` **without writing frontmatter back to disk**.

`EnrichmentDelta` reports which scalar fields changed and what new items were added to tag/relationship/source collections. This enables Plexium's **manifest-only integration mode** (the chosen default) where graph metadata lands in `.plexium/manifest.json` instead of mutating `.wiki/` files.

- Input pages are never mutated
- Returned pages are copies with merged frontmatter preserved alongside original `Body` and `SourcePath`

## Why now

Plexium's plugin architecture foundation landed in [Clarit-AI/Plexium#21](https://github.com/Clarit-AI/Plexium/pull/21). Phase C (the actual MarkedUp plugin implementation in Plexium) needs these API surfaces to cleanly implement the manifest-only enrichment mode. Phase B is small and purely additive so it can land alongside the ongoing UX refinements on `main`.

## Tests

| File | Cases |
|------|-------|
| `embed/openai_compat_from_provider_test.go` | 3 — builds equivalent embedder, empty APIKey OK, trims trailing slash |
| `index/reload_test.go` | 2 — Load-equivalence, fresh-pointer (old pointer stays valid) |
| `enrich/enrich_page_test.go` | 6 — empty frontmatter, already-complete, no mutation, body/path preserved, Tier 2 with model+summary, nil-model |

All three modified packages pass under `-race`.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./embed/ ./index/ ./enrich/` passes
- [x] `go test ./...` passes except `TestKeysStep_NoPrefillNote_WhenNoPrefill` in `internal/tui/setup` — **verified failing on clean `origin/main`** (reads real system keychain, pre-existing issue unrelated to this PR)
- [x] gofmt clean
- [ ] Code review

## Coordinates with

- Parallel UX refinements on `feat/nx-3-config-nuextract` — no file overlap
- Unblocks Phase C (MarkedUp plugin implementation in Plexium, separate repo)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New constructor to create OpenAI-compatible embedders from flat parameters
  * Page enrichment: deterministic Tier 1 extraction, optional Tier 2 model-driven enrichment, and detailed before/after enrichment deltas with deep-copied results
  * Ability to reload knowledge indexes

* **Documentation**
  * Clarified index immutability and safe concurrent access patterns

* **Tests**
  * Added unit tests for the new embedder constructor, enrichment behavior/deltas, deep-copy guarantees, and reload semantics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->