### PR TITLE
feat: [NX-5] wizard surfaces NuExtract as structured extractor choice

### DIFF
--- a/internal/tui/setup/steps.go
+++ b/internal/tui/setup/steps.go
@@ -670,7 +670,8 @@ func newKeysStep(
 	needEmbed bool, embedLabel, embedEndpoint string,
 	needLLM bool, llmLabel, llmEndpoint string,
 	needRerank bool, rerankLabel, rerankEndpoint string,
-	needTriplex bool, triplexLabel, triplexEndpoint string,
+	needExtractor bool, extractorLabel, extractorEndpoint string,
+	extractorService string, // "triplex" or "nuextract" — keyring + collectedKeys service name
 ) keysStep {
 	type svcInfo struct {
 		service  string
@@ -688,8 +689,12 @@ func newKeysStep(
 	if needRerank {
 		candidates = append(candidates, svcInfo{"rerank", rerankLabel, rerankEndpoint})
 	}
-	if needTriplex {
-		candidates = append(candidates, svcInfo{"triplex", triplexLabel, triplexEndpoint})
+	if needExtractor {
+		svc := extractorService
+		if svc == "" {
+			svc = "triplex"
+		}
+		candidates = append(candidates, svcInfo{svc, extractorLabel, extractorEndpoint})
 	}
 
 	// Deduplicate by endpoint. The first service to claim an endpoint becomes

--- a/internal/tui/setup/steps.go
+++ b/internal/tui/setup/steps.go
@@ -457,7 +457,7 @@ func (p providerStep) View(width int) string {
 const triplexModelName = "Phi-3-mini-128k-instruct/triplex"
 
 // triplexDescription explains what Triplex does and why it is optional.
-const triplexDescription = "Triplex extracts entities and relationships from your notes to build a\nrich knowledge graph. It is optional but highly recommended — without it,\nmarkedup uses your general LLM for extraction (lower quality).\n\nTriplex is a Phi-3-mini-128k-instruct fine-tune and runs locally via Ollama\nor a compatible OpenAI-compatible endpoint. The default model name is\npre-filled but can be edited if your host uses a different identifier."
+const triplexDescription = "Configure a structured extractor to build a knowledge graph from your notes.\nOptional but recommended — without it, markedup uses your general LLM (lower quality).\n\nSupported models:\n  • Triplex (default) — Phi-3-mini-128k-instruct fine-tune, emits KG triples\n  • NuExtract-2.0 (8B / 2B) — template-based extraction, runs on GGUF/vLLM/HF\n\nEnter any OpenAI-compatible endpoint. To use NuExtract, set the model name to\n\"numind/NuExtract-2.0-8B\" or \"numind/NuExtract-2.0-2B\" — the wizard auto-detects\nthe format from the model id and writes the correct config section."
 
 // triplexStep is the wizard sub-model for configuring the Triplex extraction model.
 // The model name defaults to triplexModelName but can be edited by the user.
@@ -609,7 +609,7 @@ func (t triplexStep) Update(msg tea.Msg) (triplexStep, tea.Cmd) {
 func (t triplexStep) View(width int) string {
 	var b strings.Builder
 
-	b.WriteString(headerStyle.Width(width).Render("Triple Extraction (Triplex)"))
+	b.WriteString(headerStyle.Width(width).Render("Structured Extractor"))
 	b.WriteString("\n\n")
 	b.WriteString(triplexDescription)
 	b.WriteString("\n\n")
@@ -938,13 +938,26 @@ func (c confirmStep) View(width int) string {
 		b.WriteString("\n")
 	}
 
-	// Triplex.
-	b.WriteString(labelStyle.Render("Triplex:"))
-	b.WriteString("\n")
-	if c.cfg.Triplex.Endpoint != "" {
+	// Extractor — show Triplex or NuExtract based on which is populated.
+	switch {
+	case c.cfg.NuExtract.Endpoint != "":
+		b.WriteString(labelStyle.Render("Extractor:"))
+		b.WriteString("\n")
+		b.WriteString(fmt.Sprintf("  Format:   NuExtract-2.0\n"))
+		b.WriteString(fmt.Sprintf("  URL:      %s\n", c.cfg.NuExtract.Endpoint))
+		b.WriteString(fmt.Sprintf("  Model:    %s\n", c.cfg.NuExtract.Model))
+		if c.cfg.NuExtract.Mode != "" {
+			b.WriteString(fmt.Sprintf("  Mode:     %s\n", c.cfg.NuExtract.Mode))
+		}
+	case c.cfg.Triplex.Endpoint != "":
+		b.WriteString(labelStyle.Render("Extractor:"))
+		b.WriteString("\n")
+		b.WriteString(fmt.Sprintf("  Format:   Triplex\n"))
 		b.WriteString(fmt.Sprintf("  URL:      %s\n", c.cfg.Triplex.Endpoint))
 		b.WriteString(fmt.Sprintf("  Model:    %s\n", c.cfg.Triplex.Model))
-	} else {
+	default:
+		b.WriteString(labelStyle.Render("Extractor:"))
+		b.WriteString("\n")
 		b.WriteString(mutedStyle.Render("  not configured (using LLM for extraction)"))
 		b.WriteString("\n")
 	}

--- a/internal/tui/setup/wizard.go
+++ b/internal/tui/setup/wizard.go
@@ -300,14 +300,24 @@ func (m WizardModel) updateTriplex(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if m.triplex.done {
 		if !m.triplex.skip {
-			// Configured: store endpoint + model. Format is auto-set to "triplex"
-			// by the enrich pipeline based on the model name (FormatTriplex).
-			m.config.Triplex = m.triplex.selected
+			// Route config based on the model id the user entered.
+			// NuExtract-2.0 family → config.NuExtract + Format="nuextract".
+			// Anything else → config.Triplex (backward compat).
+			if config.IsNuExtractModel(m.triplex.selected.Model) {
+				m.config.NuExtract = config.NuExtractConfig{
+					ServiceConfig: m.triplex.selected,
+					// Transport and Mode left empty → enrich defaults (parallel, auto transport).
+				}
+				m.config.Format = "nuextract"
+				m.triplexProviderLabel = "NuExtract-2.0"
+			} else {
+				m.config.Triplex = m.triplex.selected
+				m.triplexProviderLabel = "Triplex"
+			}
 			m.needTriplexKey = m.triplex.needsKey
 			m.triplexEndpoint = m.triplex.selected.Endpoint
-			m.triplexProviderLabel = "Triplex"
 		}
-		// When skipped: config.Triplex stays zero value, needTriplexKey = false.
+		// When skipped: config.Triplex/NuExtract stay zero, needTriplexKey = false.
 
 		m.stepHistory = append(m.stepHistory, m.step)
 

--- a/internal/tui/setup/wizard.go
+++ b/internal/tui/setup/wizard.go
@@ -68,6 +68,9 @@ type WizardModel struct {
 	llmProviderLabel    string
 	rerankProviderLabel string
 	triplexProviderLabel string
+	// extractorService is the keyring service name for the selected extractor:
+	// "triplex" or "nuextract". Empty when extractor is skipped.
+	extractorService string
 
 	// Track selected provider endpoints for key deduplication.
 	embedEndpoint   string
@@ -299,6 +302,13 @@ func (m WizardModel) updateTriplex(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.triplex, cmd = m.triplex.Update(msg)
 
 	if m.triplex.done {
+		// Always clear BOTH extractor blocks first so switching between
+		// extractor types (or re-running the wizard over an existing config)
+		// cannot leave stale state. Explicitly reset Format.
+		m.config.Triplex = config.ServiceConfig{}
+		m.config.NuExtract = config.NuExtractConfig{}
+		m.config.Format = ""
+
 		if !m.triplex.skip {
 			// Route config based on the model id the user entered.
 			// NuExtract-2.0 family → config.NuExtract + Format="nuextract".
@@ -310,14 +320,21 @@ func (m WizardModel) updateTriplex(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.config.Format = "nuextract"
 				m.triplexProviderLabel = "NuExtract-2.0"
+				m.extractorService = "nuextract"
 			} else {
 				m.config.Triplex = m.triplex.selected
 				m.triplexProviderLabel = "Triplex"
+				m.extractorService = "triplex"
 			}
 			m.needTriplexKey = m.triplex.needsKey
 			m.triplexEndpoint = m.triplex.selected.Endpoint
+		} else {
+			// Explicit skip: ensure key/endpoint state is also cleared.
+			m.needTriplexKey = false
+			m.triplexEndpoint = ""
+			m.triplexProviderLabel = ""
+			m.extractorService = ""
 		}
-		// When skipped: config.Triplex/NuExtract stay zero, needTriplexKey = false.
 
 		m.stepHistory = append(m.stepHistory, m.step)
 
@@ -329,11 +346,16 @@ func (m WizardModel) updateTriplex(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		extractorSvc := m.extractorService
+		if extractorSvc == "" {
+			extractorSvc = "triplex" // legacy default if no extractor selected (no-op since needTriplexKey=false)
+		}
 		m.keys = newKeysStep(
 			m.needEmbedKey, m.embedProviderLabel, m.embedEndpoint,
 			m.needLLMKey, m.llmProviderLabel, m.llmEndpoint,
 			m.needRerankKey, m.rerankProviderLabel, m.rerankEndpoint,
 			m.needTriplexKey, m.triplexProviderLabel, m.triplexEndpoint,
+			extractorSvc,
 		)
 		m.stepHistory = append(m.stepHistory, m.step)
 		m.step = 5
@@ -391,6 +413,9 @@ func (m WizardModel) updateConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				if k, ok := m.keys.collectedKeys["triplex"]; ok {
 					m.config.Triplex.APIKey = k
+				}
+				if k, ok := m.keys.collectedKeys["nuextract"]; ok {
+					m.config.NuExtract.APIKey = k
 				}
 
 				m.confirm.saved = true

--- a/internal/tui/setup/wizard_test.go
+++ b/internal/tui/setup/wizard_test.go
@@ -194,13 +194,13 @@ func TestProviderStep_RerankFormat(t *testing.T) {
 }
 
 func TestKeysStep_NoKeys(t *testing.T) {
-	ks := newKeysStep(false, "", "", false, "", "", false, "", "", false, "", "")
+	ks := newKeysStep(false, "", "", false, "", "", false, "", "", false, "", "", "")
 	ks, _ = ks.Update(nil)
 	assert.True(t, ks.done)
 }
 
 func TestKeysStep_WithKeys(t *testing.T) {
-	ks := newKeysStep(true, "Ollama", "http://localhost:11434", false, "", "", false, "", "", false, "", "")
+	ks := newKeysStep(true, "Ollama", "http://localhost:11434", false, "", "", false, "", "", false, "", "", "")
 	assert.Len(t, ks.entries, 1)
 	assert.Equal(t, "embed", ks.entries[0].service)
 }
@@ -306,7 +306,7 @@ func TestWizardModel_View_AllSteps(t *testing.T) {
 		case 4:
 			m.triplex = newTriplexStep(nil)
 		case 5:
-			m.keys = newKeysStep(true, "Ollama", "http://localhost:11434", false, "", "", false, "", "", false, "", "")
+			m.keys = newKeysStep(true, "Ollama", "http://localhost:11434", false, "", "", false, "", "", false, "", "", "")
 		case 6:
 			m.confirm = newConfirmStep(m.config, "", nil)
 		}
@@ -533,7 +533,7 @@ func TestTriplexStep_SInEndpointInput_PassesThrough(t *testing.T) {
 
 func TestKeysStep_PrefilledFlag(t *testing.T) {
 	// Create a keysStep and manually simulate pre-fill.
-	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "")
+	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "", "")
 	assert.Len(t, ks.entries, 1)
 
 	// Manually set prefilled (since we can't use real keyring in tests).
@@ -548,7 +548,7 @@ func TestKeysStep_PrefilledFlag(t *testing.T) {
 }
 
 func TestKeysStep_PrefilledView(t *testing.T) {
-	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "")
+	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "", "")
 	ks.entries[0].prefilled = true
 
 	view := ks.View(80)
@@ -557,7 +557,7 @@ func TestKeysStep_PrefilledView(t *testing.T) {
 }
 
 func TestKeysStep_PrefilledOverwrite(t *testing.T) {
-	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "")
+	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "", "")
 	ks.entries[0].prefilled = true
 	ks.inputs[0].SetValue("sk-old-key")
 	ks.collectedKeys["embed"] = "sk-old-key"
@@ -572,7 +572,7 @@ func TestKeysStep_PrefilledOverwrite(t *testing.T) {
 }
 
 func TestKeysStep_NoPrefillNote_WhenNoPrefill(t *testing.T) {
-	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "")
+	ks := newKeysStep(true, "OpenRouter", "https://openrouter.ai/api", false, "", "", false, "", "", false, "", "", "")
 
 	view := ks.View(80)
 	assert.NotContains(t, view, "Existing API keys found", "should not show pre-fill note when no keys pre-filled")
@@ -630,4 +630,89 @@ func TestWizard_NuExtractModel_WritesToNuExtractConfig(t *testing.T) {
 	assert.Equal(t, "numind/NuExtract-2.0-8B", final.config.NuExtract.Model)
 	assert.Equal(t, "nuextract", final.config.Format)
 	assert.Empty(t, final.config.Triplex.Endpoint, "NuExtract model should not populate Triplex config")
+}
+
+func TestWizard_SwitchExtractor_NuExtractThenTriplex_ClearsStaleNuExtract(t *testing.T) {
+	m := NewWizardModel()
+	// Simulate prior NuExtract run leaving state.
+	m.config.NuExtract = config.NuExtractConfig{
+		ServiceConfig: config.ServiceConfig{Endpoint: "https://old.nx.space", Model: "numind/NuExtract-2.0-8B"},
+	}
+	m.config.Format = "nuextract"
+
+	// User re-runs wizard and picks Triplex.
+	m.triplex = triplexStep{
+		selected: config.ServiceConfig{Endpoint: "http://localhost:11434", Model: "Phi-3-mini-128k-instruct/triplex"},
+		done:     true,
+	}
+	m.step = 4
+	updated, _ := m.updateTriplex(tea.KeyMsg{})
+	final := updated.(WizardModel)
+
+	assert.Equal(t, "http://localhost:11434", final.config.Triplex.Endpoint)
+	assert.Empty(t, final.config.NuExtract.Endpoint, "stale NuExtract endpoint should be cleared")
+	assert.Empty(t, final.config.NuExtract.Model, "stale NuExtract model should be cleared")
+	assert.Empty(t, final.config.Format, "Format should reset when switching to Triplex")
+	assert.Equal(t, "triplex", final.extractorService)
+}
+
+func TestWizard_SwitchExtractor_TriplexThenNuExtract_ClearsStaleTriplex(t *testing.T) {
+	m := NewWizardModel()
+	m.config.Triplex = config.ServiceConfig{Endpoint: "http://old.triplex", Model: "phi3"}
+
+	m.triplex = triplexStep{
+		selected: config.ServiceConfig{Endpoint: "https://hf.space", Model: "numind/NuExtract-2.0-8B"},
+		done:     true,
+	}
+	m.step = 4
+	updated, _ := m.updateTriplex(tea.KeyMsg{})
+	final := updated.(WizardModel)
+
+	assert.Empty(t, final.config.Triplex.Endpoint, "stale Triplex endpoint should be cleared")
+	assert.Equal(t, "https://hf.space", final.config.NuExtract.Endpoint)
+	assert.Equal(t, "nuextract", final.config.Format)
+	assert.Equal(t, "nuextract", final.extractorService)
+}
+
+func TestWizard_SkipExtractor_ClearsBoth(t *testing.T) {
+	m := NewWizardModel()
+	m.config.Triplex = config.ServiceConfig{Endpoint: "http://old.triplex"}
+	m.config.NuExtract = config.NuExtractConfig{
+		ServiceConfig: config.ServiceConfig{Endpoint: "http://old.nuextract"},
+	}
+	m.config.Format = "triplex"
+
+	m.triplex = triplexStep{skip: true, done: true}
+	m.step = 4
+	updated, _ := m.updateTriplex(tea.KeyMsg{})
+	final := updated.(WizardModel)
+
+	assert.Empty(t, final.config.Triplex.Endpoint, "skip should clear Triplex")
+	assert.Empty(t, final.config.NuExtract.Endpoint, "skip should clear NuExtract")
+	assert.Empty(t, final.config.Format, "skip should reset Format")
+	assert.Empty(t, final.extractorService)
+}
+
+func TestNewKeysStep_NuExtractService(t *testing.T) {
+	ks := newKeysStep(
+		false, "", "",
+		false, "", "",
+		false, "", "",
+		true, "NuExtract-2.0", "https://hf.space",
+		"nuextract",
+	)
+	require.Len(t, ks.entries, 1)
+	assert.Equal(t, "nuextract", ks.entries[0].service, "extractor service should be nuextract when passed")
+}
+
+func TestNewKeysStep_TriplexServiceDefault(t *testing.T) {
+	ks := newKeysStep(
+		false, "", "",
+		false, "", "",
+		false, "", "",
+		true, "Triplex", "http://localhost:11434",
+		"triplex",
+	)
+	require.Len(t, ks.entries, 1)
+	assert.Equal(t, "triplex", ks.entries[0].service)
 }

--- a/internal/tui/setup/wizard_test.go
+++ b/internal/tui/setup/wizard_test.go
@@ -413,7 +413,8 @@ func TestTriplexStep_CursorNavigation(t *testing.T) {
 func TestTriplexStep_View(t *testing.T) {
 	ts := newTriplexStep(nil)
 	view := ts.View(80)
-	assert.Contains(t, view, "Triple Extraction (Triplex)")
+	assert.Contains(t, view, "Structured Extractor")
+	assert.Contains(t, view, "NuExtract-2.0")
 	assert.Contains(t, view, "Model:")
 	assert.Contains(t, view, triplexModelName, "editable model input should show default")
 	assert.Contains(t, view, "Skip")
@@ -592,4 +593,41 @@ func TestProviderStep_CursorBounds(t *testing.T) {
 		ps, _ = ps.Update(tea.KeyMsg{Type: tea.KeyDown})
 	}
 	assert.Equal(t, len(ps.choices)-1, ps.cursor)
+}
+
+func TestWizard_TriplexModel_WritesToTriplexConfig(t *testing.T) {
+	m := NewWizardModel()
+	m.triplex = triplexStep{
+		selected: config.ServiceConfig{
+			Endpoint: "http://localhost:11434",
+			Model:    "Phi-3-mini-128k-instruct/triplex",
+		},
+		done: true,
+	}
+	m.step = 4
+	updated, _ := m.updateTriplex(tea.KeyMsg{})
+	final, ok := updated.(WizardModel)
+	require.True(t, ok)
+	assert.Equal(t, "http://localhost:11434", final.config.Triplex.Endpoint)
+	assert.Empty(t, final.config.NuExtract.Endpoint, "Triplex model should not populate NuExtract config")
+	assert.Empty(t, final.config.Format, "Triplex model should not set Format explicitly")
+}
+
+func TestWizard_NuExtractModel_WritesToNuExtractConfig(t *testing.T) {
+	m := NewWizardModel()
+	m.triplex = triplexStep{
+		selected: config.ServiceConfig{
+			Endpoint: "https://xyz.hf.space",
+			Model:    "numind/NuExtract-2.0-8B",
+		},
+		done: true,
+	}
+	m.step = 4
+	updated, _ := m.updateTriplex(tea.KeyMsg{})
+	final, ok := updated.(WizardModel)
+	require.True(t, ok)
+	assert.Equal(t, "https://xyz.hf.space", final.config.NuExtract.Endpoint)
+	assert.Equal(t, "numind/NuExtract-2.0-8B", final.config.NuExtract.Model)
+	assert.Equal(t, "nuextract", final.config.Format)
+	assert.Empty(t, final.config.Triplex.Endpoint, "NuExtract model should not populate Triplex config")
 }


### PR DESCRIPTION
## Summary
- Wizard's extractor step now supports both Triplex and NuExtract-2.0
- Model id auto-detection via \`config.IsNuExtractModel\` → routes config to \`cfg.NuExtract\` + \`cfg.Format=\"nuextract\"\` or \`cfg.Triplex\` (backward compatible default)
- Header renamed \"Triple Extraction (Triplex)\" → \"Structured Extractor\"
- Description mentions both options and shows the expected model ids
- Confirm summary displays the active extractor (Triplex or NuExtract-2.0)

## Why
Minimum-viable user surface for the NuExtract path landed in #100. Users can now reach the feature through the TUI wizard without hand-editing YAML.

## Test plan
- [x] \`go test ./internal/tui/setup/... -run 'TestWizard_|TestTriplexStep_View'\` — new tests pass (routing to Triplex vs NuExtract, updated view assertions)
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — only failure is a pre-existing \`TestKeysStep_NoPrefillNote_WhenNoPrefill\` keychain-pollution issue unrelated to this PR
- [ ] Live validation via \`markedup tui\` after merge alongside #101

## Known limitation
\`NuExtract.Mode\` and \`NuExtract.Transport\` are left empty; enrich auto-picks \`parallel\` + autodetect-from-URL defaults. A follow-up PR can add explicit mode toggles in the wizard if IRL testing shows users want the choice.

Follows #98/#99/#100/#101. Completes Wave NX-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for NuExtract-2.0 as an alternative extraction method alongside Triplex
  * Redesigned extraction configuration UI to clearly present available extractor options with setup guidance

* **Bug Fixes**
  * Corrected configuration state handling when switching between different extractors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->