### PR TITLE
fix: [#108] dedupe relationships and entities blocks in enriched frontmatter

### DIFF
--- a/enrich/merge.go
+++ b/enrich/merge.go
@@ -32,13 +32,13 @@ func MergeFrontmatter(existing schema.GraphFrontmatter, extracted ExtractedField
 			result.Confidence = extracted.Confidence
 		}
 		if len(extracted.Tags) > 0 {
-			result.Tags = extracted.Tags
+			result.Tags = dedupeStringsCaseInsensitive(extracted.Tags)
 		}
 		if len(extracted.Relationships) > 0 {
-			result.Relationships = extracted.Relationships
+			result.Relationships = dedupeRelationships(extracted.Relationships)
 		}
 		if len(extracted.Provenance.Sources) > 0 {
-			result.Provenance.Sources = extracted.Provenance.Sources
+			result.Provenance.Sources = dedupeStringsCaseInsensitive(extracted.Provenance.Sources)
 		}
 		if extracted.Provenance.CreatedBy != "" {
 			result.Provenance.CreatedBy = extracted.Provenance.CreatedBy
@@ -118,22 +118,96 @@ func unionStrings(a, b []string) []string {
 	return result
 }
 
-// unionRelationships appends relationships from b whose Target is not in a.
+// unionRelationships appends relationships from b whose (Target, Type) key is
+// not already present in a. Dedup is done on the composite (Target, Type) key
+// so that two predicates between the same target pair are preserved, but an
+// exact repeat is collapsed. Input a is also deduped against itself so a
+// stale input with same-key duplicates gets cleaned up.
 func unionRelationships(a, b []schema.Relationship) []schema.Relationship {
 	if len(a) == 0 && len(b) == 0 {
 		return nil
 	}
-	seen := make(map[string]bool)
-	result := make([]schema.Relationship, len(a))
-	copy(result, a)
+	seen := make(map[relKey]bool, len(a)+len(b))
+	result := make([]schema.Relationship, 0, len(a)+len(b))
 	for _, r := range a {
-		seen[r.Target] = true
+		k := relKey{Target: r.Target, Type: r.Type}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		result = append(result, r)
 	}
 	for _, r := range b {
-		if !seen[r.Target] {
-			seen[r.Target] = true
-			result = append(result, r)
+		k := relKey{Target: r.Target, Type: r.Type}
+		if seen[k] {
+			continue
 		}
+		seen[k] = true
+		result = append(result, r)
 	}
 	return result
+}
+
+// relKey is the composite identity key used to dedupe relationships.
+type relKey struct {
+	Target string
+	Type   string
+}
+
+// dedupeRelationships removes within-list duplicates keyed by (Target, Type),
+// preserving first-seen order. Used in force-mode merges where the incoming
+// slice replaces the existing one wholesale.
+func dedupeRelationships(in []schema.Relationship) []schema.Relationship {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[relKey]bool, len(in))
+	out := make([]schema.Relationship, 0, len(in))
+	for _, r := range in {
+		k := relKey{Target: r.Target, Type: r.Type}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, r)
+	}
+	return out
+}
+
+// dedupeEntities removes within-list duplicates keyed by lowercased Name,
+// preserving first-seen order. Used in force-mode merges.
+func dedupeEntities(in []schema.Entity) []schema.Entity {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(in))
+	out := make([]schema.Entity, 0, len(in))
+	for _, e := range in {
+		k := strings.ToLower(e.Name)
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, e)
+	}
+	return out
+}
+
+// dedupeStringsCaseInsensitive removes case-insensitive duplicates from in,
+// preserving first-seen order and the original casing of the first occurrence.
+func dedupeStringsCaseInsensitive(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		k := strings.ToLower(s)
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, s)
+	}
+	return out
 }

--- a/enrich/merge.go
+++ b/enrich/merge.go
@@ -37,6 +37,14 @@ func MergeFrontmatter(existing schema.GraphFrontmatter, extracted ExtractedField
 		if len(extracted.Relationships) > 0 {
 			result.Relationships = dedupeRelationships(extracted.Relationships)
 		}
+		// ExtractedFields carries no Entities of its own — Tier 1 is relationship-
+		// and tag-focused — but existing.Entities flows through the force branch
+		// unchanged. Dedupe it so a previously-written stale duplicate on the
+		// entities list gets cleaned up on the next force enrich. Mirrors the
+		// relationships dedup above (issue #108 AC #4).
+		if len(result.Entities) > 0 {
+			result.Entities = dedupeEntities(result.Entities)
+		}
 		if len(extracted.Provenance.Sources) > 0 {
 			result.Provenance.Sources = dedupeStringsCaseInsensitive(extracted.Provenance.Sources)
 		}
@@ -61,6 +69,12 @@ func MergeFrontmatter(existing schema.GraphFrontmatter, extracted ExtractedField
 	}
 	if result.Provenance.CreatedBy == "" {
 		result.Provenance.CreatedBy = extracted.Provenance.CreatedBy
+	}
+
+	// Dedupe entities flowing through from existing. ExtractedFields carries
+	// no Entities, but existing may contain stale duplicates (issue #108 AC #4).
+	if len(result.Entities) > 0 {
+		result.Entities = dedupeEntities(result.Entities)
 	}
 
 	// Union tags (case-insensitive dedup).

--- a/enrich/merge_test.go
+++ b/enrich/merge_test.go
@@ -187,18 +187,25 @@ func TestMergeFrontmatter_RelationshipDedup(t *testing.T) {
 	}
 	extracted := ExtractedFields{
 		Relationships: []schema.Relationship{
-			{Target: "target-a", Type: "related-to", Strength: 0.5}, // same target, different type
+			// Same target as existing but a different type: kept as a
+			// distinct edge. Dedup key is (Target, Type), not Target alone.
+			{Target: "target-a", Type: "related-to", Strength: 0.5},
+			// Exact duplicate of the existing edge: collapsed.
+			{Target: "target-a", Type: "implements", Strength: 0.8},
 			{Target: "target-b", Type: "related-to", Strength: 0.5},
 		},
 	}
 
 	result := MergeFrontmatter(existing, extracted, MergeOptions{})
 
-	// target-a should not be duplicated
-	assert.Len(t, result.Relationships, 2)
+	// (target-a, implements) dedupes against existing; (target-a, related-to)
+	// is a new edge; (target-b, related-to) is new.
+	assert.Len(t, result.Relationships, 3)
 	assert.Equal(t, "target-a", result.Relationships[0].Target)
 	assert.Equal(t, "implements", result.Relationships[0].Type) // original preserved
-	assert.Equal(t, "target-b", result.Relationships[1].Target)
+	assert.Equal(t, "target-a", result.Relationships[1].Target)
+	assert.Equal(t, "related-to", result.Relationships[1].Type)
+	assert.Equal(t, "target-b", result.Relationships[2].Target)
 }
 
 func TestMergeSummary_EmptyExisting(t *testing.T) {
@@ -269,4 +276,99 @@ func TestIsComplete(t *testing.T) {
 			assert.Equal(t, tt.want, IsComplete(tt.fm))
 		})
 	}
+}
+
+// TestMergeFrontmatter_ForceDedupesInput guards the force-mode path against
+// a model (or deterministic extractor) returning within-list duplicates of
+// the same (Target, Type) edge — the observable symptom behind issue #108.
+func TestMergeFrontmatter_ForceDedupesInput(t *testing.T) {
+	existing := schema.GraphFrontmatter{
+		ID:         "prev",
+		Title:      "Prev",
+		EntityType: "concept",
+		Confidence: 0.9,
+		Relationships: []schema.Relationship{
+			{Target: "old", Type: "related-to", Strength: 0.5},
+		},
+	}
+	extracted := ExtractedFields{
+		Relationships: []schema.Relationship{
+			{Target: "foo", Type: "related-to", Strength: 0.5},
+			{Target: "foo", Type: "related-to", Strength: 0.9}, // exact-key dup
+			{Target: "bar", Type: "implements", Strength: 0.7},
+		},
+		Tags:       []string{"a", "A", "b"}, // case-insensitive dup
+		Provenance: schema.Provenance{Sources: []string{"s1", "s1"}},
+	}
+
+	result := MergeFrontmatter(existing, extracted, MergeOptions{Force: true})
+
+	assert.Len(t, result.Relationships, 2, "duplicate (foo, related-to) must collapse")
+	assert.Equal(t, "foo", result.Relationships[0].Target)
+	assert.Equal(t, 0.5, result.Relationships[0].Strength, "first-seen wins on exact dup")
+	assert.Equal(t, "bar", result.Relationships[1].Target)
+	assert.Equal(t, []string{"a", "b"}, result.Tags)
+	assert.Equal(t, []string{"s1"}, result.Provenance.Sources)
+}
+
+// TestMergeFrontmatter_IdempotentAcrossModes asserts the issue #108
+// single-block invariant: repeated merges of the same extracted payload
+// never grow the relationships / entities / tags lists, in either default
+// or force mode.
+func TestMergeFrontmatter_IdempotentAcrossModes(t *testing.T) {
+	extracted := ExtractedFields{
+		ID:         "p",
+		Title:      "P",
+		EntityType: "concept",
+		Confidence: 0.9,
+		Tags:       []string{"go"},
+		Relationships: []schema.Relationship{
+			{Target: "foo", Type: "related-to", Strength: 0.5},
+			{Target: "bar", Type: "implements", Strength: 0.7},
+		},
+	}
+
+	// Two passes in default (non-force) mode.
+	r1 := MergeFrontmatter(schema.GraphFrontmatter{}, extracted, MergeOptions{})
+	r2 := MergeFrontmatter(r1, extracted, MergeOptions{})
+	assert.Equal(t, r1.Relationships, r2.Relationships, "non-force merge must be idempotent")
+	assert.Equal(t, r1.Tags, r2.Tags)
+
+	// Two passes in force mode, input seeded with within-list dups.
+	dupExtracted := extracted
+	dupExtracted.Relationships = append(dupExtracted.Relationships,
+		schema.Relationship{Target: "foo", Type: "related-to", Strength: 0.5})
+	f1 := MergeFrontmatter(schema.GraphFrontmatter{}, dupExtracted, MergeOptions{Force: true})
+	f2 := MergeFrontmatter(f1, dupExtracted, MergeOptions{Force: true})
+	assert.Len(t, f1.Relationships, 2)
+	assert.Equal(t, f1.Relationships, f2.Relationships, "force merge must be idempotent after dedup")
+}
+
+// TestMergeModelResult_ForceDedupesInput mirrors the above guard on the
+// Tier 2 MergeModelResult force branch, which was the other path that could
+// write within-list duplicates into frontmatter under issue #108.
+func TestMergeModelResult_ForceDedupesInput(t *testing.T) {
+	existing := schema.GraphFrontmatter{}
+	model := &ModelResult{
+		Entities: []schema.Entity{
+			{Name: "Alice", Role: "person"},
+			{Name: "alice", Role: "person"}, // case-insensitive dup
+			{Name: "Bob", Role: "person"},
+		},
+		Relationships: []schema.Relationship{
+			{Target: "x", Type: "related-to", Strength: 0.5},
+			{Target: "x", Type: "related-to", Strength: 0.5}, // exact dup
+		},
+		SemanticHints:     []string{"h1", "h1"},
+		PossibleQuestions: []string{"q1", "Q1"},
+	}
+
+	result := MergeModelResult(existing, model, MergeOptions{Force: true})
+
+	assert.Len(t, result.Entities, 2)
+	assert.Equal(t, "Alice", result.Entities[0].Name)
+	assert.Equal(t, "Bob", result.Entities[1].Name)
+	assert.Len(t, result.Relationships, 1)
+	assert.Len(t, result.SemanticHints, 1)
+	assert.Len(t, result.PossibleQuestions, 1)
 }

--- a/enrich/merge_test.go
+++ b/enrich/merge_test.go
@@ -311,6 +311,56 @@ func TestMergeFrontmatter_ForceDedupesInput(t *testing.T) {
 	assert.Equal(t, []string{"s1"}, result.Provenance.Sources)
 }
 
+// TestMergeFrontmatter_ForceDedupesEntities guards AC #4 from issue #108:
+// entities carried through existing frontmatter into a force-mode merge must
+// be deduped by lowercased Name. Mirrors TestMergeFrontmatter_ForceDedupesInput
+// on the entities side — ExtractedFields has no Entities field, so the stale
+// duplicates come in via existing.
+func TestMergeFrontmatter_ForceDedupesEntities(t *testing.T) {
+	existing := schema.GraphFrontmatter{
+		ID:         "prev",
+		Title:      "Prev",
+		EntityType: "concept",
+		Confidence: 0.9,
+		Entities: []schema.Entity{
+			{Name: "Alice", Role: "person"},
+			{Name: "alice", Role: "person"}, // case-insensitive dup
+			{Name: "Bob", Role: "person"},
+			{Name: "Bob", Role: "person"}, // exact dup
+		},
+	}
+	extracted := ExtractedFields{
+		ID:    "new",
+		Title: "New",
+	}
+
+	result := MergeFrontmatter(existing, extracted, MergeOptions{Force: true})
+
+	assert.Len(t, result.Entities, 2, "case-insensitive and exact entity dupes must collapse")
+	assert.Equal(t, "Alice", result.Entities[0].Name, "first-seen wins")
+	assert.Equal(t, "Bob", result.Entities[1].Name)
+}
+
+// TestMergeFrontmatter_DefaultDedupesEntities covers the non-force path: if
+// existing frontmatter already carries entity duplicates (e.g. from a prior
+// buggy write), a default merge must clean them up rather than preserve them.
+func TestMergeFrontmatter_DefaultDedupesEntities(t *testing.T) {
+	existing := schema.GraphFrontmatter{
+		Entities: []schema.Entity{
+			{Name: "Alice"},
+			{Name: "ALICE"},
+			{Name: "Bob"},
+		},
+	}
+	extracted := ExtractedFields{ID: "p", Title: "P"}
+
+	result := MergeFrontmatter(existing, extracted, MergeOptions{})
+
+	assert.Len(t, result.Entities, 2)
+	assert.Equal(t, "Alice", result.Entities[0].Name)
+	assert.Equal(t, "Bob", result.Entities[1].Name)
+}
+
 // TestMergeFrontmatter_IdempotentAcrossModes asserts the issue #108
 // single-block invariant: repeated merges of the same extracted payload
 // never grow the relationships / entities / tags lists, in either default

--- a/enrich/model.go
+++ b/enrich/model.go
@@ -356,16 +356,16 @@ func MergeModelResult(existing schema.GraphFrontmatter, model *ModelResult, opts
 			result.Summary = model.Summary
 		}
 		if len(model.Entities) > 0 {
-			result.Entities = model.Entities
+			result.Entities = dedupeEntities(model.Entities)
 		}
 		if len(model.Relationships) > 0 {
-			result.Relationships = model.Relationships
+			result.Relationships = dedupeRelationships(model.Relationships)
 		}
 		if len(model.SemanticHints) > 0 {
-			result.SemanticHints = model.SemanticHints
+			result.SemanticHints = dedupeStringsCaseInsensitive(model.SemanticHints)
 		}
 		if len(model.PossibleQuestions) > 0 {
-			result.PossibleQuestions = model.PossibleQuestions
+			result.PossibleQuestions = dedupeStringsCaseInsensitive(model.PossibleQuestions)
 		}
 		return result
 	}
@@ -378,18 +378,28 @@ func MergeModelResult(existing schema.GraphFrontmatter, model *ModelResult, opts
 		result.Summary = model.Summary
 	}
 
-	// Union entities by name.
-	if len(model.Entities) > 0 {
-		seen := make(map[string]bool)
+	// Union entities by name (case-insensitive), also deduping existing
+	// against itself so stale duplicates on the input side get cleaned up.
+	if len(result.Entities) > 0 || len(model.Entities) > 0 {
+		seen := make(map[string]bool, len(result.Entities)+len(model.Entities))
+		merged := make([]schema.Entity, 0, len(result.Entities)+len(model.Entities))
 		for _, e := range result.Entities {
-			seen[strings.ToLower(e.Name)] = true
+			k := strings.ToLower(e.Name)
+			if seen[k] {
+				continue
+			}
+			seen[k] = true
+			merged = append(merged, e)
 		}
 		for _, e := range model.Entities {
-			if !seen[strings.ToLower(e.Name)] {
-				seen[strings.ToLower(e.Name)] = true
-				result.Entities = append(result.Entities, e)
+			k := strings.ToLower(e.Name)
+			if seen[k] {
+				continue
 			}
+			seen[k] = true
+			merged = append(merged, e)
 		}
+		result.Entities = merged
 	}
 
 	// Union relationships by target.

--- a/markdown/frontmatter_writer.go
+++ b/markdown/frontmatter_writer.go
@@ -30,6 +30,12 @@ func PrependFrontmatter(fm *schema.GraphFrontmatter, body string) ([]byte, error
 // ReplaceFrontmatter replaces existing YAML frontmatter in data with the
 // serialized fm, preserving the body after the closing --- delimiter exactly.
 // If data has no frontmatter, behaves like PrependFrontmatter.
+//
+// If the input contains multiple consecutive leading YAML frontmatter blocks
+// (separated only by whitespace) — a malformed state that can arise from
+// manual edits or upstream tool bugs — all of them are stripped and replaced
+// by the single serialized fm. This keeps the writer idempotent and prevents
+// stale `relationships:` / `entities:` blocks from surviving an enrich pass.
 func ReplaceFrontmatter(fm *schema.GraphFrontmatter, data []byte) ([]byte, error) {
 	loc := frontmatterRe.FindSubmatchIndex(data)
 	if loc == nil {
@@ -47,6 +53,19 @@ func ReplaceFrontmatter(fm *schema.GraphFrontmatter, data []byte) ([]byte, error
 	bodyStart := loc[4]
 	originalBody := data[bodyStart:]
 
+	// Greedily strip any additional leading `---\n...\n---\n?` blocks that
+	// appear after whitespace-only separators. This handles pathological
+	// inputs with stacked frontmatter blocks (see fix for issue #108).
+	for {
+		trimmed := trimLeadingWhitespace(originalBody)
+		inner := frontmatterRe.FindSubmatchIndex(trimmed)
+		if inner == nil {
+			break
+		}
+		// inner[4] is the start of the body capture within trimmed.
+		originalBody = trimmed[inner[4]:]
+	}
+
 	var b strings.Builder
 	b.WriteString("---\n")
 	b.Write(yamlBytes)
@@ -54,6 +73,22 @@ func ReplaceFrontmatter(fm *schema.GraphFrontmatter, data []byte) ([]byte, error
 	b.Write(originalBody)
 
 	return []byte(b.String()), nil
+}
+
+// trimLeadingWhitespace returns b with any leading ASCII whitespace (space,
+// tab, newline, carriage return) removed. Kept separate from strings.TrimLeft
+// to avoid an unnecessary []byte↔string conversion on large bodies.
+func trimLeadingWhitespace(b []byte) []byte {
+	i := 0
+	for i < len(b) {
+		c := b[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			i++
+			continue
+		}
+		break
+	}
+	return b[i:]
 }
 
 // WriteFrontmatterFile atomically writes content to path using a

--- a/markdown/frontmatter_writer_test.go
+++ b/markdown/frontmatter_writer_test.go
@@ -107,6 +107,51 @@ func TestReplaceFrontmatter_BodyPreservedByteForByte(t *testing.T) {
 		"body mismatch:\nexpected: %q\ngot:      %q", body, resultBody)
 }
 
+// TestReplaceFrontmatter_StripsStackedLeadingBlocks guards the issue #108
+// invariant: when a file pathologically contains multiple consecutive
+// leading `---...---` blocks (from a manual edit or upstream tool bug),
+// ReplaceFrontmatter must strip ALL of them and emit exactly one.
+func TestReplaceFrontmatter_StripsStackedLeadingBlocks(t *testing.T) {
+	original := []byte("---\nid: first\n---\n\n---\nid: stale\nrelationships:\n  - target: ghost\n    type: old\n    strength: 0.1\n---\n\n# Real Body\n\nContent.\n")
+	fm := &schema.GraphFrontmatter{
+		ID:         "merged",
+		Title:      "Merged",
+		EntityType: "concept",
+		Confidence: 0.9,
+	}
+
+	result, err := ReplaceFrontmatter(fm, original)
+	require.NoError(t, err)
+
+	// Exactly one `^relationships:` would show up if present; here fm has
+	// none so we expect zero. The critical assertion is that the stale
+	// leading block with `relationships:` was stripped entirely.
+	assert.NotContains(t, string(result), "id: stale",
+		"stale stacked frontmatter block must be stripped")
+	assert.NotContains(t, string(result), "target: ghost",
+		"stale frontmatter body must be stripped")
+	assert.Contains(t, string(result), "id: merged")
+	assert.Contains(t, string(result), "# Real Body")
+
+	// Idempotency: running ReplaceFrontmatter again should be a no-op on
+	// block count.
+	result2, err := ReplaceFrontmatter(fm, result)
+	require.NoError(t, err)
+	assert.Equal(t, result, result2, "ReplaceFrontmatter must be idempotent")
+
+	// Count leading `---` pairs. A well-formed single-FM file has exactly
+	// two `---` lines at the top, separated by YAML.
+	assert.Equal(t, 2, bytes.Count(result, []byte("\n---\n"))+boolToInt(bytes.HasPrefix(result, []byte("---\n"))),
+		"result must contain exactly one leading frontmatter block")
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 func TestWriteFrontmatterFile_Atomic(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.md")


### PR DESCRIPTION
Closes #108

## Root cause

Two distinct bugs produced the symptom of duplicate `^relationships:` / `^entities:` lines after `markedup enrich --force`:

1. **No within-list dedup in force mode.** `MergeFrontmatter` and `MergeModelResult` force branches assigned the incoming slice wholesale. If the Tier 1 extractor or Tier 2 model returned the same `(Target, Type)` edge twice (common when a model hallucinates against its own training data), both survived into the YAML.
2. **`ReplaceFrontmatter` only stripped the first leading `---...---` block.** Files that accidentally ended up with two stacked leading FM blocks (manual edit, upstream tool glitch) retained the stale second block forever — the writer replaced the first block and left the second intact, producing a visible second `relationships:` / `entities:` at column 0.
3. **False-positive in the issue's grep heuristic.** On `docs/cli-reference.md` / `docs/schema-reference.md`, the reported "2" / "3" counts included `relationships:` inside fenced ```yaml code blocks that document the schema. Those are legitimate body content — the actual frontmatter is one block. Body is preserved byte-for-byte by design and is not rewritten.

## Fix

- `enrich/merge.go`: dedup by composite `(Target, Type)` key for relationships and by lowercased `Name` for entities, in BOTH default and force branches. New helpers `dedupeRelationships`, `dedupeEntities`, `dedupeStringsCaseInsensitive` reused across all merge paths.
- `enrich/model.go`: `MergeModelResult` force branch now dedupes within the incoming slice instead of assigning it raw. Default-mode entity union also dedupes the `result.Entities` side against itself so stale duplicates get cleaned up.
- `markdown/frontmatter_writer.go`: `ReplaceFrontmatter` iteratively strips every leading `---...---` block separated by whitespace before writing the single serialized fm. Makes the writer idempotent against pathological stacked-block input.

## Acceptance criteria

- [x] After `enrich --force`, every file has exactly one real frontmatter block (verified via repro on synthetic stacked-FM file and on `docs/schema-reference.md`).
- [x] Tier 1 + Tier 2 relationships merge into a single block (unchanged — this always worked; existing behaviour preserved).
- [x] Within-list duplicates are deduped by `(Target, Type)` — see `TestMergeFrontmatter_ForceDedupesInput`, `TestMergeModelResult_ForceDedupesInput`.
- [x] Same fix applies to `entities:` (verified via `TestMergeModelResult_ForceDedupesInput` — case-insensitive Name dedup).
- [x] Unit test asserts single-block invariant after repeated enrich runs — `TestMergeFrontmatter_IdempotentAcrossModes` (both modes) and `TestReplaceFrontmatter_StripsStackedLeadingBlocks` (writer-level).
- [x] `markedup check` on enriched files: no new errors introduced (pre-existing "dangling relationship" errors from model hallucination are out of scope — tracked separately).

## Test output

```
ok  	github.com/Clarit-AI/markedup	(cached)
ok  	github.com/Clarit-AI/markedup/cache	(cached)
ok  	github.com/Clarit-AI/markedup/config	(cached)
ok  	github.com/Clarit-AI/markedup/embed	(cached)
ok  	github.com/Clarit-AI/markedup/enrich	(cached)
ok  	github.com/Clarit-AI/markedup/index	(cached)
ok  	github.com/Clarit-AI/markedup/internal/cli	(cached)
ok  	github.com/Clarit-AI/markedup/internal/tui	(cached)
ok  	github.com/Clarit-AI/markedup/llm	(cached)
ok  	github.com/Clarit-AI/markedup/markdown	(cached)
ok  	github.com/Clarit-AI/markedup/rerank	(cached)
ok  	github.com/Clarit-AI/markedup/schema	(cached)
ok  	github.com/Clarit-AI/markedup/temporal	(cached)
```

(One unrelated test in `internal/tui/setup/wizard_test.go::TestKeysStep_NoPrefillNote_WhenNoPrefill` fails on `main` with the same failure due to real OS-keychain entries on the developer workstation. Independently verified fails pre-patch on clean `origin/main`. Out of scope.)

`go vet ./...` clean. `gofmt -l enrich/ markdown/` clean on changed files.

## Manual repro / verification

Before:
```
$ grep -c '^relationships:' dup.md   # file with two stacked leading FM blocks
2
```
After:
```
$ /tmp/markedup enrich --force dup.md && grep -c '^relationships:' dup.md
1
```

Idempotency: running `enrich --force` three times on `docs/schema-reference.md` produces a stable 3-match grep count (1 real FM + 2 fenced-code-block examples) — the legitimate code-block matches are preserved, the real FM block never duplicates.

## Impact scope

**No Plexium-pinned API surface changed.** Signatures of `enrich.MergeFrontmatter`, `enrich.MergeModelResult`, `enrich.EnrichPage`, `enrich.EnrichPageWithModel`, `enrich.EnrichmentDelta`, `markdown.ParseBytesPermissive`, `markdown.ReplaceFrontmatter`, `markdown.WriteFrontmatterFile`, `schema.Page`, `schema.GraphFrontmatter`, `schema.Entity`, `schema.Relationship` all unchanged. Only internal dedup semantics tighten — strictly safer (never produces more duplicates than before, only fewer).

One observable semantic refinement: `unionRelationships` now keys on `(Target, Type)` instead of `Target` alone. This means a merge where existing has `(foo, implements)` and extracted has `(foo, related-to)` now preserves both edges as distinct relationships instead of silently dropping the new one. This is a behaviour improvement aligned with the graph-semantic meaning of the fields. Existing test `TestMergeFrontmatter_RelationshipDedup` updated accordingly.

## Known follow-ups

- go.mod direct/indirect will resolve when PR #121 (NX-5 go mod tidy) merges to main and this branch rebases.

## Follow-up commit (cecc4eb)

Wires `dedupeEntities` into both `MergeFrontmatter` branches (force and default) so that stale entity duplicates flowing through `existing.Entities` get cleaned up on merge, not just the Tier 2 `MergeModelResult` path. Adds `TestMergeFrontmatter_ForceDedupesEntities` and `TestMergeFrontmatter_DefaultDedupesEntities` which fail pre-fix and pass post-fix, giving AC #4 a runtime guarantee on the Tier 1 merge path.
