### PR TITLE
fix: [#128] whitelist valid entity-types and make Tier 2 classification sticky

### DIFF
--- a/enrich/model.go
+++ b/enrich/model.go
@@ -349,9 +349,17 @@ func MergeModelResult(existing schema.GraphFrontmatter, model *ModelResult, opts
 	result := existing
 
 	if opts.Force {
-		if model.EntityType != "" {
-			result.EntityType = strings.ToLower(model.EntityType)
+		// Whitelist + sticky-for-non-default: only accept canonical values, and
+		// preserve any prior non-"document" classification (user or prior
+		// confident run). "document" is the default fallback and may be
+		// promoted. See issue #128.
+		if schema.IsValidEntityType(model.EntityType) {
+			if existing.EntityType == "" || strings.ToLower(existing.EntityType) == "document" {
+				result.EntityType = strings.ToLower(model.EntityType)
+			}
+			// else: keep existing — don't let Tier 2 overwrite a real type.
 		}
+		// else: model returned empty or out-of-whitelist garbage → keep existing.
 		if model.Summary != "" {
 			result.Summary = model.Summary
 		}
@@ -374,8 +382,13 @@ func MergeModelResult(existing schema.GraphFrontmatter, model *ModelResult, opts
 	}
 
 	// Default: fill missing, union arrays.
-	if result.EntityType == "" && model.EntityType != "" {
-		result.EntityType = strings.ToLower(model.EntityType)
+	// Whitelist + sticky-for-non-default: same policy as force branch, see #128.
+	// In default mode the check collapses to "fill if existing is empty or
+	// default (document)" — a real existing type is never overwritten.
+	if schema.IsValidEntityType(model.EntityType) {
+		if result.EntityType == "" || strings.ToLower(result.EntityType) == "document" {
+			result.EntityType = strings.ToLower(model.EntityType)
+		}
 	}
 	if result.Summary == "" && model.Summary != "" {
 		result.Summary = model.Summary

--- a/enrich/model_test.go
+++ b/enrich/model_test.go
@@ -342,7 +342,7 @@ func TestMergeModelResult_Default(t *testing.T) {
 		},
 	}
 	model := &ModelResult{
-		EntityType: "concept", // should NOT override since existing has entity type
+		EntityType: "concept", // "document" default → promotes to "concept" (issue #128)
 		Entities: []schema.Entity{
 			{Name: "Go", Role: "language"},   // duplicate — skip
 			{Name: "Rust", Role: "language"}, // new — add
@@ -356,8 +356,8 @@ func TestMergeModelResult_Default(t *testing.T) {
 
 	result := MergeModelResult(existing, model, MergeOptions{})
 
-	assert.Equal(t, "document", result.EntityType) // preserved
-	assert.Len(t, result.Entities, 2)              // Go + Rust
+	assert.Equal(t, "concept", result.EntityType) // document → concept (default upgrade)
+	assert.Len(t, result.Entities, 2)             // Go + Rust
 	// Tier 2 relationships route into SemanticRelationships (issue #109).
 	assert.Empty(t, result.Relationships, "Tier 2 must not write to Relationships")
 	assert.Len(t, result.SemanticRelationships, 1)
@@ -384,6 +384,81 @@ func TestMergeModelResult_SummaryForce(t *testing.T) {
 	model := &ModelResult{Summary: "New"}
 	result := MergeModelResult(existing, model, MergeOptions{Force: true})
 	assert.Equal(t, "New", result.Summary)
+}
+
+// TestMergeModelResult_EntityType_Whitelist_Sticky covers the three-layer
+// guard introduced for issue #128: whitelist (reject out-of-set), sticky for
+// non-default (don't overwrite user/prior confident type), and default upgrade
+// ("document" → real type accepted).
+func TestMergeModelResult_EntityType_Whitelist_Sticky(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing string
+		model    string
+		force    bool
+		want     string
+	}{
+		// Default (force=false) branch
+		{"empty-existing accepts valid", "", "concept", false, "concept"},
+		{"document upgrades to concept", "document", "concept", false, "concept"},
+		{"non-default sticky preserved", "software", "date", false, "software"},
+		{"non-default sticky even if model is valid", "project", "person", false, "project"},
+		{"invalid model ignored, empty preserved", "", "date", false, ""},
+		{"invalid model ignored, document preserved", "document", "location", false, "document"},
+		{"empty model is no-op", "concept", "", false, "concept"},
+		{"legacy non-whitelist existing stays put", "legacy-type", "concept", false, "legacy-type"},
+		{"case-insensitive model accepted", "document", "CONCEPT", false, "concept"},
+
+		// Force branch — same three-layer policy
+		{"force: empty-existing accepts valid", "", "concept", true, "concept"},
+		{"force: document upgrades to concept", "document", "concept", true, "concept"},
+		{"force: non-default sticky preserved", "software", "date", true, "software"},
+		{"force: non-default sticky even if model valid", "project", "person", true, "project"},
+		{"force: invalid model ignored, software preserved", "software", "date", true, "software"},
+		{"force: empty model is no-op", "concept", "", true, "concept"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			existing := schema.GraphFrontmatter{EntityType: tc.existing}
+			model := &ModelResult{EntityType: tc.model}
+			result := MergeModelResult(existing, model, MergeOptions{Force: tc.force})
+			assert.Equal(t, tc.want, result.EntityType)
+		})
+	}
+}
+
+// TestMergeModelResult_EntityType_RealWorldRegression mirrors the IRL Wave 6
+// observation from issue #128: a file with `entity-type: software` must not
+// be flipped to `date` by Tier 2 NuExtract output, even across --force reruns.
+func TestMergeModelResult_EntityType_RealWorldRegression(t *testing.T) {
+	existing := schema.GraphFrontmatter{
+		ID:         "cli-reference",
+		Title:      "CLI Reference",
+		EntityType: "software",
+		Confidence: 0.9,
+	}
+	// Simulate NuExtract returning garbage type (the IRL failure mode).
+	badModel := &ModelResult{EntityType: "date", Summary: "CLI docs."}
+
+	// Default merge: software preserved.
+	got := MergeModelResult(existing, badModel, MergeOptions{})
+	assert.Equal(t, "software", got.EntityType, "default merge must not flip software→date")
+
+	// Force merge (the user's reproducer): still preserved.
+	gotForce := MergeModelResult(existing, badModel, MergeOptions{Force: true})
+	assert.Equal(t, "software", gotForce.EntityType, "--force must not flip software→date")
+}
+
+func TestIsValidEntityType(t *testing.T) {
+	// Sanity-check the schema helper from the enrich package's perspective.
+	assert.True(t, schema.IsValidEntityType("concept"))
+	assert.True(t, schema.IsValidEntityType("CONCEPT"))
+	assert.True(t, schema.IsValidEntityType("document"))
+	assert.False(t, schema.IsValidEntityType(""))
+	assert.False(t, schema.IsValidEntityType("date"))
+	assert.False(t, schema.IsValidEntityType("location"))
+	assert.False(t, schema.IsValidEntityType("random-garbage"))
 }
 
 func TestMergeModelResult_Force(t *testing.T) {

--- a/schema/entity_types.go
+++ b/schema/entity_types.go
@@ -1,0 +1,47 @@
+package schema
+
+import "strings"
+
+// ValidEntityTypes is the canonical whitelist of document-level entity-type
+// classifications recognized by markedup's enrichment pipeline.
+//
+// Note: schema validation intentionally remains permissive — any non-empty
+// string passes ValidatePage (see validation.go), preserving backward
+// compatibility with user-authored frontmatter. This whitelist gates only
+// automated classification sources (e.g., Tier 2 NuExtract output) to prevent
+// small/quantized models from inventing implausible types like "date" or
+// "location" for unrelated documents. See issue #128.
+//
+// The canonical set covers: the default fallback (document), human-centric
+// (person), work groupings (project, organization), knowledge artifacts
+// (concept, paper), and tools/software (software, tool). event + place
+// accommodate calendar-style and geographic notes. Extend this list when a
+// genuine new category emerges, and keep the NuExtract prompt enum (issue
+// #129) synchronized by consuming this same slice.
+var ValidEntityTypes = []string{
+	"document",
+	"person",
+	"project",
+	"concept",
+	"organization",
+	"software",
+	"event",
+	"place",
+	"tool",
+	"paper",
+}
+
+// IsValidEntityType reports whether t (case-insensitive) is a member of the
+// canonical ValidEntityTypes whitelist. Empty strings return false.
+func IsValidEntityType(t string) bool {
+	if t == "" {
+		return false
+	}
+	lower := strings.ToLower(t)
+	for _, v := range ValidEntityTypes {
+		if v == lower {
+			return true
+		}
+	}
+	return false
+}

--- a/schema/entity_types_test.go
+++ b/schema/entity_types_test.go
@@ -1,0 +1,56 @@
+package schema
+
+import "testing"
+
+func TestIsValidEntityType(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		// Whitelisted values
+		{"document", true},
+		{"person", true},
+		{"project", true},
+		{"concept", true},
+		{"organization", true},
+		{"software", true},
+		{"event", true},
+		{"place", true},
+		{"tool", true},
+		{"paper", true},
+
+		// Case-insensitivity
+		{"Concept", true},
+		{"SOFTWARE", true},
+
+		// Rejections
+		{"", false},
+		{"date", false},
+		{"location", false}, // observed NuExtract hallucination
+		{"random", false},
+		{"documents", false}, // no fuzzy matching
+	}
+	for _, tc := range tests {
+		if got := IsValidEntityType(tc.in); got != tc.want {
+			t.Errorf("IsValidEntityType(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestValidEntityTypes_NonEmpty(t *testing.T) {
+	if len(ValidEntityTypes) == 0 {
+		t.Fatal("ValidEntityTypes must not be empty")
+	}
+	// "document" is required as the default fallback used in MergeModelResult
+	// default-upgrade logic.
+	found := false
+	for _, v := range ValidEntityTypes {
+		if v == "document" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error(`ValidEntityTypes must contain "document" (the default fallback)`)
+	}
+}


### PR DESCRIPTION
Closes #128

## Summary

Tier 2 (NuExtract) document-level `entity-type` classification was unreliable — README got `date`, `cli-reference` flipped between `software`/`concept` across `--force` runs. This gates the classification at the merge site in `enrich.MergeModelResult` (both force and default branches) with a three-layer guard:

1. **Whitelist** — reject values outside a canonical set.
2. **Sticky for non-default** — once a real type is set (by user or a prior confident run), Tier 2 cannot overwrite it.
3. **Default upgrade allowed** — `document` (the Tier 1 fallback) can still be promoted to a real type by the model.

## Whitelist source + placement

- **Location:** `schema/entity_types.go` — `schema.ValidEntityTypes` + `schema.IsValidEntityType(t string) bool`.
- **Rationale:** `enrich` already imports `schema` (no cycle), and issue #129 (prompt enum tightening) can consume the same slice to keep prompt + merge-site lists synchronized.
- **Canonical set:** `document, person, project, concept, organization, software, event, place, tool, paper`.

### Audit findings (for whitelist derivation)

- `schema/validation.go` — `entity-type` required but **free-form**; `docs/schema-reference.md` line 37 explicitly documents "any non-empty string is accepted."
- `testdata/` fixtures use: `concept` (6×), `person` (2×), `project`, `event`, `document`. All covered by the whitelist.
- `internal/cli/` — `--entity-type` filter and `filter_entity_type` MCP param are pass-through string filters; don't imply a canonical list.
- `enrich/model.go` — the existing `DefaultEntityTypes` is for Tier 2 *NER input types* (PERSON/ORGANIZATION/…), a different semantic axis. Left alone.

**Back-compat note:** `schema.ValidatePage` remains permissive — user-authored `entity-type: legacy-type` still validates. The whitelist gates only automated classification. A legacy out-of-whitelist existing value is treated as non-default and preserved (sticky), so existing user files are never rewritten.

## Plexium API impact: none

No pinned signature changed. `MergeModelResult(existing, model, opts)` keeps the same signature. New exports `schema.ValidEntityTypes` and `schema.IsValidEntityType` are additive.

## Acceptance criteria

- [x] `schema.IsValidEntityType` exists and rejects values outside the whitelist
- [x] `MergeModelResult` force AND default branches implement whitelist + sticky + default-upgrade
- [x] Unit tests cover: valid-in-whitelist (accepted), invalid-not-in-whitelist (rejected silently), sticky-non-default (preserved across force run), default-upgrade (`document` → `concept`), empty-model-output (no-op), both force + default branches, case-insensitivity, legacy non-whitelist existing preserved
- [x] Real-world regression test: `entity-type: software` + model returning `date` → result still `software` (both force and default)
- [x] `go test ./...` passes (the pre-existing `internal/tui/setup` `TestKeysStep_NoPrefillNote_WhenNoPrefill` keychain flake is unrelated — not in scope)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on changed files
- [x] PR body confirms no Plexium-pinned API signature changed (see above)
- [x] PR body documents whitelist source + audit findings (see above)

## Test output (relevant)

```
ok  	github.com/Clarit-AI/markedup/enrich	1.004s
ok  	github.com/Clarit-AI/markedup/schema	0.927s
```

New tests in this PR:
- `schema.TestIsValidEntityType` — helper contract (whitelist membership, case-insensitivity, rejections)
- `schema.TestValidEntityTypes_NonEmpty` — invariant: "document" must be present (default-upgrade relies on it)
- `enrich.TestMergeModelResult_EntityType_Whitelist_Sticky` — 15 table-driven cases across force + default branches
- `enrich.TestMergeModelResult_EntityType_RealWorldRegression` — IRL Wave 6 reproducer (`software` + `date` → `software`)
- `enrich.TestIsValidEntityType` — smoke-test from enrich package

Updated `TestMergeModelResult_Default` to match the new `document → concept` promotion policy (was previously asserting the buggy "document preserved" behavior).

## Follow-up

Issue #129 (NuExtract prompt enum tightening) should import `schema.ValidEntityTypes` so the prompt's allowed-type list and the merge-site whitelist stay in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)