### PR TITLE
docs: add work-in-progress notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A knowledge graph built from plain markdown files. No database required.
 
 ![Go 1.22+](https://img.shields.io/badge/Go-1.22%2B-blue)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue)
+![Status: Work in Progress](https://img.shields.io/badge/status-work%20in%20progress-orange)
+
+> ⚠️ **Work in progress.** markedup is under active development — the API surface, CLI flags, and on-disk schema may still change between commits. The library is usable today (Clarit-AI's Plexium consumes it as a dependency), but a tagged stable release is still pending. Check back soon.
 
 ## The Problem
 


### PR DESCRIPTION
Small README addition ahead of the Clarit-AI transfer and wider visibility. Adds a badge and a short callout under the title explaining that markedup is under active development, that the library is usable today (Plexium consumes it), and that a tagged stable release is pending. Both cheap to remove when we cut the first stable tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added work-in-progress status indicator.
  * Added prominent notice that the project is under active development with potential changes between releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->