### PR TITLE
feat: [Issue #109] separate Tier 2 NER edges into semantic-relationships field

### DIFF
--- a/enrich/merge_test.go
+++ b/enrich/merge_test.go
@@ -418,7 +418,72 @@ func TestMergeModelResult_ForceDedupesInput(t *testing.T) {
 	assert.Len(t, result.Entities, 2)
 	assert.Equal(t, "Alice", result.Entities[0].Name)
 	assert.Equal(t, "Bob", result.Entities[1].Name)
-	assert.Len(t, result.Relationships, 1)
+	// Tier 2 relationships route into SemanticRelationships (issue #109).
+	assert.Empty(t, result.Relationships, "Tier 2 must not write to Relationships")
+	assert.Len(t, result.SemanticRelationships, 1)
 	assert.Len(t, result.SemanticHints, 1)
 	assert.Len(t, result.PossibleQuestions, 1)
+}
+
+// TestMergeFrontmatter_Tier1_RoutesToRelationships guards the Tier 1 path: wikilink-
+// derived ExtractedFields.Relationships must remain in Relationships and must
+// NOT bleed into SemanticRelationships. Issue #109.
+func TestMergeFrontmatter_Tier1_RoutesToRelationships(t *testing.T) {
+	existing := schema.GraphFrontmatter{}
+	extracted := ExtractedFields{
+		Relationships: []schema.Relationship{
+			{Target: "other-doc", Type: "related-to", Strength: 0.5},
+		},
+	}
+
+	// Both default and force branches must route identically.
+	for _, force := range []bool{false, true} {
+		result := MergeFrontmatter(existing, extracted, MergeOptions{Force: force})
+		assert.Len(t, result.Relationships, 1, "force=%v", force)
+		assert.Equal(t, "other-doc", result.Relationships[0].Target)
+		assert.Empty(t, result.SemanticRelationships, "Tier 1 must not populate SemanticRelationships; force=%v", force)
+	}
+}
+
+// TestMergeModelResult_Tier2_PreservesExistingRelationships ensures Tier 2
+// running after Tier 1 does NOT clobber wikilink Relationships. Issue #109.
+func TestMergeModelResult_Tier2_PreservesExistingRelationships(t *testing.T) {
+	existing := schema.GraphFrontmatter{
+		Relationships: []schema.Relationship{
+			{Target: "doc-a", Type: "related-to", Strength: 0.5},
+		},
+	}
+	model := &ModelResult{
+		Relationships: []schema.Relationship{
+			{Target: "wikilinks", Type: "mentions", Strength: 0.8},
+		},
+	}
+
+	for _, force := range []bool{false, true} {
+		result := MergeModelResult(existing, model, MergeOptions{Force: force})
+		assert.Len(t, result.Relationships, 1, "wikilink edge preserved; force=%v", force)
+		assert.Equal(t, "doc-a", result.Relationships[0].Target)
+		assert.Len(t, result.SemanticRelationships, 1, "NER edge routed; force=%v", force)
+		assert.Equal(t, "wikilinks", result.SemanticRelationships[0].Target)
+	}
+}
+
+// TestMergeModelResult_SemanticRelationships_Idempotent ensures running Tier 2
+// merge twice produces stable counts on SemanticRelationships (mirror of the
+// #108 dedup invariant, but on the new field). Issue #109.
+func TestMergeModelResult_SemanticRelationships_Idempotent(t *testing.T) {
+	existing := schema.GraphFrontmatter{}
+	model := &ModelResult{
+		Relationships: []schema.Relationship{
+			{Target: "alice", Type: "mentions", Strength: 0.8},
+			{Target: "bob", Type: "mentions", Strength: 0.8},
+		},
+	}
+
+	for _, force := range []bool{false, true} {
+		pass1 := MergeModelResult(existing, model, MergeOptions{Force: force})
+		pass2 := MergeModelResult(pass1, model, MergeOptions{Force: force})
+		assert.Len(t, pass1.SemanticRelationships, 2, "force=%v", force)
+		assert.Len(t, pass2.SemanticRelationships, 2, "idempotent; force=%v", force)
+	}
 }

--- a/enrich/model.go
+++ b/enrich/model.go
@@ -358,8 +358,11 @@ func MergeModelResult(existing schema.GraphFrontmatter, model *ModelResult, opts
 		if len(model.Entities) > 0 {
 			result.Entities = dedupeEntities(model.Entities)
 		}
+		// Tier 2 NER edges go into SemanticRelationships — see issue #109.
+		// result.Relationships (wikilink-derived, doc→doc) is left untouched
+		// so graph traversal stays clean.
 		if len(model.Relationships) > 0 {
-			result.Relationships = dedupeRelationships(model.Relationships)
+			result.SemanticRelationships = dedupeRelationships(model.Relationships)
 		}
 		if len(model.SemanticHints) > 0 {
 			result.SemanticHints = dedupeStringsCaseInsensitive(model.SemanticHints)
@@ -402,8 +405,9 @@ func MergeModelResult(existing schema.GraphFrontmatter, model *ModelResult, opts
 		result.Entities = merged
 	}
 
-	// Union relationships by target.
-	result.Relationships = unionRelationships(result.Relationships, model.Relationships)
+	// Tier 2 NER edges union into SemanticRelationships — see issue #109.
+	// result.Relationships (wikilink-derived, doc→doc) is left untouched.
+	result.SemanticRelationships = unionRelationships(result.SemanticRelationships, model.Relationships)
 
 	// Union semantic hints.
 	result.SemanticHints = unionStrings(result.SemanticHints, model.SemanticHints)

--- a/enrich/model_test.go
+++ b/enrich/model_test.go
@@ -358,7 +358,9 @@ func TestMergeModelResult_Default(t *testing.T) {
 
 	assert.Equal(t, "document", result.EntityType) // preserved
 	assert.Len(t, result.Entities, 2)              // Go + Rust
-	assert.Len(t, result.Relationships, 1)
+	// Tier 2 relationships route into SemanticRelationships (issue #109).
+	assert.Empty(t, result.Relationships, "Tier 2 must not write to Relationships")
+	assert.Len(t, result.SemanticRelationships, 1)
 	assert.Equal(t, []string{"systems programming"}, result.SemanticHints)
 	assert.Equal(t, []string{"What is Go?"}, result.PossibleQuestions)
 }

--- a/schema/types.go
+++ b/schema/types.go
@@ -8,18 +8,24 @@ package schema
 // graph page. It captures identity, classification, relationships, temporal
 // metadata, and provenance for a single node in the graph.
 type GraphFrontmatter struct {
-	ID                string         `yaml:"id"`
-	Title             string         `yaml:"title"`
-	EntityType        string         `yaml:"entity-type"`
-	Confidence        float64        `yaml:"confidence"`
-	Tags              []string       `yaml:"tags"`
-	Entities          []Entity       `yaml:"entities"`
-	Relationships     []Relationship `yaml:"relationships"`
-	Temporal          TemporalInfo   `yaml:"temporal"`
-	Provenance        Provenance     `yaml:"provenance"`
-	Summary           string         `yaml:"summary"`
-	SemanticHints     []string       `yaml:"semantic-hints"`
-	PossibleQuestions []string       `yaml:"possible-questions"`
+	ID            string         `yaml:"id"`
+	Title         string         `yaml:"title"`
+	EntityType    string         `yaml:"entity-type"`
+	Confidence    float64        `yaml:"confidence"`
+	Tags          []string       `yaml:"tags"`
+	Entities      []Entity       `yaml:"entities"`
+	Relationships []Relationship `yaml:"relationships"`
+	// SemanticRelationships holds Tier 2 NER-derived edges whose Target is a
+	// free-text entity name rather than a document ID. These are kept separate
+	// from Relationships so that graph traversal (which expects doc→doc edges)
+	// only consumes wikilink-derived Relationships. Omitted from YAML output
+	// when empty. See issue #109.
+	SemanticRelationships []Relationship `yaml:"semantic-relationships,omitempty" json:"semantic-relationships,omitempty"`
+	Temporal              TemporalInfo   `yaml:"temporal"`
+	Provenance            Provenance     `yaml:"provenance"`
+	Summary               string         `yaml:"summary"`
+	SemanticHints         []string       `yaml:"semantic-hints"`
+	PossibleQuestions     []string       `yaml:"possible-questions"`
 }
 
 // Entity represents a named entity referenced within a page. Aliases allow

--- a/schema/types.go
+++ b/schema/types.go
@@ -20,7 +20,7 @@ type GraphFrontmatter struct {
 	// from Relationships so that graph traversal (which expects doc→doc edges)
 	// only consumes wikilink-derived Relationships. Omitted from YAML output
 	// when empty. See issue #109.
-	SemanticRelationships []Relationship `yaml:"semantic-relationships,omitempty" json:"semantic-relationships,omitempty"`
+	SemanticRelationships []Relationship `yaml:"semantic-relationships,omitempty"`
 	Temporal              TemporalInfo   `yaml:"temporal"`
 	Provenance            Provenance     `yaml:"provenance"`
 	Summary               string         `yaml:"summary"`

--- a/schema/types_test.go
+++ b/schema/types_test.go
@@ -112,8 +112,8 @@ func TestGraphFrontmatter_YAMLRoundTrip(t *testing.T) {
 			want: GraphFrontmatter{
 				ID:         "edge-zero",
 				Confidence: 0.0,
-				Tags:              []string{},
-				Entities:          []Entity{},
+				Tags:       []string{},
+				Entities:   []Entity{},
 				Relationships: []Relationship{
 					{Target: "t", Type: "x", Strength: 0.0},
 				},
@@ -136,8 +136,8 @@ func TestGraphFrontmatter_YAMLRoundTrip(t *testing.T) {
 			want: GraphFrontmatter{
 				ID:         "edge-one",
 				Confidence: 1.0,
-				Tags:              []string{},
-				Entities:          []Entity{},
+				Tags:       []string{},
+				Entities:   []Entity{},
 				Relationships: []Relationship{
 					{Target: "t", Type: "x", Strength: 1.0},
 				},
@@ -230,6 +230,52 @@ func TestGraphFrontmatter_YAMLRoundTrip(t *testing.T) {
 			require.Equal(t, tt.want, got, "round-trip should produce expected struct")
 		})
 	}
+}
+
+// TestGraphFrontmatter_SemanticRelationships_RoundTrip verifies the new
+// semantic-relationships field (issue #109) marshals and unmarshals cleanly.
+// omitempty means an empty slice produces no YAML key at all.
+func TestGraphFrontmatter_SemanticRelationships_RoundTrip(t *testing.T) {
+	t.Run("populated semantic-relationships round-trip", func(t *testing.T) {
+		give := GraphFrontmatter{
+			ID: "ner-page",
+			Relationships: []Relationship{
+				{Target: "other-doc", Type: "related-to", Strength: 0.5},
+			},
+			SemanticRelationships: []Relationship{
+				{Target: "wikilinks", Type: "mentions", Strength: 0.8},
+				{Target: "bob", Type: "knows", Strength: 0.7},
+			},
+		}
+		got := yamlRoundTrip(t, give)
+		require.Equal(t, give.Relationships, got.Relationships)
+		require.Equal(t, give.SemanticRelationships, got.SemanticRelationships)
+	})
+
+	t.Run("omitempty: absent key unmarshals as nil", func(t *testing.T) {
+		give := GraphFrontmatter{ID: "no-ner"}
+		data, err := yaml.Marshal(give)
+		require.NoError(t, err)
+		// omitempty: key must not appear when slice is empty.
+		require.NotContains(t, string(data), "semantic-relationships")
+
+		var got GraphFrontmatter
+		require.NoError(t, yaml.Unmarshal(data, &got))
+		require.Nil(t, got.SemanticRelationships)
+	})
+
+	t.Run("both fields independent", func(t *testing.T) {
+		// Relationships populated, SemanticRelationships empty.
+		give := GraphFrontmatter{
+			ID: "wikilinks-only",
+			Relationships: []Relationship{
+				{Target: "doc-a", Type: "links", Strength: 1.0},
+			},
+		}
+		got := yamlRoundTrip(t, give)
+		require.Len(t, got.Relationships, 1)
+		require.Empty(t, got.SemanticRelationships)
+	})
 }
 
 func TestGraphFrontmatter_YAMLIdempotent(t *testing.T) {


### PR DESCRIPTION
Closes #109

## Summary
- Adds `schema.GraphFrontmatter.SemanticRelationships []Relationship` (yaml `semantic-relationships,omitempty`).
- `enrich.MergeModelResult` (Tier 2, both force and default branches) now routes NER-derived relationships into `SemanticRelationships` instead of `Relationships`. Applies the same `dedupeRelationships` / `unionRelationships` dedup helpers introduced by #108.
- `enrich.MergeFrontmatter` (Tier 1) is unchanged — wikilink-derived edges still land in `Relationships`.
- `schema.Relationship` (the type) is unchanged; only its containing struct gained a field.

## Why Option B
Per the 2026-04-18 decision on #109: Option A (cross-doc entity reconciliation) is deferred; Option C (TUI-only traversal) rejected. Option B is the minimal, safe unblocker — the two tiers already run through distinct merge functions, so routing by source tier at the call-site cleanly splits doc→doc wikilink edges from NER entity edges without changing any public type signatures.

## Schema change notes (Plexium-safe)
- **Additive only**: new Go struct field with `omitempty` yaml tag. Adding a field to a struct is source-compatible; yaml.v3 decoders tolerate unknown fields.
- **Plexium API impact: none (additive schema field).** No pinned symbol (`index.Load/Reload/Search/Traverse`, `idx.CompactGraphSummary/Get/Pages`, `enrich.EnrichPage/EnrichPageWithModel/EnrichmentDelta`, `embed.NewFromProvider/Embedder`, `markdown.ParseBytesPermissive/ReplaceFrontmatter/WriteFrontmatterFile`, `schema.Page/GraphFrontmatter/Entity/Relationship`) changed signature or semantics.

## Graph traversal impact
- `index/index.go` `buildIndex` reads only `p.Frontmatter.Relationships` for forward/reverse adjacency — unchanged. Confirmed `SemanticRelationships` is NOT fed into the graph.
- `index.Traverse`, TUI Explore (which goes through the index), and the CLI `output.go` relationship display all consume `Relationships` only.
- Net effect: once a user re-enriches with `--force`, their graph cleans up (NER junk moves out of `relationships:`) and Explore starts showing real wikilink connections.

## Migration notes
- **`omitempty`**: files without Tier 2 output will have no `semantic-relationships:` key at all — zero diff noise for existing files.
- **Legacy files with NER junk in `relationships:`**: preserved by default `markedup enrich`. Cleaned automatically on next `markedup enrich --force`. Default (non-force) mode intentionally does NOT rewrite to avoid surprising users.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on changed files
- [x] `go test ./schema/... ./enrich/... ./index/...` — PASS
- [x] `go test ./...` — PASS except the pre-existing `TestKeysStep_NoPrefillNote_WhenNoPrefill` flake (#108 follow-up, unrelated to this PR)
- [x] New unit tests:
  - `TestMergeModelResult_ForceDedupesInput` updated to assert Tier 2 routes to `SemanticRelationships`
  - `TestMergeModelResult_Default` updated for same invariant
  - `TestMergeFrontmatter_Tier1_RoutesToRelationships` — Tier 1 never populates `SemanticRelationships`
  - `TestMergeModelResult_Tier2_PreservesExistingRelationships` — Tier 2 doesn't clobber wikilinks
  - `TestMergeModelResult_SemanticRelationships_Idempotent` — double-pass stability on the new field (mirrors #108 dedup invariant)
  - `TestGraphFrontmatter_SemanticRelationships_RoundTrip` — YAML marshal/unmarshal of the new field, including `omitempty` semantics

## AC checklist
- [x] `schema.GraphFrontmatter` has new `SemanticRelationships` field, yaml-tagged `semantic-relationships,omitempty`
- [x] `MergeModelResult` (both force and default branches) writes Tier 2 relationships to `SemanticRelationships`; `result.Relationships` untouched by Tier 2
- [x] `MergeFrontmatter` (Tier 1) unchanged — still writes wikilinks to `Relationships`
- [x] Index / traversal code consumes only `Relationships` for graph edges (documented in PR + existing code confirmed in `index/index.go` `buildIndex`)
- [x] Unit tests cover the four required invariants
- [x] `go test ./...` clean modulo pre-existing flake
- [x] `go vet ./...` clean, `gofmt -l` clean on changed files
- [x] `schema.Relationship` type unchanged — only the containing struct gained a field

🤖 Generated with [Claude Code](https://claude.com/claude-code)