### PR TITLE
test: disable native keyring access in tests

### DIFF
--- a/config/keyring.go
+++ b/config/keyring.go
@@ -5,14 +5,20 @@ package config
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"log"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/99designs/keyring"
 )
 
 const serviceName = "markedup"
+
+const disableKeyringEnv = "MARKEDUP_DISABLE_KEYRING"
+
+var errKeyringDisabled = errors.New("markedup keyring disabled")
 
 // legacyServiceKeyNames lists the historical per-service keyring entries that
 // predate endpoint-keyed storage. They are migrated and removed by
@@ -36,7 +42,19 @@ var openRingFn = func() (keyring.Keyring, error) {
 
 // openRing opens the OS keyring for the markedup service.
 func openRing() (keyring.Keyring, error) {
+	if keyringDisabled() {
+		return nil, errKeyringDisabled
+	}
 	return openRingFn()
+}
+
+func keyringDisabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(disableKeyringEnv))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 // StoreKey saves a named key to the OS keychain under the "markedup" service.

--- a/config/keyring_test.go
+++ b/config/keyring_test.go
@@ -100,9 +100,22 @@ func TestOverwriteKey(t *testing.T) {
 }
 
 func TestKeyringAvailable(t *testing.T) {
-	// KeyringAvailable uses the default OS keyring backend.
-	// We just verify it returns a boolean without panicking.
-	_ = KeyringAvailable()
+	ring := newFakeRing()
+	withFakeRing(t, ring)
+	assert.True(t, KeyringAvailable())
+}
+
+func TestKeyringDisabledByEnv(t *testing.T) {
+	ring := newFakeRing()
+	withFakeRing(t, ring)
+	t.Setenv(disableKeyringEnv, "1")
+
+	assert.False(t, KeyringAvailable())
+
+	_, err := GetKey("anything")
+	assert.ErrorIs(t, err, errKeyringDisabled)
+	assert.ErrorIs(t, StoreKey("anything", "secret"), errKeyringDisabled)
+	assert.ErrorIs(t, DeleteKey("anything"), errKeyringDisabled)
 }
 
 // TestPublicAPI_WithFileBackend exercises the public StoreKey/GetKey/DeleteKey

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -10,6 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	_ = os.Setenv("MARKEDUP_DISABLE_KEYRING", "1")
+	os.Exit(m.Run())
+}
 
 // fakeDeps builds a setupDeps with sensible defaults for testing.
 // stdin is the newline-separated user input to feed.
@@ -64,12 +70,12 @@ func TestSetup_CloudProvider_SavesConfig(t *testing.T) {
 	// User picks OpenRouter (1) for embed with model "text-embedding-3",
 	// skips LLM and reranker, confirms save.
 	input := strings.Join([]string{
-		"1",                    // Embed: OpenRouter
-		"text-embedding-3",    // model name
-		"sk-test-embed-key",   // API key
-		"5",                    // LLM: Skip
-		"5",                    // Rerank: Skip
-		"y",                    // Save
+		"1",                 // Embed: OpenRouter
+		"text-embedding-3",  // model name
+		"sk-test-embed-key", // API key
+		"5",                 // LLM: Skip
+		"5",                 // Rerank: Skip
+		"y",                 // Save
 	}, "\n") + "\n"
 
 	var savedCfg *config.Config
@@ -107,11 +113,11 @@ func TestSetup_DetectedLocal(t *testing.T) {
 	// Simulate a detected Ollama instance. User picks it for embed,
 	// selects model by number, skips rest, saves.
 	input := strings.Join([]string{
-		"1",    // Embed: Ollama (local)
-		"1",    // model by number: nomic-embed-text
-		"6",    // LLM: Skip (1 detected + 4 cloud + 1 skip = 6)
-		"6",    // Rerank: Skip
-		"y",    // Save
+		"1", // Embed: Ollama (local)
+		"1", // model by number: nomic-embed-text
+		"6", // LLM: Skip (1 detected + 4 cloud + 1 skip = 6)
+		"6", // Rerank: Skip
+		"y", // Save
 	}, "\n") + "\n"
 
 	var savedCfg *config.Config
@@ -149,13 +155,13 @@ func TestSetup_CustomEndpoint(t *testing.T) {
 	// User picks Custom for embed, provides endpoint, model, and key.
 	// Custom is option 4 (no detected servers).
 	input := strings.Join([]string{
-		"4",                        // Embed: Custom
-		"http://my-server:9000",    // endpoint
-		"my-embed-model",           // model
-		"my-secret-key",            // API key
-		"5",                        // LLM: Skip
-		"5",                        // Rerank: Skip
-		"y",                        // Save
+		"4",                     // Embed: Custom
+		"http://my-server:9000", // endpoint
+		"my-embed-model",        // model
+		"my-secret-key",         // API key
+		"5",                     // LLM: Skip
+		"5",                     // Rerank: Skip
+		"y",                     // Save
 	}, "\n") + "\n"
 
 	var savedCfg *config.Config
@@ -177,12 +183,12 @@ func TestSetup_CustomEndpoint(t *testing.T) {
 func TestSetup_KeyringUnavailable(t *testing.T) {
 	// When keyring is not available, should print env var instructions.
 	input := strings.Join([]string{
-		"1",                   // Embed: OpenRouter
+		"1", // Embed: OpenRouter
 		"text-embedding-3",
 		"sk-key",
-		"5",                   // LLM: Skip
-		"5",                   // Rerank: Skip
-		"y",                   // Save
+		"5", // LLM: Skip
+		"5", // Rerank: Skip
+		"y", // Save
 	}, "\n") + "\n"
 
 	d, out := fakeDeps(input)
@@ -211,12 +217,12 @@ func TestSetup_CommandRegistered(t *testing.T) {
 func TestSetup_InvalidInput_Reprompts(t *testing.T) {
 	// Send invalid input first, then valid.
 	input := strings.Join([]string{
-		"abc",  // invalid
-		"99",   // out of range
-		"5",    // valid: Skip
-		"5",    // LLM: Skip
-		"5",    // Rerank: Skip
-		"n",    // Don't save
+		"abc", // invalid
+		"99",  // out of range
+		"5",   // valid: Skip
+		"5",   // LLM: Skip
+		"5",   // Rerank: Skip
+		"n",   // Don't save
 	}, "\n") + "\n"
 
 	d, out := fakeDeps(input)

--- a/internal/tui/setup/wizard_test.go
+++ b/internal/tui/setup/wizard_test.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"os"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -9,6 +10,11 @@ import (
 
 	"github.com/Clarit-AI/markedup/config"
 )
+
+func TestMain(m *testing.M) {
+	_ = os.Setenv("MARKEDUP_DISABLE_KEYRING", "1")
+	os.Exit(m.Run())
+}
 
 func TestNewWizardModel_InitialState(t *testing.T) {
 	m := NewWizardModel()

--- a/smoke_test.go
+++ b/smoke_test.go
@@ -1,9 +1,15 @@
 package markedup_test
 
 import (
+	"os"
 	"os/exec"
 	"testing"
 )
+
+func TestMain(m *testing.M) {
+	_ = os.Setenv("MARKEDUP_DISABLE_KEYRING", "1")
+	os.Exit(m.Run())
+}
 
 func TestBinaryBuilds(t *testing.T) {
 	cmd := exec.Command("go", "build", "-o", t.TempDir()+"/markedup", "./cmd/markedup")


### PR DESCRIPTION
## Summary
- add MARKEDUP_DISABLE_KEYRING guard around native keyring opening
- switch KeyringAvailable coverage to the fake ring backend
- disable native keyring access in setup and smoke test packages so test runs do not trigger macOS Keychain prompts

## Tests
- go test ./config ./internal/tui/setup ./internal/cli
- go test ./...