### PR TITLE
feat: [#115 #116] wizard reconfigure mode — jump-to-section + pre-fill

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -285,6 +285,11 @@ func (m Model) updateHome(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.wizard = setup.NewWizardModel()
 				m.wizard.SetEmbedded(true)
 				m.wizard.SetSize(m.width, m.height)
+				// Reconfigure mode (#115/#116): pass the loaded config so the
+				// wizard shows a section menu and pre-fills inputs.
+				if m.cfg != nil {
+					m.wizard.SetReconfigure(m.cfg)
+				}
 				m.current = viewSetup
 				return m, m.wizard.Init()
 			}

--- a/internal/tui/setup/steps.go
+++ b/internal/tui/setup/steps.go
@@ -247,6 +247,70 @@ func newProviderStep(title, desc string, detected []config.Endpoint, filterType 
 	}
 }
 
+// newProviderStepWithCurrent is a reconfigure-mode variant of newProviderStep
+// (issue #116) that pre-fills the model input with the user's currently-
+// configured model for this service. If the current endpoint matches one of the
+// detected/cloud choices, the cursor is positioned on it so Enter pre-fills
+// both endpoint AND model. Otherwise the cursor lands on "Custom endpoint" and
+// the endpoint input is pre-filled with the current value.
+//
+// When current.Endpoint is "" the function behaves exactly like newProviderStep
+// — callers can safely call this in first-run mode too.
+func newProviderStepWithCurrent(title, desc string, detected []config.Endpoint, filterType string, optional bool, showFormat bool, current config.ServiceConfig) providerStep {
+	p := newProviderStep(title, desc, detected, filterType, optional, showFormat)
+	if current.Endpoint == "" && current.Model == "" {
+		return p
+	}
+
+	// Always seed the model input with the current model so it's the default
+	// suggestion when the user enters phase 2.
+	if current.Model != "" {
+		p.modelIn.SetValue(current.Model)
+		p.selected.Model = current.Model
+	}
+	if current.Endpoint != "" {
+		p.selected.Endpoint = current.Endpoint
+	}
+
+	// Try to position the cursor on a choice that matches the current endpoint.
+	matched := false
+	for i, c := range p.choices {
+		if c.endpoint != "" && c.endpoint == current.Endpoint {
+			p.cursor = i
+			matched = true
+			break
+		}
+	}
+	if !matched && current.Endpoint != "" {
+		// No preset matches — point at "Custom endpoint" and pre-fill the
+		// endpoint input so Enter on Custom shows the current value.
+		for i, c := range p.choices {
+			if c.kind == "custom" {
+				p.cursor = i
+				break
+			}
+		}
+		p.endpointIn.SetValue(current.Endpoint)
+	}
+
+	return p
+}
+
+// newTriplexStepWithCurrent is a reconfigure-mode variant of newTriplexStep
+// (issue #116) that pre-fills the endpoint and model inputs with the user's
+// currently-configured extractor (Triplex or NuExtract). If both are empty the
+// function falls back to newTriplexStep's defaults.
+func newTriplexStepWithCurrent(detected []config.Endpoint, current config.ServiceConfig) triplexStep {
+	t := newTriplexStep(detected)
+	if current.Endpoint != "" {
+		t.endpointIn.SetValue(current.Endpoint)
+	}
+	if current.Model != "" {
+		t.modelIn.SetValue(current.Model)
+	}
+	return t
+}
+
 // looksLikeEmbedModel returns true if the model name contains patterns that
 // indicate it is an embedding model (rather than a generative LLM).
 func looksLikeEmbedModel(name string) bool {

--- a/internal/tui/setup/wizard.go
+++ b/internal/tui/setup/wizard.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -38,15 +39,32 @@ func Run() (*config.Config, error) {
 	return wm.config, nil
 }
 
+// stepSectionMenu is the synthetic step index used in reconfigure mode (issues
+// #115/#116) for the jump-to-section menu. It sits between welcome (0) and the
+// concrete edit steps (1..6). Picking a menu entry sets m.step to the chosen
+// edit step; ESC inside an edit step returns here instead of popping back
+// through linear history.
+const stepSectionMenu = 100
+
 // WizardModel is the root BubbleTea model for the 7-step setup wizard.
 type WizardModel struct {
-	step         int   // 0=welcome, 1=embed, 2=llm, 3=rerank, 4=triplex, 5=keys, 6=confirm
+	step         int   // 0=welcome, 1=embed, 2=llm, 3=rerank, 4=triplex, 5=keys, 6=confirm, 100=section menu (reconfigure)
 	stepHistory  []int // stack of previous step indices for Esc back-navigation
 	config       *config.Config
 	detected     []config.Endpoint
 	cancelled    bool
 	width        int
 	height       int
+
+	// Reconfigure mode (issues #115 + #116). Enabled via SetReconfigure when
+	// the wizard is launched from the home Settings menu rather than first-run.
+	// In this mode the welcome/detect step is followed by a section menu
+	// instead of the linear walkthrough; each section reads its initial values
+	// from currentConfig and ESC after editing returns to the menu.
+	reconfigure   bool
+	currentConfig *config.Config
+	currentFormat string // current rerank format (cfg.Rerank.Format) for pre-fill
+	sectionCursor int    // selected entry in the section menu
 
 	// Sub-models for each step.
 	welcome  welcomeStep
@@ -112,6 +130,27 @@ func (m WizardModel) CollectedKeys() map[string]string { return m.keys.collected
 // When embedded, Esc at step 0 sets cancelled without sending tea.Quit.
 func (m *WizardModel) SetEmbedded(v bool) { m.embedded = v }
 
+// SetReconfigure enables reconfigure mode (issues #115 + #116). The wizard
+// will show a jump-to-section menu after the welcome step, pre-filling each
+// step's inputs from cfg. Pass nil cfg to disable. Must be called before Init.
+func (m *WizardModel) SetReconfigure(cfg *config.Config) {
+	if cfg == nil {
+		m.reconfigure = false
+		m.currentConfig = nil
+		return
+	}
+	m.reconfigure = true
+	m.currentConfig = cfg
+	m.currentFormat = cfg.Rerank.Format
+	// Seed the working config so any sections the user does NOT visit retain
+	// their existing values when the wizard saves.
+	cfgCopy := *cfg
+	m.config = &cfgCopy
+}
+
+// Reconfigure returns true when the wizard is in reconfigure mode.
+func (m WizardModel) Reconfigure() bool { return m.reconfigure }
+
 // SetSize sets the width and height for the wizard model.
 func (m *WizardModel) SetSize(w, h int) {
 	m.width = w
@@ -121,6 +160,111 @@ func (m *WizardModel) SetSize(w, h int) {
 // Init implements tea.Model.
 func (m WizardModel) Init() tea.Cmd {
 	return m.welcome.Init()
+}
+
+// viewSectionMenu renders the reconfigure-mode jump-to-section menu (issue
+// #115). Each entry shows the section name plus a one-line summary of the
+// current value so the user can decide what to edit at a glance.
+func (m WizardModel) viewSectionMenu(width int) string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Width(width).Render("Settings — choose a section to edit"))
+	b.WriteString("\n\n")
+	b.WriteString(mutedStyle.Render("Tab/↑↓: navigate  |  Enter: edit section  |  Esc: cancel  |  Ctrl+C: cancel"))
+	b.WriteString("\n\n")
+
+	entries := m.sectionMenuEntries()
+	cur := m.currentConfig
+	if cur == nil {
+		cur = &config.Config{}
+	}
+
+	for i, entry := range entries {
+		prefix := "  "
+		style := subtitleStyle
+		if i == m.sectionCursor {
+			prefix = "> "
+			style = selectedStyle
+		}
+		b.WriteString(style.Render(prefix + entry.label))
+		// Append a one-line current-value summary.
+		summary := ""
+		switch entry.target {
+		case 1:
+			summary = serviceSummary(cur.Embed)
+		case 2:
+			summary = serviceSummary(cur.LLM)
+		case 3:
+			summary = serviceSummary(cur.Rerank.ServiceConfig)
+			if summary != "" && cur.Rerank.Format != "" {
+				summary += "  (" + cur.Rerank.Format + ")"
+			}
+		case 4:
+			switch {
+			case cur.NuExtract.Endpoint != "":
+				summary = serviceSummary(cur.NuExtract.ServiceConfig)
+			case cur.Triplex.Endpoint != "":
+				summary = serviceSummary(cur.Triplex)
+			}
+		case 5:
+			if config.KeyringAvailable() {
+				summary = "stored in OS keychain"
+			} else {
+				summary = "set via env vars"
+			}
+		case 6:
+			summary = "write changes to " + config.GlobalPath()
+		}
+		if summary != "" {
+			b.WriteString("  ")
+			b.WriteString(mutedStyle.Render("— " + summary))
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// serviceSummary returns a compact "model @ endpoint" summary or "(not
+// configured)" when both fields are empty.
+func serviceSummary(s config.ServiceConfig) string {
+	if s.Endpoint == "" && s.Model == "" {
+		return mutedStyle.Render("(not configured)")
+	}
+	if s.Model == "" {
+		return s.Endpoint
+	}
+	if s.Endpoint == "" {
+		return s.Model
+	}
+	return s.Model + " @ " + s.Endpoint
+}
+
+// sectionEntry describes one row in the reconfigure-mode jump-to-section menu.
+type sectionEntry struct {
+	label  string
+	target int // wizard step to jump to
+}
+
+// sectionMenuEntries returns the section list for reconfigure mode. The list
+// adapts to the current config: when an extractor is configured the entry is
+// labeled "NuExtract" or "Triplex"; otherwise "Extractor".
+func (m WizardModel) sectionMenuEntries() []sectionEntry {
+	extractorLabel := "Extractor (NuExtract / Triplex)"
+	if m.currentConfig != nil {
+		switch {
+		case m.currentConfig.NuExtract.Endpoint != "":
+			extractorLabel = "NuExtract"
+		case m.currentConfig.Triplex.Endpoint != "":
+			extractorLabel = "Triplex"
+		}
+	}
+	return []sectionEntry{
+		{label: "Embed", target: 1},
+		{label: "LLM", target: 2},
+		{label: "Rerank", target: 3},
+		{label: extractorLabel, target: 4},
+		{label: "API Keys", target: 5},
+		{label: "Save & Exit", target: 6},
+	}
 }
 
 // Update implements tea.Model.
@@ -163,9 +307,156 @@ func (m WizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateKeys(msg)
 	case 6:
 		return m.updateConfirm(msg)
+	case stepSectionMenu:
+		return m.updateSectionMenu(msg)
 	}
 
 	return m, nil
+}
+
+// updateSectionMenu handles input in the reconfigure-mode jump-to-section menu.
+func (m WizardModel) updateSectionMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	entries := m.sectionMenuEntries()
+	switch keyMsg.String() {
+	case "up", "shift+tab":
+		if m.sectionCursor > 0 {
+			m.sectionCursor--
+		}
+	case "down", "tab":
+		if m.sectionCursor < len(entries)-1 {
+			m.sectionCursor++
+		}
+	case "enter":
+		target := entries[m.sectionCursor].target
+		return m.enterSection(target)
+	}
+	return m, nil
+}
+
+// enterSection initializes the chosen section's sub-model with values pre-
+// filled from m.currentConfig and jumps to it.
+func (m WizardModel) enterSection(target int) (tea.Model, tea.Cmd) {
+	cur := m.currentConfig
+	if cur == nil {
+		cur = &config.Config{}
+	}
+	switch target {
+	case 1: // Embed
+		m.embed = newProviderStepWithCurrent(
+			"Choose a text embedding model",
+			"Converts text to vectors for similarity search\ne.g. nomic-embed-text (local), text-embedding-3-small (OpenAI)",
+			m.detected, "embed", false, false, cur.Embed,
+		)
+		m.step = 1
+		return m, nil
+	case 2: // LLM
+		m.llm = newProviderStepWithCurrent(
+			"LLM Provider",
+			"Choose an LLM endpoint for enrichment and reasoning.\ne.g. granite-3.1-dense:2b (local), gpt-4o-mini (cloud)",
+			m.detected, "llm", false, false, cur.LLM,
+		)
+		m.step = 2
+		return m, nil
+	case 3: // Rerank
+		m.rerank = newProviderStepWithCurrent(
+			"Reranker (optional)",
+			"Configure a reranker model to improve search quality by re-scoring results.\ne.g. bge-reranker-v2-m3 (local TEI), jina-reranker-v2-base-multilingual (cloud)",
+			m.detected, "rerank", true, true, cur.Rerank.ServiceConfig,
+		)
+		// Pre-select the existing rerank format if configured.
+		if m.currentFormat != "" {
+			for i, f := range rerankFormats {
+				if f == m.currentFormat {
+					m.rerank.formatIdx = i
+					break
+				}
+			}
+		}
+		m.step = 3
+		return m, nil
+	case 4: // Extractor
+		// Use whichever extractor block is currently populated; NuExtract takes
+		// precedence (it's the newer config path).
+		var extractorCfg config.ServiceConfig
+		switch {
+		case cur.NuExtract.Endpoint != "":
+			extractorCfg = cur.NuExtract.ServiceConfig
+		case cur.Triplex.Endpoint != "":
+			extractorCfg = cur.Triplex
+		}
+		m.triplex = newTriplexStepWithCurrent(m.detected, extractorCfg)
+		m.step = 4
+		return m, textinput.Blink
+	case 5: // Keys
+		// Keys step needs label/endpoint metadata for each configured service.
+		// Derive from the current config.
+		needEmbed := cur.Embed.Endpoint != "" && needsKeyForEndpoint(cur.Embed.Endpoint)
+		needLLM := cur.LLM.Endpoint != "" && needsKeyForEndpoint(cur.LLM.Endpoint)
+		needRerank := cur.Rerank.Endpoint != "" && needsKeyForEndpoint(cur.Rerank.Endpoint)
+		var extractorEndpoint, extractorService string
+		switch {
+		case cur.NuExtract.Endpoint != "":
+			extractorEndpoint = cur.NuExtract.Endpoint
+			extractorService = "nuextract"
+		case cur.Triplex.Endpoint != "":
+			extractorEndpoint = cur.Triplex.Endpoint
+			extractorService = "triplex"
+		}
+		needExtractor := extractorEndpoint != "" && needsKeyForEndpoint(extractorEndpoint)
+		if !needEmbed && !needLLM && !needRerank && !needExtractor {
+			// Nothing to collect — return immediately to the menu.
+			return m, nil
+		}
+		m.keys = newKeysStep(
+			needEmbed, providerLabelForEndpoint(cur.Embed.Endpoint), cur.Embed.Endpoint,
+			needLLM, providerLabelForEndpoint(cur.LLM.Endpoint), cur.LLM.Endpoint,
+			needRerank, providerLabelForEndpoint(cur.Rerank.Endpoint), cur.Rerank.Endpoint,
+			needExtractor, providerLabelForEndpoint(extractorEndpoint), extractorEndpoint,
+			extractorService,
+		)
+		m.step = 5
+		return m, m.keys.Init()
+	case 6: // Save & Exit (reuse confirm step)
+		format := m.currentFormat
+		if m.config.Rerank.Format != "" {
+			format = m.config.Rerank.Format
+		}
+		// Carry over any keys collected via the Keys section so they get
+		// written to the keyring on save.
+		m.confirm = newConfirmStep(m.config, format, m.keys.collectedKeys)
+		m.step = 6
+		return m, nil
+	}
+	return m, nil
+}
+
+// needsKeyForEndpoint returns true when the endpoint is a remote URL that
+// typically requires an API key (i.e. not localhost/127.0.0.1).
+func needsKeyForEndpoint(endpoint string) bool {
+	if endpoint == "" {
+		return false
+	}
+	lower := strings.ToLower(endpoint)
+	return !strings.Contains(lower, "localhost") && !strings.Contains(lower, "127.0.0.1")
+}
+
+// providerLabelForEndpoint returns a human-readable label for the API key
+// input based on the endpoint URL. Falls back to "Custom" when the URL does
+// not match a known cloud preset.
+func providerLabelForEndpoint(endpoint string) string {
+	for _, c := range cloudProviders {
+		if c.endpoint == endpoint {
+			return c.label
+		}
+	}
+	if endpoint == "" {
+		return "API"
+	}
+	return "Custom"
 }
 
 func (m WizardModel) handleEsc() (tea.Model, tea.Cmd) {
@@ -185,6 +476,22 @@ func (m WizardModel) handleEsc() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	// case 4 (triplex): no sub-phases, fall through to pop history
+	}
+
+	// Reconfigure mode (issue #115): ESC inside an edit step returns to the
+	// section menu. ESC at the section menu cancels back to home.
+	if m.reconfigure {
+		if m.step == stepSectionMenu {
+			m.cancelled = true
+			if m.embedded {
+				return m, nil
+			}
+			return m, tea.Quit
+		}
+		if m.step >= 1 && m.step <= 6 {
+			m.step = stepSectionMenu
+			return m, nil
+		}
 	}
 
 	// Step 0 (welcome): Esc exits cleanly.
@@ -215,6 +522,13 @@ func (m WizardModel) updateWelcome(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Handle Enter to advance when detection is done.
 	if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "enter" && !m.welcome.detecting {
 		m.detected = m.welcome.detected
+		// Reconfigure mode (issue #115): show jump-to-section menu instead of
+		// the linear walkthrough. First-run flow is unchanged.
+		if m.reconfigure {
+			m.stepHistory = append(m.stepHistory, m.step)
+			m.step = stepSectionMenu
+			return m, nil
+		}
 		m.embed = newProviderStep(
 			"Choose a text embedding model",
 			"Converts text to vectors for similarity search\ne.g. nomic-embed-text (local), text-embedding-3-small (OpenAI)",
@@ -239,6 +553,10 @@ func (m WizardModel) updateEmbed(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.needEmbedKey = m.embed.needsKey
 		m.embedEndpoint = m.embed.selected.Endpoint
 		m.embedProviderLabel = m.embed.selectedProviderLabel()
+		if m.reconfigure {
+			m.step = stepSectionMenu
+			return m, nil
+		}
 		m.llm = newProviderStep(
 			"LLM Provider",
 			"Choose an LLM endpoint for enrichment and reasoning.\ne.g. granite-3.1-dense:2b (local), gpt-4o-mini (cloud)",
@@ -261,6 +579,10 @@ func (m WizardModel) updateLLM(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.needLLMKey = m.llm.needsKey
 		m.llmEndpoint = m.llm.selected.Endpoint
 		m.llmProviderLabel = m.llm.selectedProviderLabel()
+		if m.reconfigure {
+			m.step = stepSectionMenu
+			return m, nil
+		}
 		m.rerank = newProviderStep(
 			"Reranker (optional)",
 			"Configure a reranker model to improve search quality by re-scoring results.\ne.g. bge-reranker-v2-m3 (local TEI), jina-reranker-v2-base-multilingual (cloud)",
@@ -286,6 +608,11 @@ func (m WizardModel) updateRerank(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.needRerankKey = m.rerank.needsKey
 		m.rerankEndpoint = m.rerank.selected.Endpoint
 		m.rerankProviderLabel = m.rerank.selectedProviderLabel()
+		if m.reconfigure {
+			m.currentFormat = m.rerank.formatVal
+			m.step = stepSectionMenu
+			return m, nil
+		}
 		m.stepHistory = append(m.stepHistory, m.step)
 
 		// Advance to Triplex step (step 4).
@@ -336,6 +663,11 @@ func (m WizardModel) updateTriplex(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.extractorService = ""
 		}
 
+		if m.reconfigure {
+			m.step = stepSectionMenu
+			return m, nil
+		}
+
 		m.stepHistory = append(m.stepHistory, m.step)
 
 		// Skip keys step if no cloud providers selected.
@@ -370,6 +702,10 @@ func (m WizardModel) updateKeys(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.keys, cmd = m.keys.Update(msg)
 
 	if m.keys.done {
+		if m.reconfigure {
+			m.step = stepSectionMenu
+			return m, nil
+		}
 		m.confirm = newConfirmStep(m.config, m.rerank.formatVal, m.keys.collectedKeys)
 		m.stepHistory = append(m.stepHistory, m.step)
 		m.step = 6
@@ -456,13 +792,22 @@ func (m WizardModel) View() string {
 		width = 80
 	}
 
+	// Reconfigure-mode section menu (issue #115).
+	if m.step == stepSectionMenu {
+		return m.viewSectionMenu(width)
+	}
+
 	// Step indicator.
 	steps := []string{"Welcome", "Embed", "LLM", "Rerank", "Triplex", "Keys", "Confirm"}
 	stepLine := ""
+	stepIdx := m.step
+	if stepIdx < 0 || stepIdx > 6 {
+		stepIdx = 0
+	}
 	for i, name := range steps {
-		if i == m.step {
+		if i == stepIdx {
 			stepLine += selectedStyle.Render(fmt.Sprintf("[%s]", name))
-		} else if i < m.step {
+		} else if i < stepIdx {
 			stepLine += successStyle.Render(fmt.Sprintf("[%s]", name))
 		} else {
 			stepLine += mutedStyle.Render(fmt.Sprintf("[%s]", name))
@@ -472,6 +817,9 @@ func (m WizardModel) View() string {
 		}
 	}
 	view := stepLine + "\n\n"
+	if m.reconfigure {
+		view += mutedStyle.Render("Reconfigure mode — Esc returns to section menu") + "\n\n"
+	}
 
 	switch m.step {
 	case 0:

--- a/internal/tui/setup/wizard_test.go
+++ b/internal/tui/setup/wizard_test.go
@@ -761,3 +761,252 @@ func TestNewKeysStep_DedupesByEndpoint_Issue117(t *testing.T) {
 	}
 	assert.Len(t, written, 1, "issue #117: exactly one keyring write per shared endpoint")
 }
+
+// ---------------------------------------------------------------------------
+// Reconfigure-mode tests (issues #115 + #116)
+// ---------------------------------------------------------------------------
+
+func sampleCurrentConfig() *config.Config {
+	return &config.Config{
+		Embed: config.ServiceConfig{Endpoint: "http://localhost:11434", Model: "nomic-embed-text"},
+		LLM:   config.ServiceConfig{Endpoint: "https://openrouter.ai/api", Model: "openai/gpt-4o-mini"},
+		Rerank: config.RerankConfig{
+			ServiceConfig: config.ServiceConfig{Endpoint: "https://api.openai.com", Model: "rerank-v1"},
+			Format:        "openai",
+		},
+		Triplex: config.ServiceConfig{Endpoint: "http://localhost:11434", Model: "Phi-3-mini-128k-instruct/triplex"},
+	}
+}
+
+func TestProviderStepWithCurrent_PreFillsModelAndCursorOnDetected(t *testing.T) {
+	detected := []config.Endpoint{
+		{Name: "Ollama", URL: "http://localhost:11434", Type: "multi", Models: []string{"nomic-embed-text"}},
+	}
+	current := config.ServiceConfig{Endpoint: "http://localhost:11434", Model: "nomic-embed-text"}
+
+	ps := newProviderStepWithCurrent("Embed", "", detected, "embed", false, false, current)
+
+	// Cursor should land on the detected endpoint that matches the current config.
+	assert.Equal(t, "detected", ps.choices[ps.cursor].kind)
+	assert.Equal(t, "http://localhost:11434", ps.choices[ps.cursor].endpoint)
+	// Model input should be pre-seeded with the current model.
+	assert.Equal(t, "nomic-embed-text", ps.modelIn.Value())
+	assert.Equal(t, "nomic-embed-text", ps.selected.Model)
+}
+
+func TestProviderStepWithCurrent_PreFillsCloudPreset(t *testing.T) {
+	current := config.ServiceConfig{Endpoint: "https://openrouter.ai/api", Model: "openai/gpt-4o-mini"}
+
+	ps := newProviderStepWithCurrent("LLM", "", nil, "llm", false, false, current)
+
+	assert.Equal(t, "cloud", ps.choices[ps.cursor].kind)
+	assert.Equal(t, "https://openrouter.ai/api", ps.choices[ps.cursor].endpoint)
+	assert.Equal(t, "openai/gpt-4o-mini", ps.modelIn.Value())
+}
+
+func TestProviderStepWithCurrent_FallsBackToCustomForUnknownEndpoint(t *testing.T) {
+	current := config.ServiceConfig{Endpoint: "https://my.private.host/v1", Model: "custom-model"}
+
+	ps := newProviderStepWithCurrent("LLM", "", nil, "llm", false, false, current)
+
+	assert.Equal(t, "custom", ps.choices[ps.cursor].kind, "unknown endpoint should land on Custom")
+	// Endpoint input should be pre-filled so Enter on Custom shows current value.
+	assert.Equal(t, "https://my.private.host/v1", ps.endpointIn.Value())
+	assert.Equal(t, "custom-model", ps.modelIn.Value())
+}
+
+func TestProviderStepWithCurrent_EmptyCurrentBehavesLikeNewProviderStep(t *testing.T) {
+	psA := newProviderStepWithCurrent("Embed", "", nil, "embed", false, false, config.ServiceConfig{})
+	psB := newProviderStep("Embed", "", nil, "embed", false, false)
+	assert.Equal(t, psB.cursor, psA.cursor)
+	assert.Equal(t, psB.modelIn.Value(), psA.modelIn.Value())
+}
+
+func TestTriplexStepWithCurrent_PreFillsEndpointAndModel(t *testing.T) {
+	current := config.ServiceConfig{Endpoint: "https://api.example.com", Model: "numind/NuExtract-2.0-2B"}
+
+	t2 := newTriplexStepWithCurrent(nil, current)
+
+	assert.Equal(t, "https://api.example.com", t2.endpointIn.Value())
+	assert.Equal(t, "numind/NuExtract-2.0-2B", t2.modelIn.Value())
+}
+
+func TestWizardModel_SetReconfigure_EnablesModeAndCopiesConfig(t *testing.T) {
+	m := NewWizardModel()
+	cfg := sampleCurrentConfig()
+	m.SetReconfigure(cfg)
+
+	assert.True(t, m.Reconfigure())
+	assert.NotNil(t, m.currentConfig)
+	// The working config should be a copy seeded from cfg.
+	assert.Equal(t, cfg.Embed.Endpoint, m.config.Embed.Endpoint)
+	assert.Equal(t, cfg.LLM.Model, m.config.LLM.Model)
+	assert.Equal(t, "openai", m.currentFormat)
+
+	// Mutating the working config must not touch the caller's cfg.
+	m.config.Embed.Endpoint = "mutated"
+	assert.Equal(t, "http://localhost:11434", cfg.Embed.Endpoint)
+}
+
+func TestWizardModel_Reconfigure_WelcomeJumpsToSectionMenu(t *testing.T) {
+	m := NewWizardModel()
+	m.SetReconfigure(sampleCurrentConfig())
+
+	// Finish detection.
+	result, _ := m.Update(detectDoneMsg{endpoints: nil})
+	m = result.(WizardModel)
+
+	// Press Enter — should jump to the section menu, not step 1.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(WizardModel)
+	assert.Equal(t, stepSectionMenu, m.step)
+}
+
+func TestWizardModel_FirstRun_WelcomeStillJumpsToStep1(t *testing.T) {
+	// Regression guard: first-run mode (no SetReconfigure) MUST still go to
+	// the linear walkthrough.
+	m := NewWizardModel()
+
+	result, _ := m.Update(detectDoneMsg{endpoints: nil})
+	m = result.(WizardModel)
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(WizardModel)
+	assert.Equal(t, 1, m.step)
+	assert.False(t, m.Reconfigure())
+}
+
+func TestWizardModel_SectionMenu_NavigationAndJump(t *testing.T) {
+	m := NewWizardModel()
+	m.SetReconfigure(sampleCurrentConfig())
+	m.step = stepSectionMenu
+
+	entries := m.sectionMenuEntries()
+	require.GreaterOrEqual(t, len(entries), 5)
+
+	// Down arrow advances cursor.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = result.(WizardModel)
+	assert.Equal(t, 1, m.sectionCursor)
+
+	// Up arrow goes back.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = result.(WizardModel)
+	assert.Equal(t, 0, m.sectionCursor)
+
+	// Enter on first entry (Embed) jumps to step 1.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(WizardModel)
+	assert.Equal(t, 1, m.step)
+	// And the embed sub-step should be pre-filled from current config.
+	assert.Equal(t, "nomic-embed-text", m.embed.modelIn.Value())
+}
+
+func TestWizardModel_SectionMenu_JumpToEachSection(t *testing.T) {
+	cases := []struct {
+		cursor   int
+		wantStep int
+		check    func(t *testing.T, m WizardModel)
+	}{
+		{0, 1, func(t *testing.T, m WizardModel) {
+			assert.Equal(t, "nomic-embed-text", m.embed.modelIn.Value())
+		}},
+		{1, 2, func(t *testing.T, m WizardModel) {
+			assert.Equal(t, "openai/gpt-4o-mini", m.llm.modelIn.Value())
+		}},
+		{2, 3, func(t *testing.T, m WizardModel) {
+			assert.Equal(t, "rerank-v1", m.rerank.modelIn.Value())
+			// Format should be pre-selected to "openai".
+			assert.Equal(t, "openai", rerankFormats[m.rerank.formatIdx])
+		}},
+		{3, 4, func(t *testing.T, m WizardModel) {
+			assert.Equal(t, "Phi-3-mini-128k-instruct/triplex", m.triplex.modelIn.Value())
+		}},
+		// cursor 4 (API Keys) — for sample config the only remote service is
+		// LLM (OpenRouter) and Rerank (OpenAI), both need keys. Step should
+		// land on 5.
+		{4, 5, func(t *testing.T, m WizardModel) {
+			assert.NotEmpty(t, m.keys.entries)
+		}},
+		{5, 6, func(t *testing.T, m WizardModel) {
+			assert.NotNil(t, m.confirm.cfg)
+		}},
+	}
+
+	for _, tc := range cases {
+		m := NewWizardModel()
+		m.SetReconfigure(sampleCurrentConfig())
+		m.step = stepSectionMenu
+		m.sectionCursor = tc.cursor
+
+		result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m = result.(WizardModel)
+		assert.Equal(t, tc.wantStep, m.step, "cursor %d should jump to step %d", tc.cursor, tc.wantStep)
+		tc.check(t, m)
+	}
+}
+
+func TestWizardModel_Reconfigure_EscReturnsToSectionMenu(t *testing.T) {
+	m := NewWizardModel()
+	m.SetReconfigure(sampleCurrentConfig())
+	m.step = stepSectionMenu
+
+	// Jump into Embed.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(WizardModel)
+	require.Equal(t, 1, m.step)
+
+	// Press Esc — should return to section menu (not pop linear history).
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = result.(WizardModel)
+	assert.Equal(t, stepSectionMenu, m.step)
+	assert.False(t, m.cancelled)
+}
+
+func TestWizardModel_Reconfigure_EscAtSectionMenuCancels(t *testing.T) {
+	m := NewWizardModel()
+	m.SetReconfigure(sampleCurrentConfig())
+	m.step = stepSectionMenu
+
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = result.(WizardModel)
+	assert.True(t, m.cancelled)
+	require.NotNil(t, cmd)
+}
+
+func TestWizardModel_Reconfigure_CompletingSectionReturnsToMenu(t *testing.T) {
+	m := NewWizardModel()
+	m.SetReconfigure(sampleCurrentConfig())
+	m.step = stepSectionMenu
+
+	// Jump to Embed, simulate done, expect return to menu.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(WizardModel)
+	require.Equal(t, 1, m.step)
+
+	// Force the embed sub-model into a "done" state and re-run the parent update.
+	m.embed.done = true
+	m.embed.selected = config.ServiceConfig{Endpoint: "http://localhost:11434", Model: "nomic-embed-text"}
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyMsg{}.Type})
+	m = result.(WizardModel)
+	assert.Equal(t, stepSectionMenu, m.step)
+	assert.Equal(t, "nomic-embed-text", m.config.Embed.Model)
+}
+
+func TestSectionMenu_View_RendersAllEntriesWithSummaries(t *testing.T) {
+	m := NewWizardModel()
+	m.SetReconfigure(sampleCurrentConfig())
+	m.step = stepSectionMenu
+	m.width = 80
+
+	view := m.View()
+	// All section labels present.
+	assert.Contains(t, view, "Embed")
+	assert.Contains(t, view, "LLM")
+	assert.Contains(t, view, "Rerank")
+	assert.Contains(t, view, "Triplex") // because cur.Triplex.Endpoint is set
+	assert.Contains(t, view, "API Keys")
+	assert.Contains(t, view, "Save & Exit")
+	// Current-value summaries appear.
+	assert.Contains(t, view, "nomic-embed-text")
+	assert.Contains(t, view, "openai/gpt-4o-mini")
+}


### PR DESCRIPTION
Closes #115
Closes #116

## Summary

Together these issues make the wizard's reconfigure mode actually usable: instead of forcing a 7-step walkthrough every time the user wants to flip one setting, the wizard now shows a section menu and pre-fills each step from the currently-loaded config.

- **#115 — jump-to-section navigation.** When the wizard is entered from the home Settings menu, the welcome step is followed by a section menu (Embed / LLM / Rerank / Extractor / API Keys / Save & Exit) with current-value summaries. Tab/↑↓ navigates, Enter jumps to the section, Esc inside a section returns to the menu, Esc at the menu cancels back to home.
- **#116 — pre-fill on reconfigure.** Each section's endpoint + model inputs are seeded from \`appConfig.Embed/.LLM/.Rerank/.Triplex/.NuExtract\`. The cursor lands on the choice that matches the current endpoint (detected, cloud preset, or Custom), and the model input shows the currently-configured model as the default suggestion.
- **First-run unchanged.** Reconfigure mode is opt-in via \`SetReconfigure(cfg)\`. Without that call the linear flow is bit-for-bit the same.

## Files

- \`internal/tui/setup/wizard.go\` — \`stepSectionMenu\` step, \`SetReconfigure\`/\`Reconfigure\` API, \`updateSectionMenu\`, \`enterSection\`, \`viewSectionMenu\`, ESC routing, per-step \`done\` short-circuit back to the menu.
- \`internal/tui/setup/steps.go\` — additive \`newProviderStepWithCurrent\` and \`newTriplexStepWithCurrent\` constructors. Existing constructor signatures untouched to minimise rebase pain with the parallel #112 / #111+#118 wizard workers.
- \`internal/tui/model.go\` — 4-line wire-up in \`homeMenuSettings\` so Settings hands the loaded config to the wizard.
- \`internal/tui/setup/wizard_test.go\` — 14 new tests; existing 45 unchanged.

## Acceptance criteria

### #115
- [x] First-run wizard keeps the linear 7-step walkthrough (covered by \`TestWizardModel_FirstRun_WelcomeStillJumpsToStep1\` and the existing \`TestWizardModel_FullFlow_SkipAll\`).
- [x] Reconfigure mode shows a section menu after Welcome (\`TestWizardModel_Reconfigure_WelcomeJumpsToSectionMenu\`).
- [x] Tab/arrow navigates the menu, Enter jumps to the chosen section (\`TestWizardModel_SectionMenu_NavigationAndJump\`, \`TestWizardModel_SectionMenu_JumpToEachSection\`).
- [x] Esc inside an edit step returns to the menu (\`TestWizardModel_Reconfigure_EscReturnsToSectionMenu\`).
- [x] Esc at the menu cancels back to home (\`TestWizardModel_Reconfigure_EscAtSectionMenuCancels\`).
- [x] Completing a section returns to the menu instead of advancing linearly (\`TestWizardModel_Reconfigure_CompletingSectionReturnsToMenu\`).

### #116
- [x] Endpoint + model inputs pre-fill from current config (\`TestProviderStepWithCurrent_*\`, \`TestTriplexStepWithCurrent_*\`).
- [x] Cursor lands on the matching detected / cloud / custom choice (\`TestProviderStepWithCurrent_PreFillsModelAndCursorOnDetected\`, \`...PreFillsCloudPreset\`, \`...FallsBackToCustomForUnknownEndpoint\`).
- [x] Currently-configured model used as the default in the model-suggestion list — currently the model input is a free-text field, so the current value is set as the input's value; once the model picker (#111) lands the same hook will set its default selection.
- [x] Empty current config behaves identically to the existing constructor (\`TestProviderStepWithCurrent_EmptyCurrentBehavesLikeNewProviderStep\`).

## Section menu mockup

\`\`\`
Settings — choose a section to edit

Tab/↑↓: navigate  |  Enter: edit section  |  Esc: cancel  |  Ctrl+C: cancel

> Embed                          — nomic-embed-text @ http://localhost:11434
  LLM                            — openai/gpt-4o-mini @ https://openrouter.ai/api
  Rerank                         — rerank-v1 @ https://api.openai.com  (openai)
  Triplex                        — Phi-3-mini-128k-instruct/triplex @ http://localhost:11434
  API Keys                       — stored in OS keychain
  Save & Exit                    — write changes to ~/.config/markedup/config.yaml
\`\`\`

## Test plan

- [x] \`go build ./...\` — pass
- [x] \`go vet ./...\` — pass
- [x] \`go test ./... -count=1\` — 782 passed in 15 packages (was 768; +14 new tests in setup pkg)
- [x] \`go test ./internal/tui/setup/... -run Reconfigure -v\` — 5 reconfigure-flow tests pass
- [ ] Manual TTY check from \`markedup tui → Settings\` — recommended before merge

## Coordination notes

- Branch is rebased onto **acfde62** (current main).
- Diff in \`steps.go\` is purely additive (new functions, no signature changes) so the parallel #112 (View URL strings) and #111 + #118 (model picker / test-connection) workers should rebase without conflict.
- \`internal/tui/model.go\` change is minimal (4 lines) and only adds an \`if m.cfg != nil { m.wizard.SetReconfigure(m.cfg) }\` call inside \`homeMenuSettings\`.