### PR TITLE
fix: [#131] accept array-wrapped scalar fields on NuExtract relations

### DIFF
--- a/enrich/nuextract.go
+++ b/enrich/nuextract.go
@@ -545,18 +545,22 @@ func stripJSONFences(s string) string {
 }
 
 type nuextractEntity struct {
-	Name string        `json:"name"`
-	Type nuextractType `json:"type"`
+	Name string          `json:"name"`
+	Type nuextractScalar `json:"type"`
 }
 
-// nuextractType tolerates both string ("PERSON") and array-of-string
-// (["PERSON"]) values for the "type" field. NuExtract's template declares
-// the type enum as an array, and MLX quants occasionally echo the array
-// literal back verbatim instead of selecting a single enum value. We accept
-// either and collapse arrays to their first non-empty string.
-type nuextractType string
+// nuextractScalar tolerates both string ("PERSON") and array-of-string
+// (["PERSON"]) values on any JSON field whose template type is a scalar
+// string. NuExtract's templates declare enum-ish fields (entity type,
+// predicate) as arrays, and MLX / quantized runtimes occasionally echo an
+// array literal back verbatim — or wrap a plain "object"/"subject" string
+// in a singleton array — instead of selecting a single value. We accept
+// either and collapse arrays to their first non-empty string. Used for
+// `entities[].type` (issue #107) and `relationships[].subject/predicate/object`
+// (issue #131).
+type nuextractScalar string
 
-func (t *nuextractType) UnmarshalJSON(data []byte) error {
+func (t *nuextractScalar) UnmarshalJSON(data []byte) error {
 	trimmed := strings.TrimSpace(string(data))
 	if trimmed == "" || trimmed == "null" {
 		*t = ""
@@ -567,7 +571,7 @@ func (t *nuextractType) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(data, &s); err != nil {
 			return err
 		}
-		*t = nuextractType(s)
+		*t = nuextractScalar(s)
 		return nil
 	}
 	if trimmed[0] == '[' {
@@ -575,7 +579,7 @@ func (t *nuextractType) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(data, &arr); err == nil {
 			for _, s := range arr {
 				if strings.TrimSpace(s) != "" {
-					*t = nuextractType(s)
+					*t = nuextractScalar(s)
 					return nil
 				}
 			}
@@ -589,7 +593,7 @@ func (t *nuextractType) UnmarshalJSON(data []byte) error {
 		}
 		for _, v := range anyArr {
 			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
-				*t = nuextractType(s)
+				*t = nuextractScalar(s)
 				return nil
 			}
 		}
@@ -602,9 +606,9 @@ func (t *nuextractType) UnmarshalJSON(data []byte) error {
 }
 
 type nuextractRelation struct {
-	Subject   string `json:"subject"`
-	Predicate string `json:"predicate"`
-	Object    string `json:"object"`
+	Subject   nuextractScalar `json:"subject"`
+	Predicate nuextractScalar `json:"predicate"`
+	Object    nuextractScalar `json:"object"`
 }
 
 func parseNuExtractEntities(content string) ([]schema.Entity, string, error) {
@@ -676,13 +680,14 @@ func entitiesFromRaw(raw []nuextractEntity) ([]schema.Entity, string, error) {
 func relationshipsFromRaw(raw []nuextractRelation) []schema.Relationship {
 	rels := make([]schema.Relationship, 0, len(raw))
 	for _, r := range raw {
-		target := strings.TrimSpace(r.Object)
-		if target == "" || strings.TrimSpace(r.Predicate) == "" {
+		target := strings.TrimSpace(string(r.Object))
+		predicate := strings.TrimSpace(string(r.Predicate))
+		if target == "" || predicate == "" {
 			continue
 		}
 		rels = append(rels, schema.Relationship{
 			Target:   target,
-			Type:     r.Predicate,
+			Type:     predicate,
 			Strength: nuExtractStrength,
 		})
 	}

--- a/enrich/nuextract_repair_test.go
+++ b/enrich/nuextract_repair_test.go
@@ -44,7 +44,7 @@ func TestRepairNuExtractJSON_PatternA_ConcatenatedObjects(t *testing.T) {
 	assert.Equal(t, "LM Studio", parsed.Entities[0].Name)
 	assert.Equal(t, "TECHNOLOGY", string(parsed.Entities[0].Type))
 	require.Len(t, parsed.Relationships, 1)
-	assert.Equal(t, "lmstudio", parsed.Relationships[0].Subject)
+	assert.Equal(t, "lmstudio", string(parsed.Relationships[0].Subject))
 }
 
 // Pattern B — missing colon after key; closing quote present.
@@ -188,8 +188,9 @@ func TestRepairTruncatedTrailingBrace_SkipsBalancedInput(t *testing.T) {
 	assert.Equal(t, string(in), string(got))
 }
 
-// nuextractType must accept both string and array-of-string shapes, and
-// collapse the array to its first non-empty element.
+// nuextractScalar (formerly nuextractType) must accept both string and
+// array-of-string shapes, and collapse the array to its first non-empty
+// element.
 func TestNuextractType_AcceptsStringAndArray(t *testing.T) {
 	var e1 nuextractEntity
 	require.NoError(t, json.Unmarshal([]byte(`{"name":"x","type":"PERSON"}`), &e1))
@@ -206,4 +207,46 @@ func TestNuextractType_AcceptsStringAndArray(t *testing.T) {
 	var e4 nuextractEntity
 	require.NoError(t, json.Unmarshal([]byte(`{"name":"x","type":[]}`), &e4))
 	assert.Equal(t, "", string(e4.Type))
+}
+
+// Issue #131: NuExtract intermittently wraps relationships[].object (and
+// potentially subject/predicate) in a singleton/multi array instead of a
+// bare string. Before the fix, strict unmarshal failed and the entire
+// relationships extraction was dropped. This uses the exact README.md
+// failure payload from the issue and asserts that all 7 relationships
+// with non-empty predicate+object survive parsing, and that the
+// array-wrapped object collapses to its first non-empty element.
+func TestParseNuExtractRelations_Issue131ReadmePayload(t *testing.T) {
+	// Payload modeled after the README.md failure. Seven entries have
+	// non-empty predicate+object (one with array-wrapped object, one with
+	// array-wrapped subject to exercise the symmetry); two have a null
+	// predicate and are expected to be filtered out downstream.
+	payload := `{"relationships": [
+  {"subject": "markedup", "predicate": "uses", "object": "cli-reference"},
+  {"subject": "markedup", "predicate": "relates_to", "object": ["design-graph-reasoning-tool", "design-page-summaries"]},
+  {"subject": "markedup", "predicate": null, "object": "orphan-one"},
+  {"subject": ["markedup", "core"], "predicate": "depends_on", "object": "go"},
+  {"subject": "markedup", "predicate": "mentions", "object": "triplex"},
+  {"subject": "enrich", "predicate": "part_of", "object": "markedup"},
+  {"subject": "cli", "predicate": "uses", "object": "cobra"},
+  {"subject": "docs", "predicate": null, "object": "orphan-two"},
+  {"subject": "wizard", "predicate": "created_by", "object": "claude"}
+]}`
+
+	rels, err := parseNuExtractRelations(payload)
+	require.NoError(t, err, "relationships extraction must succeed despite array-wrapped fields")
+	require.Len(t, rels, 7, "expected 7 surviving relationships (2 dropped for null predicate)")
+
+	// Find the relationship whose target collapsed from the array.
+	// First non-empty element of ["design-graph-reasoning-tool", ...] is
+	// "design-graph-reasoning-tool".
+	var found bool
+	for _, r := range rels {
+		if r.Type == "relates_to" {
+			assert.Equal(t, "design-graph-reasoning-tool", r.Target,
+				"array-wrapped object should collapse to its first non-empty element")
+			found = true
+		}
+	}
+	assert.True(t, found, "expected to find the relates_to relation with collapsed object")
 }


### PR DESCRIPTION
Closes #131.

## Approach

Extends #107 coverage. The NuExtract model intermittently wraps
`relationships[].object` (and by symmetry `subject`/`predicate`) in a
JSON array (`["a", "b"]`) instead of emitting a bare string. Before
this fix, strict unmarshal failed and the entire relationships
extraction was dropped for that file.

- Renamed `nuextractType` → `nuextractScalar` (broader name fits both
  `entities[].type` and relation scalars — the unmarshal logic is
  identical).
- Applied `nuextractScalar` to `nuextractRelation.Subject/Predicate/Object`.
- Updated `relationshipsFromRaw` to cast the scalar to `string` when
  building `schema.Relationship`, so the Plexium-facing
  `schema.Relationship.Target`/`Type` stay typed as `string`.

## Test

New fixture in `enrich/nuextract_repair_test.go` modeled after the
exact README.md failure payload from the issue. Asserts 7
relationships parse (two filtered for null predicate) and the
array-wrapped object collapses to its first non-empty element
(`design-graph-reasoning-tool`).

```
$ go test ./enrich/...
ok  	github.com/Clarit-AI/markedup/enrich	0.472s
$ go vet ./...
$ gofmt -l enrich/nuextract.go enrich/nuextract_repair_test.go
```

All existing #107 tests pass unchanged (one test updated trivially to
`string(parsed.Relationships[0].Subject)` since the field type changed
from `string` to `nuextractScalar`).

## Plexium API impact

None. `nuextractRelation`, `nuextractScalar`, and `nuextractEntity` are
unexported. `schema.Relationship` public fields remain typed as
`string`.