### PR TITLE
fix: [#133] NuExtract Pattern F — missing closing quote on key name

### DIFF
--- a/enrich/nuextract.go
+++ b/enrich/nuextract.go
@@ -264,6 +264,11 @@ func (m *ModelExtractor) nuExtractSingle(ctx context.Context, entityTypes, predi
 //	E. Truncated trailing close: when the payload opens N braces and
 //	   closes only N-1, append a single '}'. We only append one brace —
 //	   deeper truncation is left for the caller's error path.
+//	F. Missing closing quote on the KEY name, e.g. '"type:"VALUE"' —
+//	   parses as string '"type:"' followed by bare token 'VALUE"'. We
+//	   rewrite to '"type":"VALUE"' only for the five known NuExtract keys
+//	   (name / type / subject / predicate / object), and only when the
+//	   sequence is encountered outside of a JSON string value.
 //
 // The function always returns a []byte (never nil); callers can safely
 // pass the result straight to json.Unmarshal.
@@ -278,6 +283,9 @@ func repairNuExtractJSON(raw []byte) []byte {
 
 	// Patterns B + C — missing colon (and/or closing key quote) before '['.
 	out = repairMissingColonBeforeArray(out)
+
+	// Pattern F — missing closing quote on known key names before ':"'.
+	out = repairMissingKeyClosingQuote(out)
 
 	// Pattern D — mismatched '}' where a ']' is expected inside an array.
 	out = repairBracketBraceMismatch(out)
@@ -411,6 +419,132 @@ func repairMissingColonBeforeArray(raw []byte) []byte {
 		return raw
 	}
 	return []byte(s)
+}
+
+// nuExtractKnownKeys is the closed set of JSON keys NuExtract emits. Pattern F
+// only rewrites when the corrupted token exactly matches one of these — we
+// refuse to speculate about arbitrary identifiers because the fix inserts a
+// quote into the byte stream.
+var nuExtractKnownKeys = []string{"name", "type", "subject", "predicate", "object"}
+
+// repairMissingKeyClosingQuote fixes Pattern F: the model drops the closing
+// quote on a KEY name, producing e.g. `"type:"VALUE"` which the JSON parser
+// reads as the string `"type:"` followed by a stray bare word. The target
+// rewrite is `"type:"` → `"type":"` — insert the missing closing quote
+// between the key name and the colon that's already followed by an opening
+// quote.
+//
+// The walker is string-aware (tracks JSON string context with escape
+// handling) so a value that legitimately contains the substring
+// (e.g. `{"desc":"See \"type:\" docs"}`) is left untouched. We also require
+// brace depth >= 1 to skip any speculative match at the document root.
+func repairMissingKeyClosingQuote(raw []byte) []byte {
+	if len(raw) == 0 {
+		return raw
+	}
+	// Quick reject: if no ':"' sequence exists, nothing to do.
+	if !strings.Contains(string(raw), `:"`) {
+		return raw
+	}
+	out := make([]byte, 0, len(raw)+8)
+	depth := 0
+	inStr := false
+	escape := false
+	i := 0
+	for i < len(raw) {
+		c := raw[i]
+		if inStr {
+			out = append(out, c)
+			if escape {
+				escape = false
+				i++
+				continue
+			}
+			if c == '\\' {
+				escape = true
+				i++
+				continue
+			}
+			if c == '"' {
+				inStr = false
+			}
+			i++
+			continue
+		}
+		switch c {
+		case '"':
+			// Candidate start of either a string value or a malformed key.
+			// Try to match `"<known-key>:"` exactly at this position while
+			// we're outside of a string and at depth >= 1.
+			if depth >= 1 {
+				if matched, keyLen := matchKnownKeyPatternF(raw, i); matched {
+					// raw[i .. i+1+keyLen+2] is `"<key>:"` — rewrite to
+					// `"<key>":"` by emitting an extra '"' before the ':'.
+					// Layout in source: '"' keyLen bytes ':' '"'
+					// Layout in output: '"' keyLen bytes '"' ':' '"'
+					out = append(out, '"')
+					out = append(out, raw[i+1:i+1+keyLen]...)
+					out = append(out, '"', ':', '"')
+					i += 1 + keyLen + 2
+					// The trailing '"' we just emitted opens the VALUE
+					// string. Enter string context so its contents — and
+					// its closing '"' — are handled correctly.
+					inStr = true
+					continue
+				}
+			}
+			// Not a Pattern F match — enter a regular JSON string.
+			out = append(out, c)
+			inStr = true
+			i++
+			continue
+		case '{', '[':
+			depth++
+			out = append(out, c)
+			i++
+			continue
+		case '}', ']':
+			if depth > 0 {
+				depth--
+			}
+			out = append(out, c)
+			i++
+			continue
+		default:
+			out = append(out, c)
+			i++
+		}
+	}
+	// If we never rewrote anything the outputs are byte-equal; return the
+	// original slice so callers (and tests) see true identity for clean
+	// inputs.
+	if len(out) == len(raw) {
+		return raw
+	}
+	return out
+}
+
+// matchKnownKeyPatternF checks whether raw[i:] begins with the exact byte
+// sequence `"<known-key>:"` for one of the NuExtract keys. On a match it
+// returns (true, len(key)); otherwise (false, 0). The caller has already
+// verified raw[i] == '"'.
+func matchKnownKeyPatternF(raw []byte, i int) (bool, int) {
+	for _, key := range nuExtractKnownKeys {
+		// Need room for: '"' + key + ':' + '"' == len(key)+3 bytes after i.
+		end := i + 1 + len(key) + 2
+		if end > len(raw) {
+			continue
+		}
+		// raw[i] is '"' (caller checked). Compare key bytes.
+		if string(raw[i+1:i+1+len(key)]) != key {
+			continue
+		}
+		if raw[i+1+len(key)] != ':' || raw[i+1+len(key)+1] != '"' {
+			continue
+		}
+		return true, len(key)
+	}
+	return false, 0
 }
 
 // repairBracketBraceMismatch fixes Pattern D: a `}` appears where the

--- a/enrich/nuextract_repair_test.go
+++ b/enrich/nuextract_repair_test.go
@@ -19,6 +19,12 @@ func TestRepairNuExtractJSON_ValidUnchanged(t *testing.T) {
 		`{"relationships":[]}`,
 		`{"entities":[{"name":"LM Studio","type":["TECHNOLOGY"]}]}`,
 		`{"entities":[{"name":"Dr. }]{ Chen","type":"PERSON"}]}`, // braces inside a string value — must not fool the repairer.
+		// Pattern F regression guard: the substring `"type:"` appears
+		// INSIDE a JSON string value (escaped quotes unescape to
+		// `See "type:" docs`). The walker must not rewrite it, because
+		// doing so would corrupt a legitimate value. Also exercises the
+		// escape-handling path of the string-aware walker.
+		`{"entities":[{"name":"x","type":"PERSON"}],"notes":"See \"type:\" docs and \"subject:\" notes"}`,
 	}
 	for _, in := range inputs {
 		got := repairNuExtractJSON([]byte(in))
@@ -108,6 +114,45 @@ func TestRepairNuExtractJSON_PatternE_TruncatedTrailingBrace(t *testing.T) {
 	assert.Equal(t, "system", parsed.Entities[3].Name)
 }
 
+// Pattern F — the closing quote on the KEY name got eaten, producing
+// `"type:"VALUE"` which JSON parses as string `"type:"` plus a stray bare
+// token. Uses the exact IRL payload from issue #133.
+func TestRepairNuExtractJSON_PatternF_MissingKeyClosingQuote(t *testing.T) {
+	bad := `{"entities":[{"name":"markedup_search","type:"TECHNOLOGY"}, {"name":"markedup_traverse","type:"TECHNOLOGY"}]}`
+	got := repairNuExtractJSON([]byte(bad))
+
+	var parsed struct {
+		Entities []nuextractEntity `json:"entities"`
+	}
+	require.NoError(t, json.Unmarshal(got, &parsed),
+		"repaired payload must be valid JSON: %s", string(got))
+	require.Len(t, parsed.Entities, 2)
+	assert.Equal(t, "markedup_search", parsed.Entities[0].Name)
+	assert.Equal(t, "TECHNOLOGY", string(parsed.Entities[0].Type))
+	assert.Equal(t, "markedup_traverse", parsed.Entities[1].Name)
+	assert.Equal(t, "TECHNOLOGY", string(parsed.Entities[1].Type))
+}
+
+// Pattern F coverage across all five known keys. Each fixture has exactly
+// one corrupted key; the repair must restore every one.
+func TestRepairNuExtractJSON_PatternF_AllKnownKeys(t *testing.T) {
+	cases := map[string]string{
+		"name":      `{"entities":[{"name:"x","type":"PERSON"}]}`,
+		"type":      `{"entities":[{"name":"x","type:"PERSON"}]}`,
+		"subject":   `{"relationships":[{"subject:"a","predicate":"uses","object":"b"}]}`,
+		"predicate": `{"relationships":[{"subject":"a","predicate:"uses","object":"b"}]}`,
+		"object":    `{"relationships":[{"subject":"a","predicate":"uses","object:"b"}]}`,
+	}
+	for key, bad := range cases {
+		t.Run(key, func(t *testing.T) {
+			got := repairNuExtractJSON([]byte(bad))
+			var v any
+			require.NoError(t, json.Unmarshal(got, &v),
+				"repaired payload must be valid JSON for key=%s: %s", key, string(got))
+		})
+	}
+}
+
 // End-to-end: parseNuExtractEntities must recover entities from each
 // malformed payload rather than erroring out. Covers the real caller path
 // including stripJSONFences + repair + Unmarshal.
@@ -131,6 +176,10 @@ func TestParseNuExtractEntities_ToleratesAllPatterns(t *testing.T) {
 		"patternD_IRL1": {
 			raw:       `{"entities":[{"name":"markedup", "type":["TECHNOLOGY"]}, {"name":"Go Library Usage Guide", "type":["CONCEPT"}]}`,
 			wantNames: []string{"markedup", "Go Library Usage Guide"},
+		},
+		"patternF_IRL": {
+			raw:       `{"entities":[{"name":"markedup_search","type:"TECHNOLOGY"}, {"name":"markedup_traverse","type:"TECHNOLOGY"}]}`,
+			wantNames: []string{"markedup_search", "markedup_traverse"},
 		},
 		"patternE_IRL2": {
 			raw:       `{"entities":[{"name":"Alice Chen","type":"person","confidence":0.95,"alias":["alice", "Dr. Chen"]}, {"name":"bob","type":"person","confidence":1.0,"alias":["colleague"]}, {"name":"concept-graph","type":"project","confidence":1.0,"alias":["studies"]}, {"name":"system", "type":"person", "confidence":1.0}]`,
@@ -168,6 +217,7 @@ func TestRepairSubpasses_NoOpOnUnrelatedInput(t *testing.T) {
 	clean := []byte(`{"entities":[{"name":"A","type":"PERSON"}]}`)
 	assert.Equal(t, string(clean), string(repairConcatenatedObjects(clean)))
 	assert.Equal(t, string(clean), string(repairMissingColonBeforeArray(clean)))
+	assert.Equal(t, string(clean), string(repairMissingKeyClosingQuote(clean)))
 	assert.Equal(t, string(clean), string(repairBracketBraceMismatch(clean)))
 	assert.Equal(t, string(clean), string(repairTruncatedTrailingBrace(clean)))
 }


### PR DESCRIPTION
Closes #133

## Problem

NuExtract occasionally emits `"type:"VALUE"` where the closing quote on the KEY got eaten. JSON then parses `"type:"` as a string followed by a bare token, erroring with `invalid character 'T' after object key`.

IRL payload from today's test run:
```
{"entities":[{"name":"markedup_search","type:"TECHNOLOGY"}, {"name":"markedup_traverse","type:"TECHNOLOGY"}]}
```

## Approach

Add `repairMissingKeyClosingQuote` as a new sub-pass in the `repairNuExtractJSON` pipeline, wired between Patterns B/C and Pattern D.

- Conservative scope — only triggers on NuExtract's five known keys: `name`, `type`, `subject`, `predicate`, `object`.
- Only triggers at brace depth >= 1.
- Uses a string-aware walker (with escape handling) that mirrors the style of `repairConcatenatedObjects` and `repairBracketBraceMismatch` — a legitimate value containing the substring `"type:"` (e.g. `"See \"type:\" docs"`) is left untouched.
- Rewrites the exact 8+ byte span `"<key>:"` to `"<key>":"` and flips the walker into string context so the VALUE string's closing quote is consumed correctly on the next iteration.

## Tests

- `TestRepairNuExtractJSON_PatternF_MissingKeyClosingQuote` — exact IRL payload, asserts 2 entities with `type="TECHNOLOGY"`
- `TestRepairNuExtractJSON_PatternF_AllKnownKeys` — coverage across all five known keys
- `TestRepairNuExtractJSON_ValidUnchanged` extended with a string-value regression fixture containing escaped `\"type:\"` and `\"subject:\"` — must pass through unchanged
- `TestParseNuExtractEntities_ToleratesAllPatterns` extended with a `patternF_IRL` case (end-to-end)
- `TestRepairSubpasses_NoOpOnUnrelatedInput` extended with the new sub-pass

## Test output

```
$ go test ./enrich/...
ok  	github.com/Clarit-AI/markedup/enrich	0.193s

$ go vet ./...    # clean
$ gofmt -l enrich/nuextract.go enrich/nuextract_repair_test.go   # clean
```

All existing Pattern A–E tests pass unchanged.

## Plexium API impact

None — `repairNuExtractJSON` and all its sub-passes are unexported.