### PR TITLE
fix: [#113] IsComplete accounts for Tier 2 fields

### DIFF
--- a/enrich/merge.go
+++ b/enrich/merge.go
@@ -102,10 +102,56 @@ func MergeSummary(existing schema.GraphFrontmatter, summary string, opts MergeOp
 	return result
 }
 
-// IsComplete reports whether the frontmatter has all required fields populated,
-// meaning enrichment would be a no-op in default (non-force) mode for scalars.
+// Tier identifies a stage of the enrichment pipeline.
+//
+// Tier 1 is the deterministic pass that fills scalar identity fields from
+// filename/headings/wikilinks. Tier 2 is the model-assisted pass that fills
+// semantic fields (summary, entities, semantic-relationships, etc.).
+type Tier int
+
+const (
+	// Tier1 is the deterministic scalar-identity pass.
+	Tier1 Tier = 1
+	// Tier2 is the model-assisted semantic pass.
+	Tier2 Tier = 2
+)
+
+// IsComplete reports whether the frontmatter has both Tier 1 and Tier 2
+// enrichment applied, meaning a non-force re-run would be a no-op.
+//
+// Before the #113 fix this returned true for Tier 1 scalars alone, which
+// caused re-runs under a newly-configured Tier 2 model to skip every file.
+// Callers that only care about a specific tier should use IsCompleteForTier.
 func IsComplete(fm schema.GraphFrontmatter) bool {
+	return tier1Complete(fm) && tier2Complete(fm)
+}
+
+// IsCompleteForTier reports whether the frontmatter has the fields produced
+// by the given tier populated. Unknown tiers return false.
+func IsCompleteForTier(fm schema.GraphFrontmatter, tier Tier) bool {
+	switch tier {
+	case Tier1:
+		return tier1Complete(fm)
+	case Tier2:
+		return tier2Complete(fm)
+	default:
+		return false
+	}
+}
+
+// tier1Complete checks that the deterministic scalar-identity fields are set.
+func tier1Complete(fm schema.GraphFrontmatter) bool {
 	return fm.ID != "" && fm.Title != "" && fm.EntityType != "" && fm.Confidence > 0
+}
+
+// tier2Complete checks for a reliable Tier 2 "ran at all" signal.
+//
+// Summary is used as the anchor because the Tier 2 path in the enrich CLI
+// always generates one, whereas entities/relationships/semantic-relationships
+// can legitimately be empty for a doc that genuinely has none — keying on
+// those would force a redundant re-run on every enrich invocation.
+func tier2Complete(fm schema.GraphFrontmatter) bool {
+	return fm.Summary != ""
 }
 
 // unionStrings returns the union of a and b, case-insensitive, preserving order.

--- a/enrich/merge_test.go
+++ b/enrich/merge_test.go
@@ -242,26 +242,48 @@ func TestMergeSummary_EmptySummaryNoOp(t *testing.T) {
 }
 
 func TestIsComplete(t *testing.T) {
+	// Post-#113 semantics: IsComplete requires BOTH Tier 1 scalars AND Tier 2
+	// summary. Tier-1-only frontmatter now correctly reports incomplete so a
+	// re-run under a newly-configured Tier 2 model will process the file.
 	tests := []struct {
 		name string
 		fm   schema.GraphFrontmatter
 		want bool
 	}{
 		{
-			name: "complete",
+			name: "both tiers complete",
 			fm: schema.GraphFrontmatter{
 				ID: "x", Title: "X", EntityType: "doc", Confidence: 0.7,
+				Summary: "A summary.",
 			},
 			want: true,
 		},
 		{
+			name: "tier 1 only (the #113 bug)",
+			fm: schema.GraphFrontmatter{
+				ID: "x", Title: "X", EntityType: "doc", Confidence: 0.7,
+			},
+			want: false,
+		},
+		{
+			name: "tier 2 only (missing scalars)",
+			fm: schema.GraphFrontmatter{
+				Summary: "A summary.",
+			},
+			want: false,
+		},
+		{
 			name: "missing id",
-			fm:   schema.GraphFrontmatter{Title: "X", EntityType: "doc", Confidence: 0.7},
+			fm: schema.GraphFrontmatter{
+				Title: "X", EntityType: "doc", Confidence: 0.7, Summary: "s",
+			},
 			want: false,
 		},
 		{
 			name: "zero confidence",
-			fm:   schema.GraphFrontmatter{ID: "x", Title: "X", EntityType: "doc"},
+			fm: schema.GraphFrontmatter{
+				ID: "x", Title: "X", EntityType: "doc", Summary: "s",
+			},
 			want: false,
 		},
 		{
@@ -274,6 +296,39 @@ func TestIsComplete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, IsComplete(tt.fm))
+		})
+	}
+}
+
+func TestIsCompleteForTier(t *testing.T) {
+	tier1Only := schema.GraphFrontmatter{
+		ID: "x", Title: "X", EntityType: "doc", Confidence: 0.7,
+	}
+	tier2Only := schema.GraphFrontmatter{Summary: "s"}
+	both := schema.GraphFrontmatter{
+		ID: "x", Title: "X", EntityType: "doc", Confidence: 0.7, Summary: "s",
+	}
+	empty := schema.GraphFrontmatter{}
+
+	tests := []struct {
+		name string
+		fm   schema.GraphFrontmatter
+		tier Tier
+		want bool
+	}{
+		{"tier1 on tier1-only", tier1Only, Tier1, true},
+		{"tier2 on tier1-only", tier1Only, Tier2, false},
+		{"tier1 on tier2-only", tier2Only, Tier1, false},
+		{"tier2 on tier2-only", tier2Only, Tier2, true},
+		{"tier1 on both", both, Tier1, true},
+		{"tier2 on both", both, Tier2, true},
+		{"tier1 on empty", empty, Tier1, false},
+		{"tier2 on empty", empty, Tier2, false},
+		{"unknown tier", both, Tier(99), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsCompleteForTier(tt.fm, tt.tier))
 		})
 	}
 }

--- a/internal/cli/enrich.go
+++ b/internal/cli/enrich.go
@@ -231,8 +231,17 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		// Skip if complete and not forcing.
-		if enrich.IsComplete(page.Frontmatter) && !enrichForce {
+		// Skip if complete for all configured tiers and not forcing. When no
+		// model is configured, Tier 2 fields are unreachable, so we must only
+		// require Tier 1 completeness — otherwise idempotent re-runs would
+		// re-process every file on every invocation.
+		var complete bool
+		if modelExtractor != nil {
+			complete = enrich.IsComplete(page.Frontmatter)
+		} else {
+			complete = enrich.IsCompleteForTier(page.Frontmatter, enrich.Tier1)
+		}
+		if complete && !enrichForce {
 			results = append(results, enrichResult{Path: filePath, Status: "skipped", Reason: "already complete"})
 			skipped++
 			continue

--- a/internal/cli/enrich_test.go
+++ b/internal/cli/enrich_test.go
@@ -139,6 +139,78 @@ func TestRunEnrich_SkipComplete(t *testing.T) {
 	assert.Contains(t, buf.String(), "0 errors")
 }
 
+// TestRunEnrich_TierAwareSkip_NoModel verifies that when no --model is
+// configured, a Tier-1-complete file is skipped on re-run. Regression guard
+// for the post-#113 regression where IsComplete (which requires Tier 2) was
+// applied unconditionally, causing every file to be re-enriched on every
+// invocation when no model was configured.
+func TestRunEnrich_TierAwareSkip_NoModel(t *testing.T) {
+	dir := t.TempDir()
+
+	plain := "# My Document\n\nSome content with #golang tag.\n"
+	filePath := filepath.Join(dir, "my-doc.md")
+	require.NoError(t, os.WriteFile(filePath, []byte(plain), 0644))
+
+	runOnce := func() string {
+		cmd := newEnrichCmd()
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{dir})
+
+		enrichDryRun = false
+		enrichForce = false
+		enrichSkipExist = false
+		enrichEndpoint, enrichModel, enrichAPIKey = "", "", ""
+
+		require.NoError(t, cmd.Execute())
+		return buf.String()
+	}
+
+	// First run: Tier 1 enrichment happens.
+	first := runOnce()
+	assert.Contains(t, first, "Enriched 1 files")
+
+	// Capture enriched file contents.
+	afterFirst, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	// Second run with no model: should SKIP (Tier-1-complete) — not re-enrich.
+	second := runOnce()
+	assert.Contains(t, second, "1 skipped", "second run without model must skip Tier-1-complete files")
+	assert.NotContains(t, second, "Enriched 1 files")
+
+	// File contents must be byte-identical (no rewrite).
+	afterSecond, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, string(afterFirst), string(afterSecond), "file should not be rewritten on second run")
+}
+
+// TestRunEnrich_TierAwareSkip_ForceReprocesses verifies --force bypasses
+// the tier-aware skip even when the file is Tier-1-complete and no model
+// is configured.
+func TestRunEnrich_TierAwareSkip_ForceReprocesses(t *testing.T) {
+	dir := t.TempDir()
+
+	// Already Tier-1-complete frontmatter.
+	complete := "---\nid: doc\ntitle: Doc\nentity-type: concept\nconfidence: 0.9\n---\nBody.\n"
+	filePath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(filePath, []byte(complete), 0644))
+
+	cmd := newEnrichCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{dir, "--force"})
+
+	enrichDryRun = false
+	enrichForce = true
+	enrichSkipExist = false
+	enrichEndpoint, enrichModel, enrichAPIKey = "", "", ""
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, buf.String(), "Enriched 1 files", "--force must re-process even Tier-1-complete files")
+}
+
 func TestRunEnrich_Force(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
Closes #113

## Summary
`enrich.IsComplete` previously returned true on Tier 1 scalars alone, so any file enriched before a Tier 2 model was configured would be skipped forever on re-runs unless the user discovered `--force`. This change makes `IsComplete` require BOTH tiers, fixing the hostile UX.

## Caller audit
Exhaustive sweep of `IsComplete` usage:
- `internal/cli/enrich.go:235` — gate for the `already complete` skip. This is the bug site. Behavior after fix: Tier-1-only files now fall through to enrichment instead of skipping, which is exactly what we want.
- `enrich/merge_test.go:244` — updated.
- `enrich/merge.go:107` — definition (updated).

No other callers. No surprising impact.

## New semantics
- `IsComplete(fm)` = `tier1Complete(fm) && tier2Complete(fm)`.
- `tier1Complete`: id / title / entity-type / confidence > 0 (unchanged check).
- `tier2Complete`: `fm.Summary != ""`. Summary is the most reliable "Tier 2 ran" signal — the enrich CLI always generates one in the Tier 2 path. Keying on entities/relationships/semantic-relationships would force redundant re-runs on docs that legitimately have none.
- Added `IsCompleteForTier(fm, tier)` with exported `Tier1` / `Tier2` constants for callers that want a single-tier check.

## Plexium API impact
**None.** `IsComplete` is not on the pinned surface list (`index.Load/Reload/Search/Traverse`, `idx.CompactGraphSummary/Get/Pages`, `enrich.EnrichPage/EnrichPageWithModel/EnrichmentDelta`, `embed.NewFromProvider/Embedder`, `markdown.ParseBytesPermissive/ReplaceFrontmatter/WriteFrontmatterFile`, `schema.Page/GraphFrontmatter/Entity/Relationship`). Only addition is two exported symbols (`IsCompleteForTier`, `Tier`/`Tier1`/`Tier2`); `IsComplete`'s signature is unchanged, its semantics are tightened.

## Acceptance criteria
- [x] Tier 2 re-runs no longer skip Tier-1-only files without `--force`.
- [x] Fully-complete files (both tiers) still skip.
- [x] Unit tests cover Tier-1-only / Tier-2-only / both / neither.
- [x] `TestIsComplete` updated; `TestIsCompleteForTier` added.
- [x] `go test ./...` clean (excluding a pre-existing TUI keychain-prompt test that hangs on macOS Keychain access — unrelated to this change).
- [x] `go vet ./...` clean.
- [x] `gofmt -l` clean on the two files changed.
- [x] PR body confirms no pinned Plexium API changed and documents the behavior change.

## Test plan
- [x] `go test ./enrich/...` passes (new + updated tests).
- [x] `go test $(go list ./... | grep -v internal/tui/setup)` passes.
- [ ] Manual: enrich a plain markdown file without a model, re-run with a Tier 2 model configured, confirm the file is no longer skipped.